### PR TITLE
fix: default to all scopes in dataset search

### DIFF
--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -373,7 +373,7 @@ class SparqlInterface:
         """
         search_for = search_query["search_for"] # list
         operator   = search_query["operator"]   # str
-        scopes     = search_query["scope"]      # list
+        scopes     = search_query["scope"] or ["title", "description", "tag", "author"]
         andgate    = operator == "AND"
 
         if not search_for:


### PR DESCRIPTION
**Summary**

Fix dataset search failing when no scopes are provided. When scope is an empty list, the search throws a 500 error. This defaults to all available scopes (title, description, tag, author) when none are specified.

**Changes**
- src/djehuty/web/database.py: Default to all scopes when search_query["scope"] is empty.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Extracted from #56 as requested in https://github.com/4TUResearchData/djehuty/pull/56#discussion_r3037010331.