### PR TITLE
Add EULA Template to restricted access deposit instructions

### DIFF
--- a/src/djehuty/web/resources/html_templates/depositor/edit-dataset.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-dataset.html
@@ -322,12 +322,16 @@ table#files tbody tr td:nth-child(3) { width: 15px; text-align: right; }
   </div>
   <div class="access_level" id="restricted_access_form">
     <p>
-      Restricted access allows you to share your dataset under specific
-      conditions and with users who have been granted access. Please specify
-      the End-User Licence Agreement (EULA) in which you specify the
-      conditions under which you grant users access to your data files,
-      and add the reason why your dataset is restricted.
+      Restricted access allows you to share your dataset under specific 
+      conditions and with users who have been granted access. 
+      Please specify the End-User Licence Agreement (EULA), 
+      which outlines the conditions under which you grant users 
+      access to your data files. You can create such an agreement 
+      using our 
+      <a href="https://data.4tu.nl/s/documents/4TU.ResearchData_EULA_Sept.2024.pdf">EULA template</a>. 
+      Please also include the reason why your dataset is restricted.
     </p>
+
     <label class="inner-head">Reason</label><span class="required-field"> &#8727;</span>
     <div id="restricted_access_reason" class="texteditor">
       {{article["embargo_reason"] | default("", True) | replace("\\n", "<br>") | safe }}


### PR DESCRIPTION
Hi @roelj ! 
I was uploading a dataset on next.data.4tu.nl  and thought we could include the new EULA template directly in the Metadata form. 


web: html_templates: depositor: Add EULA template to the restricted access deposit.

* src/djehuty/web/resources/html_templates/edit-dataset.html:
  add EULA template to the meta data from, restricted access instructions.