### PR TITLE
Release version v26.2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(djehuty, 26.1)
+AC_INIT(djehuty, 26.2)
 AM_INIT_AUTOMAKE([foreign tar-ustar])
 AM_PATH_PYTHON([3.9])
 AC_CONFIG_FILES([

--- a/doc/contact.tex
+++ b/doc/contact.tex
@@ -13,27 +13,25 @@
 
 \section*{General inquiries}
 
-  For questions about the project or requesting an (test) instance,
-  e-mail us at \href{mailto:info@djehuty.4tu.nl}{info@djehuty.4tu.nl}.
+  For questions about the project or requests,
+  e-mail us at \href{mailto:djehuty@4tu.nl}{djehuty@4tu.nl}.
 
 \section*{Reporting security vulnerabilities}
 
-  For security-related matters, please e-mail us at
-  \href{mailto:security@djehuty.4tu.nl}{security@djehuty.4tu.nl}. This
-  will reach only the security teams at 4TU.ResearchData and Nikhef.
+  For security-related matters, please take a look at the
+  \href{https://github.com/4TUResearchData/djehuty?tab=security-ov-file#readme}{security policy}
+  document and e-mail us at \href{mailto:djehuty@4tu.nl.}{djehuty@4tu.nl.}.
 
-\section*{Meet the team}
+\section*{Contact the team}
 
-We would love to have you over at either TU Delft or Nikhef for a cup
-of coffee, to talk about the endless possibilities of \t{djehuty} and
-what it could mean for you!
+  If you have questions, suggestions, or would like to contribute to the Djehuty project,
+  please contact the project team via the
+  \href{https://github.com/4TUResearchData/djehuty}{GitHub repository}
+  or via email:
 
-\textbf{Catharina Vaendel}\\~
-\href{mailto:cvaendel@nikhef.nl}{cvaendel@nikhef.nl}\\~
-Software Infrastructure Engineer @ Nikhef\\~
-\href{https://www.linkedin.com/in/catharinavaendel}{LinkedIn}
+\textbf{Gabriela Kuhn}\\~
+\href{mailto:g.kuhn@tudelft.nl}{g.kuhn@tudelft.nl}\\~
+Software Engineer @ TU Delft
 
-\textbf{Roel Janssen}\\~
-\href{mailto:r.r.e.janssen@tudelft.nl}{r.r.e.janssen@tudelft.nl}\\~
-Senior Software Engineer @ TU Delft\\~
-\href{https://github.com/roelj}{Github}
+\textbf{For General Questions about 4TU ResearchData}\\~
+\href{mailto:researchdata@4tu.nl}{researchdata@4tu.nl}

--- a/doc/news.tex
+++ b/doc/news.tex
@@ -5,6 +5,41 @@
 \fi
 \chapter*{News}
 
+\labelWithConsistentHTMLTag{release-26-2}
+\section*{Release notes for \texttt{v26.2}.}
+
+  The second release of 2026 consists of 9 commits made by 2 authors.
+
+\subsection*{Documentation}
+\begin{itemize}
+\item{Add SECURITY.md with coordinated disclosure policy.
+    (\commitLink{9076560f16f1b18c20120d5093d60b271f357f18}).}
+\item{Update GOVERNANCE.md Diagram as a code.
+    (\commitLink{f1108ed8dce7b03c6ea57347c3e962605afab3c7}).}
+\end{itemize}
+
+\subsection*{Bugfixes}
+\begin{itemize}
+\item{Fix documentation build issues and make debugging it easier.
+    (\commitLink{d0f3f957561fc51fa2e2854d404bbceaecef42a3}).}
+\item{Fix new author fields not displaying in collections.
+    (\commitLink{60ec8bf4c35e03e1f4cf0c59f0c491fe68cd9691}).}
+\end{itemize}
+
+\subsection*{Incremental improvements}
+\begin{itemize}
+\item{Add option to disable “Full content embargo”.
+    (\commitLink{42b6eb1a9991da9288bfc12571d91606b004d1f9}).}
+\item{Add custom message to dataset file deposit.
+    (\commitLink{5f42855a88cf86dbb21c5c111504fda95a2e3f69}).}
+\item{Make primary menu layout dynamic and flexible.
+    (\commitLink{0f3f8d9b95dc2e0ae96fc5b5088af8dd6a8c5c52}).}
+\item{Implement easy development start process with djehuty.
+    (\commitLink{c8635b4c7bc9ca53cbb4efe0d16e3e8e763a7652}).}
+\item{Create dependabot.yml file to monitors dependencies.
+    (\commitLink{fdbeee753a57d31664a4fb8f7a1bd830bdc5084c}).}
+\end{itemize}
+
 \labelWithConsistentHTMLTag{release-26-1}
 \section*{Release notes for \texttt{v26.1}.}
 


### PR DESCRIPTION
**Summary**
Release version v26.2. We are now using for naming year and
sequence order of the release (26.2 - second release of 2026).

https://github.com/4TUResearchData/djehuty/releases/tag/v26.2

**Changes**
* configure.ac: Bump version to v26.2.
* doc/news.tex: Add release notes for v26.2.
* doc/contact.tex: Update contact information.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).