### PR TITLE
Add scale factors to IIIF Image API

### DIFF
--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -18,6 +18,7 @@ import base64
 import csv
 import requests
 import pygit2
+import math
 from requests.utils import quote, unquote
 from werkzeug.utils import redirect, send_file
 from werkzeug.wrappers import Request, Response
@@ -9476,6 +9477,11 @@ class WebServer:
             else:
                 image = pyvips.Image.new_from_file (input_filename)
 
+            tileSize = 1024
+            maxSize = max(image.width, image.height)
+            layers = math.ceil(math.log2(maxSize / tileSize))
+            scaleFactors = [2 ** i for i in range(layers + 1)]
+
             output = {
                 "@context":  "http://iiif.io/api/image/3/context.json",
                 "id":        f"{config.base_url}/iiif/v3/{file_uuid}",
@@ -9491,6 +9497,13 @@ class WebServer:
                 "extraFeatures": ["cors", "mirroring", "regionByPx",
                                   "regionSquare", "rotationArbitrary",
                                   "rotationBy90s"],
+                "tiles": [
+                    {
+                        "width": tileSize,
+                        "height": tileSize,
+                        "scaleFactors": scaleFactors,
+                    }
+                ],
                 "sizes": [{ "width": image.width, "height": image.height }]
             }
             del image


### PR DESCRIPTION
This PR adds a tiles property containing an object with a preconfigured tile size and list of scale factors to the info.json response of the IIIF Image API. This encourages clients to request the same tiles, and thus cache those resources in Djehuty. (If no tile property is present, clients use their own logic, which differs across IIIF viewers.)

The default tile size is set at 1024 x 1024 pixels. (It is possible to add multiple tile sets with different tile sizes, if needed.)

Scale factors are calculated by dividing the largest image dimension by two until it's equal or smaller than the configured tile size.

This implementation has not yet been tested; [this Notebook](https://observablehq.com/@allmaps/tile-pyramid) can be used to check if the scale factors are calculated correctly (and for more information about the tiles property in general).

See also the relevant section of the [IIIF Image API 3.0 documentation](https://iiif.io/api/image/3.0/#54-tiles).

Q: Will this work correctly if the image is smaller than 1024 x 1024? It should then output only one scale factor.