### PR TITLE
doc: Add SECURITY.md with coordinated disclosure policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 contact_links:
   - name: "🛡️ Reporting security issues"
-    url: https://github.com/4TUResearchData/djehuty?tab=readme-ov-file#reporting-potential-security-issues
+    url: https://github.com/4TUResearchData/djehuty/blob/main/SECURITY.md
     about: ⚠️ IMPORTANT - For security-related matters, DO NOT create an issue. Please e-mail djehuty@4tu.nl.
   - name: "📣 Contact information"
     url: https://github.com/4TUResearchData/djehuty/blob/main/GOVERNANCE.md#contact-information

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Before starting any work, please **contact repository maintainers at [djehuty@4t
 Before you start work, **search the [issue tracker](https://github.com/4TUResearchData/djehuty/issues)** to see if your idea is already being discussed: issues.
     - If you find a relevant issue, comment to say you’re taking it on and, if possible, assign yourself. If you cannot assign, leave a comment like “Working on this” so maintainers know.
     - If no issue exists, open a new issue using the [issue template](#issue-template) and include: a short, descriptive title; a brief explanation of the problem or feature and why it’s needed.
-        - ⚠️ **IMPORTANT**: **Do not discuss security-related aspects**, vulnerabilities, or sensitive information in GitHub issues. Contact the maintainers at [djehuty@4tu.nl](djehuty@4tu.nl) privately for any security concerns.
+        - ⚠️ **IMPORTANT**: **Do not discuss security-related aspects**: to report a vulnerability, please see [SECURITY.md](./SECURITY.md)
 
 3. **Work from a fork**
 Contributors should work from a fork of the repository. Maintainers may work directly on the main djehuty instance.
@@ -62,8 +62,8 @@ Follow the instructions in the [README](https://github.com/4TUResearchData/djehu
 - Once your work is ready for review, open a Pull Request (PR) against the main project repository.
     - Provide a clear description of what you changed and link the related issue.
     - Use the [PR template](#pull-request-template) and check the approval checklist before submitting.
-    - ⚠️ **IMPORTANT**: **Do not open a PR for a security issue until** you have received confirmation from the maintainers that all affected instances have been patched. When opening the PR, strictly follow maintainer instructions and keep naming, commit messages, and descriptions neutral.
-        
+    - ⚠️ **IMPORTANT**: **Do not open a PR for a security issue**: to report a vulnerability, please see [SECURITY.md](./SECURITY.md)
+
 7. **Final approval and merge**
 After review and approval, your PR must be squashed into a single commit using the project’s [commit message template](#commit-message-template). Once the checklist is complete, a maintainer will rebase-merge it into the main branch to keep the history clean.
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@ djehuty
 
 This Python package provides the repository system for 4TU.ResearchData and Nikhef.
 
-## Reporting (potential) security issues
+## Security
 
-For **security-related matters**, please e-mail
-[djehuty@4tu.nl](mailto:djehuty@4tu.nl). 
+To report a vulnerability, please see [SECURITY.md](./SECURITY.md).
 
 ## Creating a development environment
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in djehuty, please report it
+**privately** by emailing [djehuty@4tu.nl](mailto:djehuty@4tu.nl).
+
+**Please do not open a public issue for security vulnerabilities.**
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected version(s)
+- Potential impact, if known
+
+### What to expect
+
+- **Acknowledgment** within **48 hours** of your report.
+- A follow-up with our assessment and an estimated timeline for a fix
+  within **7 business days**.
+- Credit in the advisory, unless you prefer to remain anonymous.
+
+## Supported Versions
+
+| Version | Supported          |
+|---------|--------------------|
+| Latest  | Yes                |
+
+## Disclosure Policy
+
+We follow [coordinated vulnerability disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure).
+After a fix is available, we will:
+
+1. Release a patched version.
+2. Publish a [GitHub Security Advisory](https://github.com/4TUResearchData/djehuty/security/advisories)
+   with details and remediation steps.
+3. Request a CVE identifier when appropriate.
+
+We aim to resolve confirmed vulnerabilities within **90 days** of the
+initial report.


### PR DESCRIPTION
**Summary**

Add a dedicated security policy following OpenSSF guidelines, covering private reporting instructions, response timelines, and coordinated disclosure. Update README.md to reference the new SECURITY.md.

**Changes**
- filename: `README.md`, `SECURITY.md`

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

part of #58 
