### PR TITLE
Added a reference to example config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ The RPMs will be available under `rpmbuild/RPMS/noarch`.
 djehuty web --config-file=config.xml
 ```
 
+An example of configuration file can be found in [etc/djehuty/djehuty-example-config.xml](./etc/djehuty/djehuty-example-config.xml).
+
 Use the `maximum-workers` configuration option to use forking rather than threading.
 
 ### Using `uwsgi`:


### PR DESCRIPTION
When running `djehuty web`, I had difficulty figuring out how to properly set `DJEHUTY_CONFIG_FILE`. I thought it might be helpful to prevent such a case for new people trying to run the project if you reference the example xml config file in the README.md.