### PR TITLE
Improv #46 | Disable “Full content embargo” from the upload form

### DIFF
--- a/doc/running-djehuty.tex
+++ b/doc/running-djehuty.tex
@@ -475,12 +475,24 @@ djehuty web --config-file=config.xml --apply-transactions
 \section{Configuring dataset upload}
 
   The dataset upload behaviour can be configured under the \t{upload-dataset}
-  node.  Currently you can add a custom message under dataset file deposit section.
-  The \t{file-deposit} sub-node supports the following option:
+  node.  Currently you can:
+
+\begin{itemize}
+  \item Disable the “Full content embargo” option (enabled by default).
+  \item Add a custom message to be displayed in the dataset file deposit section.
+\end{itemize}
+
+  The \t{upload-dataset} node supports the following option:
 
 \begin{tabularx}{\textwidth}{*{1}{!{\VRule[-1pt]}l}!{\VRule[-1pt]}X}
   \headrow
   \textbf{Option}             & \textbf{Description}\\
+  \t{allow-full-embargo}      & ``Full content embargo'' is enabled by default.
+                                Set this option to 0 to disable it. When users
+                                choose to deposit a dataset or software under a
+                                ``Full content embargo'', both the files and the
+                                metadata will remain unavailable during the embargo
+                                period.\\
   \t{file-deposit/notice}     & An HTML message displayed above the file upload
                                 area when a depositor edits a dataset.  HTML
                                 markup, including hyperlinks, is supported.
@@ -490,6 +502,7 @@ djehuty web --config-file=config.xml --apply-transactions
 
 \begin{lstlisting}[language=xml]
 <upload-dataset>
+  <allow-full-embargo>0</allow-full-embargo>
   <file-deposit>
     <notice>Your message here</notice>
   </file-deposit>

--- a/src/djehuty/web/config.py
+++ b/src/djehuty/web/config.py
@@ -99,6 +99,7 @@ class RuntimeConfiguration:  # pylint: disable=too-few-public-methods
         self.datacite_password           = None
         self.datacite_prefix             = None
         self.ssi_psk                     = None
+        self.allow_full_embargo         = True
         self.file_deposit_notice         = None
         self.menu                        = []
         self.colors                      = {

--- a/src/djehuty/web/resources/html_templates/depositor/edit-dataset.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-dataset.html
@@ -325,10 +325,13 @@ table#files tbody tr td:nth-child(3) { width: 15px; text-align: right; }
     <input id="embargo_until_date" type="date" name="embargo_until_date" value="{{article["embargo_until_date"]}}" />
     <label for="embargo-type-wrapper" class="inner-head">Embargo type</label><span class="required-field"> &#8727;</span>
     <div id="embargo-type-wrapper" class="options-wrapper">
-      <input type="radio" name="embargo_type" id="files_only_embargo" value="file" /><!--
---><label for="files_only_embargo" class="no-head">Files-only embargo</label>
-      <input type="radio" name="embargo_type" id="content_embargo" value="article" /><!--
---><label for="content_embargo" class="no-head">Full content embargo</label></div>
+      <input {% if not allow_full_embargo and article["is_embargoed"] and article["embargo_type"] != "article" %} checked {% endif %} type="radio" name="embargo_type" id="files_only_embargo" value="file" />
+      <label for="files_only_embargo" class="no-head">Files-only embargo</label>
+    {% if allow_full_embargo or article["embargo_type"] == "article" %}
+      <input {% if article["embargo_type"] == "article" %} checked {% endif %} type="radio" name="embargo_type" id="content_embargo" value="article" />
+      <label for="content_embargo" class="no-head">Full content embargo</label>
+    {% endif %}
+    </div>
     <label for="embargo_reason" class="inner-head">Reason</label><span class="required-field"> &#8727;</span>
     <div id="embargo_reason" class="texteditor">
       {{article["embargo_reason"] | default("", True) | replace("\\n", "<br>") | safe }}

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -681,12 +681,13 @@ def read_email_configuration (server, xml_root, logger):
             logger.error ("Could not configure the email subsystem:")
             logger.error ("The email port should be a numeric value.")
 
-def read_upload_dataset_configuration (xml_root):
+def read_upload_dataset_configuration (xml_root, logger):
     """Procedure to parse and set the upload dataset configuration."""
     upload_dataset = xml_root.find("upload-dataset")
     if upload_dataset is not None:
-        item = upload_dataset.find("file-deposit/notice")
-        if item is not None:
+        config.allow_full_embargo = read_boolean_value(upload_dataset, "allow-full-embargo", True, logger)
+        file_deposit_notice = upload_dataset.find("file-deposit/notice")
+        if file_deposit_notice is not None:
             config.file_deposit_notice, _ = read_raw_xml(upload_dataset, "file-deposit/notice")
 
 def read_configuration_file (server, config_file, logger, config_files):
@@ -927,7 +928,7 @@ def read_configuration_file (server, config_file, logger, config_files):
         read_storage_configuration (xml_root, logger)
         read_quotas_configuration (xml_root)
         read_colors_configuration (xml_root)
-        read_upload_dataset_configuration (xml_root)
+        read_upload_dataset_configuration (xml_root, logger)
 
         for include_element in xml_root.iter('include'):
             include    = include_element.text

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -2334,6 +2334,7 @@ class WebServer:
                 categories = categories,
                 groups     = groups,
                 show_codecheck = config.enable_codecheck,
+                allow_full_embargo = config.allow_full_embargo,
                 file_deposit_notice = config.file_deposit_notice,
                 api_token  = self.token_from_request (request))
 
@@ -4845,6 +4846,9 @@ class WebServer:
 
                 if is_restricted or is_closed:
                     record["embargo_type"] = "file"
+
+                if not config.allow_full_embargo and record.get("embargo_type") == "article":
+                    return self.error_400 (request, "Full content embargo is not permitted.", 400)
 
                 authors, errors = self.__author_list_from_request_input (record, account_uuid)
                 if errors:


### PR DESCRIPTION
**Summary**
Currently there are 2 options to embargo a dataset:  “Full content embargo” 
an “Files- only embargo”. We want to have the possibility to disable the 
“Full content embargo” deposit. “Full content embargo” means that the metadata
will be fully hidden.

This change adds in djehuty config file the option for disable the “Full content embargo” 
from the upload dataset form. Full content embargo is enable by default. 

**Changes**
web: Add option to disable “Full content embargo”

* src/djehuty/web/ui.py: Create a new configuration parameter allow_full_embargo
  and read it from the configuration file.
* src/djehuty/web/config.py: Initialize allow_full_embargo
* src/djehuty/web/wsgi.py: Return allow_full_embargo in the edit dataset UI page
  and add validation for the save a dataset API.
* src/djehuty/web/resources/html_templates/depositor/edit-dataset.html: Use 
  allow_full_embargo to control “Full Content embargo” display. Keep visible 
  if already stored (backward compatibility).
* src/djehuty/web/resources/static/js/edit-dataset.js: If allow_full_embargo 
  is false, preselect file embargo and show clearer message.
* doc/running-djehuty.tex: Update documentation to include allow_full_embargo

**Approval Checklist**
- [X] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [X] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [X] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Closes issue [Disable “Full content embargo” from the upload form](https://github.com/4TUResearchData/djehuty/issues/46)

**Screenshots**

Before:
<img width="700" height="562" alt="image" src="https://github.com/user-attachments/assets/d80f2819-2205-409d-b336-b710899a32cf" />

After:
<img width="700" height="740" alt="image" src="https://github.com/user-attachments/assets/cbd918d2-b27d-43fc-aa8e-8a14e9c326ff" />



**Notes**
Full content embargo is enable by default. To disable the option, add tag 
`allow-full-embargo` and set it to `0` (false)
```
  <upload-dataset>
    <allow-full-embargo>0</allow-full-embargo>
  </upload-dataset>
```