### PR TITLE
Release version v26.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(djehuty, 25.6)
+AC_INIT(djehuty, 26.1)
 AM_INIT_AUTOMAKE([foreign tar-ustar])
 AM_PATH_PYTHON([3.9])
 AC_CONFIG_FILES([

--- a/doc/news.tex
+++ b/doc/news.tex
@@ -5,6 +5,43 @@
 \fi
 \chapter*{News}
 
+\labelWithConsistentHTMLTag{release-26-1}
+\section*{Release notes for \texttt{v26.1}.}
+
+  The first release of 2026 consists of 10 commits made by 4 authors.
+
+\subsection*{New features}
+\begin{itemize}
+\item{Introduce CODECHECK request in metadata form.
+    \commitLink{c61eed80e18ff9f89d4030ca91ad5a314e799c6f},
+    \commitLink{f6143dd18514bf8012ff967087cf0e656726de2e}).}
+\end{itemize}
+
+\subsection*{Documentation}
+\begin{itemize}
+\item{Add contributing guidelines, code of conduct, and governance document.
+    \commitLink{4e66a99611189d2832a4c9754075986aace1bb39},
+    \commitLink{afd028d081c1192ecfe7f03a610ae9005aeb7785},
+    \commitLink{7b10467a462975ccc0145658e3d6269f41aa2fdb}).}
+\item{Update contact information and copyright license.
+    \commitLink{4c5de37067420fa11851351ea20060cfbb100a15},
+    \commitLink{53bf4e0b4ec5c45746ea63f6922285d4e30b21f0}).}
+\item{Add issue and pull request templates.
+    (\commitLink{568f94d3c1a212304e520a93a5935f7eba43b340}).}
+\end{itemize}
+
+\subsection*{Bugfixes}
+\begin{itemize}
+\item{Fix rendering of DOI in private viewing.
+    (\commitLink{d93ff4b3195f129e2dff2d7641c8cb7f71e19602}).}
+\end{itemize}
+
+\subsection*{Incremental improvements}
+\begin{itemize}
+\item{Add support for symbolic links in generated zip files.
+    \commitLink{2bc0e4e27bff8f0dee00634aeb33f9328b7da0cf}).}
+\end{itemize}
+
 \labelWithConsistentHTMLTag{release-25-6}
 \section*{Release notes for \texttt{v25.6}.}
 


### PR DESCRIPTION
**Summary**
Release version v26.1. We are now using for naming year and 
sequence order of the release (26.1 - first release of 2026).

https://github.com/4TUResearchData/djehuty/releases/tag/v26.1

**Changes**
* configure.ac: Bump version to 26.1.
* doc/news.tex: Add release notes for v26.1.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).