### PR TITLE
Improv | Add support for nesting a sub-submenu for an sub-menu item

### DIFF
--- a/doc/running-djehuty.tex
+++ b/doc/running-djehuty.tex
@@ -564,6 +564,91 @@ djehuty web --config-file=config.xml --apply-transactions
   \t{background-color}         & Background color for the content section.
 \end{tabularx}
 
+\section{Customizing the menu}
+\label{sec:customize-menu}
+
+  The top navigation menu is defined using the \t{menu} XML element, which can
+  be placed in a separated menu configuration file and loaded via \t{include} in the Djehuty
+  configuration.
+  The menu supports up to three levels of nesting:
+  primary menu items, sub-menus, and sub-sub-menus.
+
+\subsection{Menu structure}
+
+  A \t{menu} element contains one or more \t{primary-menu} elements, each
+  rendered as a top-level entry in the navigation bar.  Hovering over a primary
+  item reveals its \t{sub-menu} children in a dropdown panel.  A \t{sub-menu}
+  may contain a \t{sub-sub-menu} children.
+
+  Every item requires a \t{title} with its display text.
+  \t{sub-menu} and \t{sub-sub-menu} items also require an \t{href} element
+  with the destination URL.
+
+\begin{tabularx}{\textwidth}{*{1}{!{\VRule[-1pt]}l}!{\VRule[-1pt]}X}
+  \headrow
+  \textbf{Element}    & \textbf{Description}\\
+  \t{menu}            & Root element that groups all primary menu items.\\
+  \t{primary-menu}    & A top-level navigation bar entry.  Requires a
+                        \t{title} child.\\
+  \t{sub-menu}        & A dropdown item inside a \t{primary-menu}.  Requires
+                        \t{title} and \t{href} children.  May contain one or
+                        more \t{sub-sub-menu} children.\\
+  \t{sub-sub-menu}    & A flyout item inside a \t{sub-menu}, displayed to the
+                        right on hover.  Requires \t{title} and \t{href}
+                        children.\\
+\end{tabularx}
+
+\subsection{Example}
+
+\begin{lstlisting}[language=XML]
+<djehuty>
+  <menu>
+
+    <primary-menu>
+      <title>About your Data</title>
+      <sub-menu>
+        <title>Getting started</title>
+        <href>/info/about-your-data/getting-started</href>
+      </sub-menu>
+      <sub-menu>
+        <title>Publish and Cite</title>
+        <href>/info/about-your-data/publish-cite</href>
+      </sub-menu>
+    </primary-menu>
+
+    <primary-menu>
+      <title>Collaborations</title>
+      <sub-menu>
+        <title>Collaborations overview</title>
+        <href>https://example.org/collaborations/</href>
+      </sub-menu>
+      <sub-menu>
+        <title>Digital Capacity for NES</title>
+        <href>https://example.org/digital-capacity/</href>
+        <sub-sub-menu>
+          <title>Call 1: Instructors</title>
+          <href>https://example.org/digital-capacity/call-1/</href>
+        </sub-sub-menu>
+        <sub-sub-menu>
+          <title>Call 2: Learners</title>
+          <href>https://example.org/digital-capacity/call-2/</href>
+        </sub-sub-menu>
+      </sub-menu>
+    </primary-menu>
+
+  </menu>
+</djehuty>
+\end{lstlisting}
+
+  Keep the menu definition in a dedicated config file and load it
+  from the main configuration file using \t{include}:
+
+\begin{lstlisting}[language=XML]
+<djehuty>
+  <include>/etc/djehuty/djehuty-menu.xml</include>
+</djehuty>
+\end{lstlisting}
+
 \section{Configuring privileged users}
 
   By default an authenticated user may deposit data. But users can have

--- a/src/djehuty/web/resources/html_templates/colors.css
+++ b/src/djehuty/web/resources/html_templates/colors.css
@@ -23,6 +23,8 @@ body,html { background-color: {{background_color}}; }
 #login-button:active { background: {{primary_color_active}}; cursor: pointer; }
 #primary-menu .menu-item-has-children:hover { color: {{primary_color_hover}}; }
 #primary-menu li a:hover { color: {{primary_color_hover}}; }
+.sub-submenu-item a { color: {{primary_color}}; }
+.sub-submenu-item a:hover { color: {{primary_color_hover}}; }
 .publish-button a { background: {{primary_color}} !important; }
 .publish-button a:hover { background: {{primary_color_hover}} !important; }
 .publish-button a:active { background: {{primary_color_active}} !important; }

--- a/src/djehuty/web/resources/html_templates/layout.html
+++ b/src/djehuty/web/resources/html_templates/layout.html
@@ -82,7 +82,17 @@
           <li class="menu-item menu-item-has-children">{{primary_menu.title}}
             <ul class="submenu">
               {% for submenu in primary_menu.submenu %}
+              {% if submenu.sub_submenu %}
+              <li class="submenu-item submenu-item-has-children"><a href="{{ submenu.href }}">{{ submenu.title }}</a>
+                <ul class="sub-submenu">
+                  {% for sub in submenu.sub_submenu %}
+                  <li class="sub-submenu-item"><a href="{{ sub.href }}">{{ sub.title }}</a></li>
+                  {% endfor %}
+                </ul>
+              </li>
+              {% else %}
               <li class="submenu-item"><a href="{{ submenu.href }}">{{ submenu.title }}</a></li>
+              {% endif %}
               {% endfor %}
             </ul>
           </li>

--- a/src/djehuty/web/resources/static/css/main.css
+++ b/src/djehuty/web/resources/static/css/main.css
@@ -204,28 +204,73 @@ a.inline-button.close:active { background: #aa4444; color: #000; text-decoration
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.25);
     border-radius: .5em;
     margin: 0pt !important;
-    padding: 0pt 10pt 0pt 10pt;
-    overflow: hidden;
+    padding: 0pt 10pt 10pt 10pt;
+    overflow: visible;
     z-index: 1;
 }
 nav { display: block; padding-top: 1pt; }
-.submenu li {
+.submenu > li {
     font-weight: normal;
-    width: 100%;
     min-width: 100pt;
     margin: 0pt 10pt 10pt 10pt;
     padding: 5pt 10pt 5pt 10pt !important;
     user-select: none;
     z-index: 0;
+    box-sizing: border-box;
 }
-.submenu li:nth-child(even) {
+.submenu > li:nth-child(even) {
     background: #fafafa !important;
+}
+.submenu > li:last-child {
+    border-radius: 0 0 .5em .5em;
 }
 .menu-item a { color: #505050; }
 .menu-item a:hover { color: #303030; }
 .submenu-item { white-space: normal!important; }
 .submenu-item a { font-size: 13pt; color: #000000; }
 .submenu-item a:hover { color: #333333; }
+.submenu-item-has-children {
+    display: flex !important;
+    align-items: center;
+    gap: 8pt;
+}
+.submenu-item-has-children > a { flex: 1; }
+.submenu-item-has-children::after {
+    content: '\f054';
+    font-family: "Font Awesome 6", sans-serif;
+    font-weight: 900;
+    font-size: 10pt;
+    color: #d0d0d0;
+    flex-shrink: 0;
+}
+.sub-submenu {
+    position: absolute;
+    display: none;
+    left: 100%;
+    top: 0;
+    max-width: 340pt;
+    background: #ffffff;
+    border: solid 1pt #ccc;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.25);
+    border-radius: .5em;
+    margin: 0pt !important;
+    padding: 0pt 10pt 0pt 10pt;
+    overflow: hidden;
+    z-index: 2;
+}
+.submenu-item-has-children { position: relative; }
+.submenu-item-has-children:hover > .sub-submenu { display: block; }
+.sub-submenu li {
+    font-weight: normal;
+    min-width: 100pt;
+    margin: 0pt 10pt 10pt 10pt;
+    padding: 5pt 10pt 5pt 10pt !important;
+    user-select: none;
+    white-space: nowrap;
+    box-sizing: border-box;
+}
+.sub-submenu-item a { font-size: 13pt; }
+.sub-submenu-item a:hover { text-decoration: underline; }
 #footer {
     height: auto;
     width: 100%;

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -582,9 +582,17 @@ def read_menu_configuration (xml_root):
         submenu = []
         for submenu_item in primary_menu_item:
             if submenu_item.tag == "sub-menu":
+                sub_submenu = []
+                for sub_submenu_item in submenu_item:
+                    if sub_submenu_item.tag == "sub-sub-menu":
+                        sub_submenu.append({
+                            "title": config_value (sub_submenu_item, "title"),
+                            "href":  config_value (sub_submenu_item, "href")
+                        })
                 submenu.append({
-                    "title": config_value (submenu_item, "title"),
-                    "href":  config_value (submenu_item, "href")
+                    "title":       config_value (submenu_item, "title"),
+                    "href":        config_value (submenu_item, "href"),
+                    "sub_submenu": sub_submenu
                 })
 
         config.menu.append({


### PR DESCRIPTION
**Summary**

The [community website of the 4TU ResearchchData](https://community.data.4tu.nl/) supports nesting 
a sub-submenu for an sub-menu item. We would like to include the same functionality and Djehuty, 
thus Djehuty and the 4TU Data Repository can also support same functionality for the menu. 

This changes also include documentation for how to customise the menu that is currently not available.
 
**Changes**
* src/djehuty/web/resources/html_templates/colors.css: Add colors for sub-submenu
  items.
* src/djehuty/web/resources/html_templates/layout.html: Add sub-submenu items in
  the template render.
* src/djehuty/web/resources/static/css/main.css: Add styles for .sub-submenu
  items.
* src/djehuty/web/ui.py: Method read_menu_configuration now parses sub-sub-menu
  childrens from the configurations.
* doc/running-djehuty.tex: Update documentation to include
  information about how to customize the menu.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Screenshots**

Before:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/2e5c6dd3-85a1-4df7-a873-7e4c6d80bb66" />


After:

<img width="750" alt="image" src="https://github.com/user-attachments/assets/57092474-3fdb-4d13-b5a9-14b2b59b9353" />

