### PR TITLE
web: database: Add sesame-style SPARQL update endpoint URI option.

### DIFF
--- a/etc/djehuty/djehuty-example-config.xml
+++ b/etc/djehuty/djehuty-example-config.xml
@@ -14,6 +14,7 @@
   <!-- <maximum-workers>4</maximum-workers> -->
   <rdf-store>
     <sparql-uri>http://localhost:8890/sparql</sparql-uri>
+    <sparql-update-uri>http://localhost:8890/sparql</sparql-update-uri>
     <state-graph>djehuty://local</state-graph>
   </rdf-store>
   <datacite>

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -26,6 +26,7 @@ class SparqlInterface:
         self.secondary_storage = None
         self.secondary_storage_quirks = False
         self.endpoint    = "http://127.0.0.1:8890/sparql"
+        self.update_endpoint = None
         self.state_graph = "https://data.4tu.nl/portal/self-test"
         self.privileges  = {}
         self.profile_images_storage = None
@@ -43,9 +44,9 @@ class SparqlInterface:
         self.default_quota  = 5000000000
 
     def setup_sparql_endpoint (self):
-        """Procedure to be called after setting the 'endpoint' member."""
+        """Procedure to be called after setting the 'endpoint' members."""
 
-        self.sparql = SPARQLWrapper(self.endpoint, returnFormat=JSON)
+        self.sparql = SPARQLWrapper(endpoint=self.endpoint, updateEndpoint=self.update_endpoint, returnFormat=JSON)
         self.sparql.setOnlyConneg (True)
         self.sparql_is_up = True
 

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -131,7 +131,7 @@ class SparqlInterface:
 
         except HTTPError as error:
             self.log.error ("SPARQL endpoint returned %d:\n---\n%s\n---",
-                            error.code, error.message)
+                            error.code, error.reason)
             return []
         except (URLError, SPARQLExceptions.EndPointNotFound):
             if self.sparql_is_up:

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -457,6 +457,10 @@ def read_configuration_file (server, config_file, address, port, state_graph,
         if endpoint:
             server.db.endpoint = endpoint
 
+        update_endpoint = config_value (xml_root, "rdf-store/sparql-update-uri")
+        if update_endpoint:
+            server.db.update_endpoint = update_endpoint
+
         maintenance_mode = config_value (xml_root, "maintenance-mode")
         if maintenance_mode:
             try:
@@ -668,6 +672,7 @@ def main (address=None, port=None, state_graph=None, storage=None,
                     raise DependencyNotAvailable
 
             logger.info ("SPARQL endpoint:  %s.", server.db.endpoint)
+            logger.info ("SPARQL update_endpoint:  %s.", server.db.update_endpoint)
             logger.info ("State graph:  %s.", server.db.state_graph)
             logger.info ("Storage path: %s.", server.db.storage)
             logger.info ("Secondary storage path: %s.", server.db.secondary_storage)


### PR DESCRIPTION
Some SPARQL endpoint implementations like RDF4J(replaced OpenRDF Sesame project) and GraphDB have separate endpoint URIs for query and update.

* etc/djehuty/djehuty-example-config.xml: Add "sparql-update-uri" option.
* src/djehuty/web/database.py: Add "updateEndpoint" parameter in SPARQLWrapper.
* src/djehuty/web/ui.py: Add "update_endpoint" variable.