### PR TITLE
Doc #33 | Add contributing guidelines, code of conduct, and reusable templates 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,44 @@
+# Code of Conduct
+
+We are committed to fostering a welcoming, inclusive, and respectful community for everyone who participates in this project. By participating in this project, you agree to follow our Code of Conduct.
+
+## Encouraged Behaviours
+
+While acknowledging differences in social norms, we all strive to meet our community’s expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+- Be respectful and considerate in your communication.
+- Use inclusive and welcoming language.
+- Give and accept constructive feedback gracefully.
+- Focus on what is best for the project and the community.
+- Assume good intent, and seek to resolve conflicts in a kind and collaborative way.
+- Commit to repairing harm when it occurs.
+
+### Unacceptable behavior includes:
+- **Harassment**. Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+- **Character attacks**. Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+- **Discrimination**. Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+- **Sexualization**. Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+- **Violating confidentiality**.Sharing private or security-sensitive information without consent.
+- **Endangerment**. Causing, encouraging, or threatening violence or other harm toward any person or group.
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact Core Maintainers via email at [djehuty@4tu.nl](mailto:djehuty@4tu.nl).
+
+Core Maintainers take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Core Maintainers will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+## Addressing and Repairing Harm
+
+Core Maintainers are responsible for upholding the Code of Conduct.
+They may take appropriate action in response to unacceptable behavior, including warnings, temporary bans, or permanent exclusion from the community, depending on severity of violation and frequency of incidents.
+
+Once an unacceptable behaviour occurs, we expect the person(s) involved to commit repairing harm. The repair may involve a written apology, acknowledgement of responsibility, and making a thoughtful reflection on their actions and impact.
+
+## Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at https://www.contributor-covenant.org/version/3/0/.
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit https://creativecommons.org/licenses/by-sa/4.0/
+
+For answers to common questions about Contributor Covenant, see the FAQ at https://www.contributor-covenant.org/faq. Translations are provided at https://www.contributor-covenant.org/translations. Additional enforcement and community guideline resources can be found at https://www.contributor-covenant.org/resources. The enforcement ladder was inspired by the work of Mozilla’s code of conduct team.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,285 @@
+# Contributing Guidelines
+
+Thanks for your interest in contributing! 🎉  
+We welcome all contributions - code, documentation, bug reports, or ideas.
+
+When contributing, remember to follow our [Code of Conduct](https://github.com/4TUResearchData/djehuty/blob/main/CODE_OF_CONDUCT.md).
+
+## How to Contribute?
+- **Report bugs or request features** by opening an issue.
+  - By opening an issue you can be in touch with us to request a new feature or report a bug. Check in the Report bugs or request features section how to make the request.
+- **Code contributions:** pick an open issue or propose a new idea.
+  - Do you have development skills? You also can contribute by helping us to develop Djehuty. Check the Code contributions section on how to become a developer contributor.
+
+## Recognition of Contributions
+
+All contributions - whether it’s code, bug reports, or ideas are appreciated and recognized. Contributors may be credited in release notes or project acknowledgments. Thank you for helping make the project better!
+
+## Contribution workflows
+
+### Report bugs or request features
+
+We welcome contributions in the form of bug reports and feature suggestions. Here’s how to make them most useful:
+
+1. **Look for Existing Issues**
+Before opening a new report or suggestion, [check the issue tracker](https://github.com/4TUResearchData/djehuty/issues) to see if it’s already been raised. This helps prevent duplicates and keeps the conversation focused.
+
+2. **Submit a New Issue**
+If you don’t find an existing issue, create a new one [using the appropriate template](#issue-template). Add relevant labels if applicable.
+
+
+3. **Provide Useful Information**
+    - **For Bugs:** Explain the steps to reproduce the problem, what you expected to happen, what actually happened, and include any relevant screenshots, logs, or environment details.
+    - **For Feature Suggestions:** Describe the idea clearly and explain why it would improve the project.
+
+**4. Participate in Discussion**
+Be ready to answer questions or provide additional details. Open discussion helps the team understand the issue and work toward the best solution.
+
+### Code contributions
+
+1. **Contact us!**
+Before starting any work, please **contact repository maintainers at [djehuty@4tu.nl](mailto:djehuty@4tu.nl)** to discuss how your idea fits with our strategic goals.
+
+2. **Check or open an issue**
+Before you start work, **search the [issue tracker](https://github.com/4TUResearchData/djehuty/issues)** to see if your idea is already being discussed: issues.
+    - If you find a relevant issue, comment to say you’re taking it on and, if possible, assign yourself. If you cannot assign, leave a comment like “Working on this” so maintainers know.
+    - If no issue exists, open a new issue using the [issue template](#issue-template) and include: a short, descriptive title; a brief explanation of the problem or feature and why it’s needed.
+        - ⚠️ **IMPORTANT**: **Do not discuss security-related aspects**, vulnerabilities, or sensitive information in GitHub issues. Contact the maintainers at [djehuty@4tu.nl](djehuty@4tu.nl) privately for any security concerns.
+
+3. **Work from a fork**
+Contributors should work from a fork of the repository. Maintainers may work directly on the main djehuty instance.
+If you’re new to the fork-and-pull-request workflow, [check out the First Contributions](https://github.com/firstcontributions/first-contributions) guide for a step-by-step introduction.
+
+4. **Clone and create a branch**
+Clone your fork to your local machine and create a new branch for your work.
+
+5. **Set up your development environment**
+Follow the instructions in the [README](https://github.com/4TUResearchData/djehuty/blob/main/README.md) to install dependencies, configure the project, and run the required setup steps. Make sure you can build and test the project locally before starting your contribution.
+
+6. **Work on your branch and open a PR**
+- Make your changes on your branch. 
+- Commits must be verified, see the [commit signature verification guide](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) for more details.
+- Once your work is ready for review, open a Pull Request (PR) against the main project repository.
+    - Provide a clear description of what you changed and link the related issue.
+    - Use the [PR template](#pull-request-template) and check the approval checklist before submitting.
+    - ⚠️ **IMPORTANT**: **Do not open a PR for a security issue until** you have received confirmation from the maintainers that all affected instances have been patched. When opening the PR, strictly follow maintainer instructions and keep naming, commit messages, and descriptions neutral.
+        
+7. **Final approval and merge**
+After review and approval, your PR must be squashed into a single commit using the project’s [commit message template](#commit-message-template). Once the checklist is complete, a maintainer will rebase-merge it into the main branch to keep the history clean.
+
+---
+
+## Conventions
+
+
+### Code conventions
+
+Follow existing code conventions and existing patterns such as:
+- **Naming conventions**: Follow existing patterns for variables, functions, classes, and file names.
+    - Use snake_case for functions and variables.
+    - Be descriptive but concise in names.
+- **Indentation**: Use the same indentation style (tabs vs. spaces, number of spaces) already present in the codebase.
+    - Line length: Keep lines within the project’s limit.
+    - Comments & docs: Write comments/docstrings in the same style.
+- **No unused code**: Remove dead or commented-out code before committing.
+
+
+### Commits
+
+All **commits will be squashed into a single commit** before merging into main. This has two purposes:
+- **Clean history**: The main branch stays tidy.
+- **Readable log**: Each merge commit clearly tells the story of a completed change.
+
+When planning a change remember to:
+- **Limit the scope**: Keep the diff as small as possible so reviewers can understand the change quickly.
+- **Avoid commit noise**: Don’t include generated files, formatting-only changes, or experimental code unless they are the sole purpose of the commit.
+
+For the **squashed commit message** please also have a look at the [commit message template](#commit-message-template).
+
+
+### Branch Naming Conventions
+
+Branches must follow a **consistent naming scheme** to make collaboration, reviews, and automation easier.
+Use the following pattern:
+
+```markdown
+wip-<type>-<issue-number>-<short-description>
+```
+
+```markdown
+- wip = prefix for “Work in Progress”
+- type = category of change (bug, feat, impr, docs, chore)
+- issue-number = the GitHub issue number related to the work (if applicable)
+- short-description = a brief, kebab-case summary of the change
+```
+#### Example of branch name:
+
+| Type  | Branch name example               | When to use                      |
+| ----- |-----------------------------------| -------------------------------- |
+| bug   | wip-bug-123-fix-login-crash       | Bug fixes                        |
+| feat  | wip-feat-007-add-endpoint         | New features                     |
+| impr  | wip-impr-321-optimize-query       | Improvements, refactors, cleanup |
+| docs  | wip-docs-789-update-install-guide | Documentation updates            |
+| chore | wip-chore-101-bump-dependencies   | Maintenance or config updates    |
+
+---
+
+## Templates
+
+### Issue Template
+
+#### 🐞 Bug
+Use when something is **broken** or misbehaving (broken functionality).
+
+```markdown
+**Describe the bug**
+A clear and short description of the bug.
+
+** Steps to Reproduce**
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and short description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain the problem.
+
+**Your personal set up:**
+ - Smartphone or Desktop
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+
+**Additional context**
+Add any other context about the problem here.
+```
+
+
+#### 🪴 **Improvement**
+Use when you want to refine an **existing functionality** (enhance functionality).
+
+```markdown
+**Summary**
+A clear and short description of the enhancement.
+
+**Current Behavior**
+Brief description of the existing behavior or limitation.
+
+**Proposed Improvement**
+How you suggest to improve it.
+
+**Additional Notes**
+References, related issues, examples.
+```
+
+#### 🚀 **New Feature**
+Use when you would like to introduce a **new idea**.
+
+```markdown
+**Summary**
+A short description the functionality and who will use it.
+
+**Is your feature request related to a problem? **
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. 
+
+Suggestion: if possible, describe who will benefit from the functionality and for what reason.
+Example:
+- As a "data steward", I want "to do ..." so that "i can ....".
+- As a "researcher", I want "to do ..." so that "i can ....".
+- As a "reviewer", I want "to do ..." so that "i can ....".
+
+**Additional Context**
+Designs, diagrams, examples, screenshots etc.
+```
+---
+### Pull Request Template
+Regardless of the issue type, **use the PR template below**. Note that some PRs may not be associated with an issue.
+
+```markdown
+**Summary**
+A clear and short description of the change. Please provide what and why.
+
+**Changes**
+- filename: description of key update. Keep it concise.
+
+**Approval Checklist**
+- [ ] PR follows [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md)
+- [ ] Code style and conventions respected
+- [ ] Documentation has been updated where needed (README, docs, or examples).
+- [ ] Review approved by at least one maintainer.
+- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).
+
+**Issue Reference (optional - PRs may not be associated with an issue)**
+Closes #ISSUE_NUMBER - issue label
+
+**Screenshots (optional)**
+Before/After visuals, UI changes, or relevant logs.
+
+**Notes (optional)**
+Additional context, caveats, or follow-up tasks.
+```
+---
+
+### Commit Message Template
+
+The **commits in djehuty have a specific format**. By being detailed in your commit message, you help specific changes to the software be more traceable, and if necessary, revertible.
+
+The commits should be clear and focused. In the commit message:
+- The first line provides a general idea of what change has been done and in which part of code.
+- The following lines give a one-line summary of changes made to each individual file with the commit.
+- If a line extends 80 characters, a line break should be introduced.
+- Imperative mood (e.g. “Add test for …”, “Implement error handling …”, “Fix UUID validator …”) is used to describe the changes made.
+
+The message follows the format:
+```markdown
+[folder]:[subfolder]: <Describe a change in one line>
+* [path to 1st file changed]: <Describe change in the file>
+* [path to 2nd file changed]: <Describe change in the file>
+* [path to 3rd file changed]: <Describe change in the file>
+```
+...
+
+Example of a commit message:
+```markdown
+web: html_templates: Add keyword autocomplete options.
+* src/djehuty/web/resources/html_templates/depositor/edit-dataset.html: Add
+  ID for displaying keyword autocomplete and edit help text.
+* src/djehuty/web/resources/static/js/edit-dataset.js: Load keyword
+  autocomplete options when typing a keyword.
+* src/djehuty/web/resources/html_templates/depositor/edit-collection.html: Add
+  ID for displaying keyword autocomplete and edit help text.
+* src/djehuty/web/resources/static/js/edit-collection.js: Load keyword
+  autocomplete options when typing a keyword.
+* src/djehuty/web/resources/static/js/utils.js: Add method to search keyword
+  options and load them as an autocomplete dropdown.
+```
+
+---
+
+## Label Guide
+
+To help indicate the status of issue or pull request discussions, maintainers will [apply labels](https://github.com/4TUResearchData/djehuty/labels) to each as described below:
+
+| Label | When to use |
+|-------|-------------|
+| 🐞 ![bug](https://img.shields.io/badge/bug-red?style=flat) | Something is broken or behaves unexpectedly|
+| 🪴 ![improvement](https://img.shields.io/badge/improvement-d4c5f9?style=flat) | Refining current functionality |
+| 🚀 ![new feature](https://img.shields.io/badge/new_feature-mediumseagreen?style=flat) | Introducing functionality that did not previously exist  |
+| 📚 ![documentation](https://img.shields.io/badge/documentation-0075ca?style=flat) | Docs updates, corrections, or additions |
+| 🔧 ![refactor](https://img.shields.io/badge/refactor-c2e0c6?style=flat) | Internal code restructuring without changing external behavior |
+| 🌱 ![good first issue](https://img.shields.io/badge/good_first_issue-ABE6E4?style=flat) | Beginner-friendly tasks with clear steps |
+| 💬 ![needs discussion](https://img.shields.io/badge/needs_discussion-moccasin?style=flat) | Further clarification or consensus is required |
+| ⛔ ![blocked](https://img.shields.io/badge/blocked-indianred?style=flat) | Waiting on dependencies, or prerequisites |
+| ![wontfix](https://img.shields.io/badge/wontfix-FFF?style=flat) | This will not be worked on
+| ![duplicate](https://img.shields.io/badge/duplicate-lightgray?style=flat) | Waiting on dependencies, or prerequisites |
+
+---
+
+💡 By contributing to this project, you help us build a positive and supportive community. Thank you!


### PR DESCRIPTION
**Summary**
Add standard contribution guidelines, a code of conduct, and reusable templates to improve collaboration and communication.

**Changes**
* new file: CONTRIBUTING.md: Add guides for contribution workflows, conventions and templates.
* new file: CODE_OF_CONDUCT.md: Add document to define acceptable behavior and guidelines.

**Approval Checklist**
- [X] PR follows [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md)
- [X] Code style and conventions respected
- [X] Documentation has been updated where needed (README, docs, or examples).
- [X] Review approved by at least one maintainer.
- [X] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**
Closes Issue: [Documentation]: Add contributing guidelines, code of conduct, and templates #33


