### PR TITLE
Sanitize the cookie value when deleting sessions to prevent injections

### DIFF
--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3365,7 +3365,7 @@ class SparqlInterface:
         if token is None:
             return True
 
-        query = self.__query_from_template ("delete_session", {"token": token})
+        query = self.__query_from_template ("delete_session", {"token": rdf.escape_string_value (token)})
         return self.__run_logged_query (query)
 
     def sessions (self, account_uuid, session_uuid=None, mfa_token=None):

--- a/src/djehuty/web/resources/sparql_templates/delete_session.sparql
+++ b/src/djehuty/web/resources/sparql_templates/delete_session.sparql
@@ -11,7 +11,7 @@ WHERE {
     ?session    djht:token    ?token .
     ?session    ?predicate   ?object .
 
-    FILTER (?token = "{{token | safe}}"^^xsd:string)
+    FILTER (?token = {{token | safe}})
   }
 }
 {% endblock %}


### PR DESCRIPTION
The PR has a small change from @roelj to remedy a low impact SPARQL injection in the cookie field