### PR TITLE
Improv #43 | Add explanation to option 'File deposit' in upload dataset form

### DIFF
--- a/doc/running-djehuty.tex
+++ b/doc/running-djehuty.tex
@@ -472,6 +472,30 @@ djehuty web --config-file=config.xml --apply-transactions
   \t{enable-codecheck}        & Enable CODECHECK requests in the metadata form.
 \end{tabularx}
 
+\section{Configuring dataset upload}
+
+  The dataset upload behaviour can be configured under the \t{upload-dataset}
+  node.  Currently you can add a custom message under dataset file deposit section.
+  The \t{file-deposit} sub-node supports the following option:
+
+\begin{tabularx}{\textwidth}{*{1}{!{\VRule[-1pt]}l}!{\VRule[-1pt]}X}
+  \headrow
+  \textbf{Option}             & \textbf{Description}\\
+  \t{file-deposit/notice}     & An HTML message displayed above the file upload
+                                area when a depositor edits a dataset.  HTML
+                                markup, including hyperlinks, is supported.
+\end{tabularx}
+
+  How to use:
+
+\begin{lstlisting}[language=xml]
+<upload-dataset>
+  <file-deposit>
+    <notice>Your message here</notice>
+  </file-deposit>
+</upload-dataset>
+\end{lstlisting}
+
 \section{Customizing looks}
 
   With the following options, the instance can be branded as necessary.

--- a/src/djehuty/web/config.py
+++ b/src/djehuty/web/config.py
@@ -99,6 +99,7 @@ class RuntimeConfiguration:  # pylint: disable=too-few-public-methods
         self.datacite_password           = None
         self.datacite_prefix             = None
         self.ssi_psk                     = None
+        self.file_deposit_notice         = None
         self.menu                        = []
         self.colors                      = {
             "primary-color":            "#f49120",

--- a/src/djehuty/web/resources/html_templates/depositor/edit-dataset.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-dataset.html
@@ -195,6 +195,7 @@ table#files tbody tr td:nth-child(3) { width: 15px; text-align: right; }
 #api-upload pre { font-size: 0.9em; white-space: pre-wrap; overflow-wrap: anywhere; }
 #api-upload-fold { display: none; }
 .no-margin { margin: 0em; padding: 0em; }
+.text-left { text-align: left; }
 </style>
 {% endblock %}
 {% block submenu %}
@@ -542,6 +543,11 @@ git push {{site_shorttag}} --tags</pre>
   </p>
 </div>
 <div id="file_upload_field" class="upload-wrapper record-type-field">
+  {% if file_deposit_notice %}
+  <div class="text-left">
+    <p>{{ file_deposit_notice|safe }}</p>
+  </div>
+  {% endif %}
 <form id="dropzone-field" class="upload-container dropzone" action="/v3/datasets/{{container_uuid}}/upload" method="post">
   <div class="fallback">
     <input type="file" name="file" id="file" aria-label="Upload file" multiple="">

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -103,9 +103,9 @@ def read_raw_xml (xml_root, path, default_value=None):
     DEFAULT_VALUE upon failure.
     """
     try:
-        length = len(path) + 2 # Add two for the < and >.
         node = config_value (xml_root, path, None, None, return_node=True)
         if node is not None:
+            length = len(node.tag) + 2 # Add two for the < and >.
             # Attributes are rendered in the raw XML. We need to
             # remove it to get the inner XML.
             attributes = node.attrib
@@ -681,6 +681,14 @@ def read_email_configuration (server, xml_root, logger):
             logger.error ("Could not configure the email subsystem:")
             logger.error ("The email port should be a numeric value.")
 
+def read_upload_dataset_configuration (xml_root):
+    """Procedure to parse and set the upload dataset configuration."""
+    upload_dataset = xml_root.find("upload-dataset")
+    if upload_dataset is not None:
+        item = upload_dataset.find("file-deposit/notice")
+        if item is not None:
+            config.file_deposit_notice, _ = read_raw_xml(upload_dataset, "file-deposit/notice")
+
 def read_configuration_file (server, config_file, logger, config_files):
     """Procedure to parse a configuration file."""
 
@@ -919,6 +927,7 @@ def read_configuration_file (server, config_file, logger, config_files):
         read_storage_configuration (xml_root, logger)
         read_quotas_configuration (xml_root)
         read_colors_configuration (xml_root)
+        read_upload_dataset_configuration (xml_root)
 
         for include_element in xml_root.iter('include'):
             include    = include_element.text

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -2334,6 +2334,7 @@ class WebServer:
                 categories = categories,
                 groups     = groups,
                 show_codecheck = config.enable_codecheck,
+                file_deposit_notice = config.file_deposit_notice,
                 api_token  = self.token_from_request (request))
 
         except IndexError:


### PR DESCRIPTION
**Summary**
In the “Files” section at the bottom of the upload dataset form, we would like to display 
a message for the user with orientations about the file deposit

**Changes**
* src/djehuty/web/ui.py: Create a new config parameter file_deposit_notice and 
  read if from the configuration file. Fix read_raw_xml to compute length from
  the actual tag name are the same string.
* src/djehuty/web/config.py: Initialize file_deposit_notice 
* src/djehuty/web/wsgi.py: Return file_deposit_notice in the edit dataset ui page
* src/djehuty/web/resources/html_templates/depositor/edit-dataset.html: Add the
  file_deposit_notice in the template if exist
* doc/running-djehuty.tex: Update documentation to include file_deposit_notice

**Approval Checklist**
- [X] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [X] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [X] Code style and conventions were respected.
- [X] Documentation has been updated where needed (README, docs, or examples).
- [X] Review approved by at least one maintainer.
- [X] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**
Is part of  [Improve the deposit and publication workflow](https://github.com/4TUResearchData/djehuty/issues/43)

**Screenshots (optional)**

Before:
<img width="700" alt="image" src="https://github.com/user-attachments/assets/80cce985-3669-4c37-9eb5-faf7dcc5418d" />

After:
<img width="700" height="489" alt="image" src="https://github.com/user-attachments/assets/292d53cc-7ee5-4351-aebe-f966ce2b4441" />

**Notes**
To use it, include in the djehuty config file the tags below:
```
  <upload-dataset>
    <file-deposit>
      <notice>Your message here</file-deposit>
  </upload-dataset>
```
If the tag is not included, the message will not be displayed.