### PR TITLE
Bug #52 | Input form for creating a new author record is missing for a collection

### DIFF
--- a/src/djehuty/web/resources/html_templates/depositor/edit-collection.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-collection.html
@@ -3,7 +3,7 @@
 <script src="/static/js/jquery-3.6.0.min.js"></script>
 <script src="/static/js/quill.min.js"></script>
 <script src="/static/js/utils.js?cache=1744290797"></script>
-<script src="/static/js/edit-collection.js?cache=1749693285"></script>
+<script src="/static/js/edit-collection.js?cache=1774629850"></script>
 <script nonce="{{nonce}}">
 jQuery(document).ready(function () {
     root_categories = []

--- a/src/djehuty/web/resources/static/js/edit-collection.js
+++ b/src/djehuty/web/resources/static/js/edit-collection.js
@@ -545,7 +545,7 @@ function submit_new_author_event (event) {
     submit_new_author (event.data["collection_id"]);
 }
 
-function new_author (dataset_uuid) {
+function new_author (collection_id) {
     let banner = `<br><span><i>Enter the details of the author you want to add.</i></span>`;
     jQuery("#new-author-description").after(banner).remove();
     let html = jQuery("<div/>", { "id": "new-author-form" });


### PR DESCRIPTION
**Summary**
Input form for creating a new author record is missing for a collection

**Changes**
- /src/djehuty/web/resources/html_templates/depositor/edit-collection.html: 
  Update cache.
- src/djehuty/web/resources/static/js/edit-collection.js: Pass collection_uuid
  to the function that handles new authors.


**Approval Checklist**
- [X] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [X] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [X] Code style and conventions were respected.
- [X] Documentation has been updated where needed (README, docs, or examples).
- [X] Review approved by at least one maintainer.
- [X] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Closes #52 

**Screenshots**

Before
<img width="700" height="449" alt="image" src="https://github.com/user-attachments/assets/adedfff2-8f34-44ec-a073-f880ff85367b" />


After 
<img width="700" height="949" alt="image" src="https://github.com/user-attachments/assets/c4c75780-d764-4fcb-a08a-9409dde57e58" />