### PR TITLE
handle paths using os package for __git_create_repository()

### DIFF
--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -8012,12 +8012,12 @@ class ApiServer:
         return self.response (json.dumps(output))
 
     def __git_create_repository (self, git_uuid):
-        git_directory = f"{self.db.storage}/{git_uuid}.git"
+        git_directory = os.path.join(self.db.storage, f"{git_uuid}.git")
         if not os.path.exists (git_directory):
             initial_repository = pygit2.init_repository (git_directory, True)
             if initial_repository:
                 try:
-                    with open (f"{git_directory}/config", "a",
+                    with open (os.path.join(git_directory, "config"), "a",
                                encoding = "utf-8") as config:
                         config.write ("\n[http]\n  receivepack = true\n")
                 except FileNotFoundError:


### PR DESCRIPTION
This pull request changes the way paths are handled in `__git_create_repository()`. Paths are no longer treated as strings to avoid issue with tailing slashes. Instead, `os.path.join()` is used. Closes #23 