### PR TITLE
Feature #41 | Add review and publish workflow for physical samples 

### DIFF
--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3095,7 +3095,7 @@ class SparqlInterface:
                           is_published=True, is_latest=True, limit=None,
                           order=None, order_direction=None,
                           offset=None, private_link_id_string=None,
-                          is_under_review=None):
+                          is_under_review=None, use_cache=True):
         """Procedure to retrieve physical samples."""
 
         filters  = rdf.sparql_filter ("container", rdf.uuid_to_uri (container_uuid, "container"), is_uri=True)
@@ -3112,6 +3112,11 @@ class SparqlInterface:
         })
 
         query += rdf.sparql_suffix (order, order_direction, limit, offset)
+
+        if use_cache:
+            cache_prefix = (f"physical-samples_{account_uuid}"
+                            if account_uuid is not None else "physical-samples")
+            return self.__run_query (query, query, cache_prefix)
 
         return self.__run_query (query)
 
@@ -3168,7 +3173,12 @@ class SparqlInterface:
             "sample_uuid": sample_uuid
         })
 
-        return self.__run_logged_query (query)
+        if self.__run_logged_query (query):
+            self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+            self.cache.invalidate_by_prefix ("physical-samples")
+            return True
+
+        return False
 
     def publish_physical_sample (self, container_uuid, account_uuid):
         """Procedure to publish a draft physical sample."""
@@ -3177,32 +3187,36 @@ class SparqlInterface:
         self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
         self.cache.invalidate_by_prefix ("physical-samples")
 
+        # Read the current state fresh so these reads don't repopulate the
+        # cache with the pre-publish data.
         draft = None
         try:
             draft = self.physical_samples (container_uuid = container_uuid,
                                            is_published   = False,
-                                           is_latest      = False)[0]
+                                           is_latest      = False,
+                                           use_cache      = False)[0]
         except IndexError:
             self.log.error ("Attempted to publish without a draft <container:%s>.",
                             container_uuid)
             return False
 
-        new_version_number = 1
-        latest             = None
+        # Physical samples are not versioned: an update replaces the single
+        # published record in place, so the version number stays at 1.
+        latest = None
         try:
             latest = self.physical_samples (container_uuid = container_uuid,
                                             is_published   = True,
-                                            is_latest      = True)[0]
-            new_version_number = conv.value_or (latest, "version", 0) + 1
+                                            is_latest      = True,
+                                            use_cache      = False)[0]
         except IndexError:
-            self.log.info ("No latest version for <container:%s>.", container_uuid)
+            self.log.info ("No published version yet for <container:%s>.", container_uuid)
 
         sample_uuid  = draft["sample_uuid"]
         blank_node   = self.wrap_in_blank_node (sample_uuid, "physical-sample")
         current_time = datetime.strftime (datetime.now(), datetime_format)
         query        = self.__query_from_template ("publish_draft_physical_sample", {
             "blank_node":        blank_node,
-            "version":           new_version_number,
+            "version":           1,
             "container_uuid":    container_uuid,
             "sample_uuid":       sample_uuid,
             "timestamp":         current_time,
@@ -3213,6 +3227,7 @@ class SparqlInterface:
             self.cache.invalidate_by_prefix ("repository_statistics")
             self.cache.invalidate_by_prefix ("reviews")
             self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+            self.cache.invalidate_by_prefix ("physical-samples")
             return True
 
         return False
@@ -3294,12 +3309,114 @@ class SparqlInterface:
 
         return results
 
-    def physical_sample_creators (self, container_uuid, account_uuid):
-        """Returns the creators of a physical sample."""
+    def create_draft_from_published_physical_sample (self, container_uuid, account_uuid):
+        """Procedure to copy a published physical sample as a draft in its container.
+
+        Physical samples are not versioned: an update reuses the same container
+        (and therefore the same IGSN).  This creates a separate editable draft so
+        the published record stays untouched until a reviewer approves the update.
+        Returns the new draft's sample UUID, or None on failure. It uses similar
+        workflow than dataset but without create a versioning at end
+        """
+
+        try:
+            published = self.physical_samples (container_uuid = container_uuid,
+                                               account_uuid   = account_uuid,
+                                               is_published   = True,
+                                               is_latest      = True)[0]
+        except (IndexError, TypeError):
+            return None
+
+        published_uri = f"physical-sample:{published['sample_uuid']}"
+
+        ## Mint a new draft node linked to the existing container.
+        container_uuid, draft_uuid = self.insert_physical_sample (
+            title          = conv.value_or (published, "title", "Untitled item"),
+            account_uuid   = account_uuid,
+            container_uuid = container_uuid)
+
+        if draft_uuid is None:
+            return None
+
+        ## Copy the scalar metadata onto the draft.  We deliberately skip the DOI,
+        ## published/posted dates and version: the IGSN lives on the container and
+        ## the draft is yet-to-be-published.
+        self.update_physical_sample (
+            title                     = conv.value_or (published, "title", "Untitled item"),
+            sample_uuid               = draft_uuid,
+            account_uuid              = account_uuid,
+            container_uuid            = container_uuid,
+            abstract                  = conv.value_or_none (published, "abstract"),
+            methods                   = conv.value_or_none (published, "methods"),
+            publisher                 = conv.value_or_none (published, "publisher"),
+            publication_year          = conv.value_or_none (published, "publication_year"),
+            resource_type             = conv.value_or_none (published, "resource_type"),
+            subject                   = conv.value_or_none (published, "subject"),
+            alternate_identifier      = conv.value_or_none (published, "alternate_identifier"),
+            related_resource          = conv.value_or_none (published, "related_resource"),
+            organizations             = conv.value_or_none (published, "organizations"),
+            physical_storage_location = conv.value_or_none (published, "physical_storage_location"),
+            geolocation               = conv.value_or_none (published, "geolocation"),
+            longitude                 = conv.value_or_none (published, "longitude"),
+            latitude                  = conv.value_or_none (published, "latitude"),
+            sample_owner_name         = conv.value_or_none (published, "sample_owner_name"),
+            sample_owner_email        = conv.value_or_none (published, "sample_owner_email"),
+            group_id                  = conv.value_or_none (published, "group_id"))
+
+        ## Copy the lists metadata.  Like, creators reference shared author URIs,
+        ## so only a new list cell is created.  Dates and related resources are
+        ## per sample, so fresh entities are created for the draft.  We read the
+        ## published lists by sample URI only (account_uuid=None): the URI already
+        ## pins the sample, and combining sample_uri with account_uuid triggers a
+        ## pathological query plan on the large state graph.
+        for creator in self.physical_sample_creators (container_uuid, None,
+                                                       sample_uri = published_uri):
+            self.add_creator_to_physical_sample (container_uuid, creator["uuid"], account_uuid)
+
+        for date in self.physical_sample_dates (container_uuid, None,
+                                                 sample_uri = published_uri):
+            self.add_date_to_physical_sample (container_uuid,
+                                              conv.value_or (date, "date_type", "other"),
+                                              conv.value_or_none (date, "date"),
+                                              account_uuid)
+
+        for resource in self.physical_sample_related_resources (container_uuid, None,
+                                                                sample_uri = published_uri):
+            self.add_related_resource_to_physical_sample (
+                container_uuid,
+                conv.value_or_none (resource, "url"),
+                conv.value_or (resource, "type_id", "URL"),
+                conv.value_or (resource, "relation_id", "IsPartOf"),
+                account_uuid)
+
+        ## Copy the categories, which reference shared category URIs.
+        categories = self.categories (item_uri = published_uri, limit = None)
+        if categories:
+            category_uris = rdf.uris_from_records (categories, "category", "uuid")
+            self.update_item_list (draft_uuid, account_uuid, category_uris, "categories")
+
+        ## Copy the keywords/tags (stored as a list of string literals).
+        tags = self.tags (item_uri = published_uri, limit = None)
+        if tags:
+            tag_values = [tag["tag"] for tag in tags if conv.value_or_none (tag, "tag")]
+            self.update_item_list (draft_uuid, account_uuid, tag_values, "tags")
+
+        self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+        self.cache.invalidate_by_prefix ("physical-samples")
+        return draft_uuid
+
+    def physical_sample_creators (self, container_uuid, account_uuid, sample_uri=None):
+        """Returns the creators of a physical sample.
+
+        By default the container's draft is used.  Pass SAMPLE_URI to read the
+        creators of a specific sample (e.g. the published one), so a draft and a
+        published sample can coexist in the same container.
+        """
 
         query = self.__query_from_template ("physical_sample_creators", {
             "container_uuid": container_uuid,
-            "account_uuid":   account_uuid
+            "account_uuid":   account_uuid,
+            "sample_uri":     sample_uri
         })
         return self.__run_query (query)
 
@@ -3323,12 +3440,17 @@ class SparqlInterface:
 
         return None
 
-    def physical_sample_dates (self, container_uuid, account_uuid):
-        """Returns dates of a physical sample."""
+    def physical_sample_dates (self, container_uuid, account_uuid, sample_uri=None):
+        """Returns dates of a physical sample.
+
+        By default the container's draft is used.  Pass SAMPLE_URI to read the
+        dates of a specific sample (e.g. the published one).
+        """
 
         query = self.__query_from_template ("physical_sample_dates", {
             "container_uuid": container_uuid,
-            "account_uuid":   account_uuid
+            "account_uuid":   account_uuid,
+            "sample_uri":     sample_uri
         })
         return self.__run_query (query)
 
@@ -3364,12 +3486,17 @@ class SparqlInterface:
 
         return None
 
-    def physical_sample_related_resources (self, container_uuid, account_uuid):
-        """Returns related identifiers of a physical sample."""
+    def physical_sample_related_resources (self, container_uuid, account_uuid, sample_uri=None):
+        """Returns related identifiers of a physical sample.
+
+        By default the container's draft is used.  Pass SAMPLE_URI to read the
+        related resources of a specific sample (e.g. the published one).
+        """
 
         query = self.__query_from_template ("physical_sample_related_resources", {
             "container_uuid": container_uuid,
-            "account_uuid":   account_uuid
+            "account_uuid":   account_uuid,
+            "sample_uri":     sample_uri
         })
         return self.__run_query (query)
 

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3094,7 +3094,8 @@ class SparqlInterface:
                           sample_uuid=None,
                           is_published=True, is_latest=True, limit=None,
                           order=None, order_direction=None,
-                          offset=None, private_link_id_string=None,):
+                          offset=None, private_link_id_string=None,
+                          is_under_review=None):
         """Procedure to retrieve physical samples."""
 
         filters  = rdf.sparql_filter ("container", rdf.uuid_to_uri (container_uuid, "container"), is_uri=True)
@@ -3105,6 +3106,7 @@ class SparqlInterface:
             "account_uuid":            account_uuid,
             "is_published":            is_published,
             "is_latest":               is_latest,
+            "is_under_review":         is_under_review,
             "private_link_id_string":  private_link_id_string,
             "filters":                 filters
         })
@@ -3167,6 +3169,81 @@ class SparqlInterface:
         })
 
         return self.__run_logged_query (query)
+
+    def publish_physical_sample (self, container_uuid, account_uuid):
+        """Procedure to publish a draft physical sample."""
+
+        # Prevent caches from playing a role.
+        self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+        self.cache.invalidate_by_prefix ("physical-samples")
+
+        draft = None
+        try:
+            draft = self.physical_samples (container_uuid = container_uuid,
+                                           is_published   = False,
+                                           is_latest      = False)[0]
+        except IndexError:
+            self.log.error ("Attempted to publish without a draft <container:%s>.",
+                            container_uuid)
+            return False
+
+        new_version_number = 1
+        latest             = None
+        try:
+            latest = self.physical_samples (container_uuid = container_uuid,
+                                            is_published   = True,
+                                            is_latest      = True)[0]
+            new_version_number = conv.value_or (latest, "version", 0) + 1
+        except IndexError:
+            self.log.info ("No latest version for <container:%s>.", container_uuid)
+
+        sample_uuid  = draft["sample_uuid"]
+        blank_node   = self.wrap_in_blank_node (sample_uuid, "physical-sample")
+        current_time = datetime.strftime (datetime.now(), datetime_format)
+        query        = self.__query_from_template ("publish_draft_physical_sample", {
+            "blank_node":        blank_node,
+            "version":           new_version_number,
+            "container_uuid":    container_uuid,
+            "sample_uuid":       sample_uuid,
+            "timestamp":         current_time,
+            "first_publication": not latest
+        })
+
+        if self.__run_logged_query (query):
+            self.cache.invalidate_by_prefix ("repository_statistics")
+            self.cache.invalidate_by_prefix ("reviews")
+            self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+            return True
+
+        return False
+
+    def decline_physical_sample (self, container_uuid, account_uuid):
+        """Procedure to decline a draft physical sample."""
+
+        # Prevent caches from playing a role.
+        self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+        self.cache.invalidate_by_prefix ("physical-samples")
+
+        try:
+            self.physical_samples (container_uuid = container_uuid,
+                                   is_published   = False,
+                                   is_latest      = False)[0]
+        except IndexError:
+            self.log.error ("Attempted to decline without a draft <container:%s>.",
+                            container_uuid)
+            return False
+
+        query = self.__query_from_template ("decline_draft_physical_sample", {
+            "container_uuid": container_uuid,
+        })
+
+        if self.__run_logged_query (query):
+            self.cache.invalidate_by_prefix ("reviews")
+            self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+            return True
+
+        self.log.error ("Failed to decline physical sample %s", container_uuid)
+        return False
 
     def update_physical_sample (self, title, sample_uuid, account_uuid,
                                 container_uuid=None, abstract=None, methods=None,

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3228,9 +3228,26 @@ class SparqlInterface:
             self.cache.invalidate_by_prefix ("reviews")
             self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
             self.cache.invalidate_by_prefix ("physical-samples")
+            if not self.__physical_sample_is_published (container_uuid, sample_uuid):
+                self.log.error ("Publishing physical sample %s did not change its state.",
+                                container_uuid)
+                return False
             return True
 
         return False
+
+    def __physical_sample_is_published (self, container_uuid, sample_uuid):
+        """Returns True when SAMPLE_UUID is the published record of its container."""
+
+        try:
+            published = self.physical_samples (container_uuid = container_uuid,
+                                               is_published   = True,
+                                               is_latest      = True,
+                                               use_cache      = False)[0]
+        except IndexError:
+            return False
+
+        return conv.value_or_none (published, "sample_uuid") == sample_uuid
 
     def decline_physical_sample (self, container_uuid, account_uuid):
         """Procedure to decline a draft physical sample."""
@@ -3239,10 +3256,13 @@ class SparqlInterface:
         self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
         self.cache.invalidate_by_prefix ("physical-samples")
 
+        # Read the current state fresh so this read doesn't repopulate the
+        # cache with some pre-decline data.
         try:
             self.physical_samples (container_uuid = container_uuid,
                                    is_published   = False,
-                                   is_latest      = False)[0]
+                                   is_latest      = False,
+                                   use_cache      = False)[0]
         except IndexError:
             self.log.error ("Attempted to decline without a draft <container:%s>.",
                             container_uuid)
@@ -3255,10 +3275,32 @@ class SparqlInterface:
         if self.__run_logged_query (query):
             self.cache.invalidate_by_prefix ("reviews")
             self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+            self.cache.invalidate_by_prefix ("physical-samples")
+            if self.__physical_sample_is_under_review (container_uuid):
+                self.log.error ("Declining physical sample %s did not change its state.",
+                                container_uuid)
+                return False
             return True
 
         self.log.error ("Failed to decline physical sample %s", container_uuid)
         return False
+
+    def __physical_sample_is_under_review (self, container_uuid):
+        """Returns True when the container's draft is still under review.
+
+        An UPDATE whose WHERE clause matches nothing is not an error, so the
+        outcome of publishing or declining has to be verified separately.
+        """
+
+        try:
+            draft = self.physical_samples (container_uuid = container_uuid,
+                                           is_published   = False,
+                                           is_latest      = False,
+                                           use_cache      = False)[0]
+        except IndexError:
+            return False
+
+        return bool (conv.value_or (draft, "is_under_review", False))
 
     def update_physical_sample (self, title, sample_uuid, account_uuid,
                                 container_uuid=None, abstract=None, methods=None,

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3383,7 +3383,7 @@ class SparqlInterface:
         ## Copy the scalar metadata onto the draft.  We deliberately skip the DOI,
         ## published/posted dates and version: the IGSN lives on the container and
         ## the draft is yet-to-be-published.
-        self.update_physical_sample (
+        copied = self.update_physical_sample (
             title                     = conv.value_or (published, "title", "Untitled item"),
             sample_uuid               = draft_uuid,
             account_uuid              = account_uuid,
@@ -3405,6 +3405,10 @@ class SparqlInterface:
             sample_owner_email        = conv.value_or_none (published, "sample_owner_email"),
             group_id                  = conv.value_or_none (published, "group_id"))
 
+        if not copied:
+            self.log.error ("Failed to copy the metadata of %s into draft %s.",
+                            container_uuid, draft_uuid)
+
         ## Copy the lists metadata.  Like, creators reference shared author URIs,
         ## so only a new list cell is created.  Dates and related resources are
         ## per sample, so fresh entities are created for the draft.  We read the
@@ -3413,35 +3417,45 @@ class SparqlInterface:
         ## pathological query plan on the large state graph.
         for creator in self.physical_sample_creators (container_uuid, None,
                                                        sample_uri = published_uri):
-            self.add_creator_to_physical_sample (container_uuid, creator["uuid"], account_uuid)
+            if self.add_creator_to_physical_sample (container_uuid, creator["uuid"],
+                                                    account_uuid) is None:
+                self.log.error ("Failed to copy creator %s into draft %s.",
+                                creator["uuid"], draft_uuid)
 
         for date in self.physical_sample_dates (container_uuid, None,
                                                  sample_uri = published_uri):
-            self.add_date_to_physical_sample (container_uuid,
-                                              conv.value_or (date, "date_type", "other"),
-                                              conv.value_or_none (date, "date"),
-                                              account_uuid)
+            if self.add_date_to_physical_sample (container_uuid,
+                                                 conv.value_or (date, "date_type", "other"),
+                                                 conv.value_or_none (date, "date"),
+                                                 account_uuid) is None:
+                self.log.error ("Failed to copy date %s into draft %s.",
+                                conv.value_or_none (date, "uuid"), draft_uuid)
 
         for resource in self.physical_sample_related_resources (container_uuid, None,
                                                                 sample_uri = published_uri):
-            self.add_related_resource_to_physical_sample (
+            resource_uuid = self.add_related_resource_to_physical_sample (
                 container_uuid,
                 conv.value_or_none (resource, "url"),
                 conv.value_or (resource, "type_id", "URL"),
                 conv.value_or (resource, "relation_id", "IsPartOf"),
                 account_uuid)
+            if resource_uuid is None:
+                self.log.error ("Failed to copy related resource %s into draft %s.",
+                                conv.value_or_none (resource, "uuid"), draft_uuid)
 
         ## Copy the categories, which reference shared category URIs.
         categories = self.categories (item_uri = published_uri, limit = None)
         if categories:
             category_uris = rdf.uris_from_records (categories, "category", "uuid")
-            self.update_item_list (draft_uuid, account_uuid, category_uris, "categories")
+            if not self.update_item_list (draft_uuid, account_uuid, category_uris, "categories"):
+                self.log.error ("Failed to copy the categories into draft %s.", draft_uuid)
 
         ## Copy the keywords/tags (stored as a list of string literals).
         tags = self.tags (item_uri = published_uri, limit = None)
         if tags:
             tag_values = [tag["tag"] for tag in tags if conv.value_or_none (tag, "tag")]
-            self.update_item_list (draft_uuid, account_uuid, tag_values, "tags")
+            if not self.update_item_list (draft_uuid, account_uuid, tag_values, "tags"):
+                self.log.error ("Failed to copy the keywords into draft %s.", draft_uuid)
 
         self.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
         self.cache.invalidate_by_prefix ("physical-samples")

--- a/src/djehuty/web/formatter.py
+++ b/src/djehuty/web/formatter.py
@@ -710,6 +710,7 @@ def format_review_record (record):
     """Record formatter for reviews."""
     return {
         "uuid":                  conv.value_or_none (record, "uuid"),
+        "item_type":             conv.value_or (record, "item_type", "dataset"),
         "container_uuid":        conv.value_or_none (record, "container_uuid"),
         "dataset_title":         conv.value_or_none (record, "dataset_title"),
         "dataset_uuid":          conv.value_or_none (record, "dataset_uuid"),

--- a/src/djehuty/web/locks.py
+++ b/src/djehuty/web/locks.py
@@ -15,6 +15,7 @@ class LockTypes(Enum):
     PRIVATE_LINKS = 2
     AUTHORS       = 3
     SUBMIT_DATASET = 4
+    SUBMIT_PHYSICAL_SAMPLE = 5
 
 class Locks:
     """This class implements multiple locks"""
@@ -33,6 +34,7 @@ class Locks:
             LockTypes.PRIVATE_LINKS: Lock(),
             LockTypes.AUTHORS: Lock(),
             LockTypes.SUBMIT_DATASET: Lock(),
+            LockTypes.SUBMIT_PHYSICAL_SAMPLE: Lock(),
         }
 
     def lock (self, lock_type):

--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -78,13 +78,26 @@ jQuery(document).ready(function (){
 #sample-owner-wrapper input[type="text"] { width: 812pt; }
 .preview-button a { background: #736f53 !important; }
 .preview-button a:hover { background: #96937e !important; }
+.decline-button a { background: #aa3333 !important; }
+.decline-button a:hover { background: #cc3333 !important; }
 </style>
 {% endblock %}
 {% block submenu %}
 <ul>
+  {%- if object.is_under_review and is_reviewing %}
+  <li><a href="/logout">&#8592; Go back</a>
+  {%- else %}
   <li><a href="/my/physical-samples">&#8592; Go back</a>
+  {%- endif %}
   <li class="active corporate-identity-submenu-active">Edit physical sample
   <li class="hide-for-javascript save-button"><a id="save" href="#">Save draft</a>
+  {%- if not object.is_under_review %}
+  <li class="hide-for-javascript submit-button"><a id="submit" href="#">Submit for review</a>
+  {%- endif %}
+  {%- if object.is_under_review and is_reviewing %}
+  <li class="hide-for-javascript publish-button"><a id="publish" href="#">Publish</a>
+  <li class="hide-for-javascript decline-button"><a id="decline" href="#">Decline</a>
+  {%- endif %}
   <li class="hide-for-javascript delete-button"><a id="delete" href="#">Delete</a>
   <li class="hide-for-javascript preview-button"><a id="preview" href="#">Preview</a>
 </ul>
@@ -229,6 +242,13 @@ jQuery(document).ready(function (){
 <label for="physical_storage_location">Physical storage location</label><div class="fas fa-question-circle help-icon"><span class="help-text">Add the location details (name university, faculty, department, etc.) where the sample is stored.</span></div><span class="required-field">&#8727;</span>
 <textarea id="physical_storage_location" name="physical_storage_location" placeholder="Example: Delft University of Technology, Faculty of Geoscience & Engineering, Department of Applied Geology - Building 23">{{object["physical_storage_location"] | default("", True) }}</textarea>
 
+{%- if not object.is_under_review %}
+<h3 class="corporate-identity-h3">Terms and agreement</h3>
+<input type="checkbox" name="deposit_agreement" id="deposit_agreement">
+<label class="no-head" for="deposit_agreement">I agree with the <a target="_blank" rel="noopener noreferrer" href="/s/docs/deposit-agreement.pdf">Deposit Agreement</a>.</label><span class="required-field">&#8727;</span><br />
+<input type="checkbox" name="publish_agreement" id="publish_agreement">
+<label class="no-head" for="publish_agreement">I agree that my physical sample will be published once it is approved by a reviewer.</label><span class="required-field">&#8727;</span>
+{%- endif %}
 
 </div>
 </div>

--- a/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
+++ b/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
@@ -11,7 +11,7 @@
 </ul>
 {% endblock %}
 {% block body %}
-<h1>Physical sample</h1>
+<h1>Physical samples</h1>
 
 <h2>Drafts</h2>
 {%- if drafts: %}
@@ -33,10 +33,57 @@
       <td>{{object.created_date | truncate(10,False,'')}}</td>
       <td>{% if not object.is_under_review %}<a href="/my/physical-samples/{{object.container_uuid}}/delete" class="fas fa-trash-can" title="Remove"></a>{% endif %}</td>
     </tr>
-  {% endfor %}</tbody>
+  {% endfor %}
+  </tbody>
 </table>
 {%- else %}
 <p>You don&apos;t have draft physical samples (yet).</p>
 <div class="center"><a id="add-new-object" href="/my/physical-samples/new" class="button corporate-identity-standard-button">Register physical sample</a></div>
+{%- endif %}
+
+{%- if review_samples: %}
+<h2>Under review</h2>
+<table id="table-review" class="corporate-identity-table">
+  <thead>
+    <tr>
+      <th>Physical sample</th>
+      <th>Type</th>
+      <th>Status</th>
+      <th>Submitted&nbsp;at</th>
+    </tr>
+  </thead>
+  <tbody>{% for object in review_samples: %}
+    <tr>
+      <td><a href="/my/physical-samples/{{object.container_uuid}}/edit">{{object.title}}</a></td>
+      <td>{{object.resource_type | default("undefined", False)}}</td>
+      <td>{{object.review_status | default("unassigned", False)}}</td>
+      <td>{{object.review_submit_date | truncate(10,False,'')}}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{%- endif %}
+
+{%- if published_samples: %}
+<h2>Published</h2>
+<table id="table-published" class="corporate-identity-table">
+  <thead>
+    <tr>
+      <th>Physical sample</th>
+      <th>Type</th>
+      <th>Status</th>
+      <th>Published&nbsp;at</th>
+    </tr>
+  </thead>
+  <tbody>{% for object in published_samples: %}
+    <tr>
+      <td><a href="/my/physical-samples/{{object.container_uuid}}/edit">{{object.title}}</a></td>
+      <td>{{object.resource_type | default("undefined", False)}}</td>
+      <td>Published</td>
+      <td>{{object.published_date | default(object.created_date, True) | truncate(10,False,'')}}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
 {%- endif %}
 {% endblock %}

--- a/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
+++ b/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
@@ -20,6 +20,7 @@
     <tr>
       <th>Physical sample</th>
       <th>Type</th>
+      <th>Status</th>
       <th>Created&nbsp;at</th>
       <th>Actions</th>
     </tr>
@@ -28,8 +29,9 @@
     <tr>
       <td><a href="/my/physical-samples/{{object.container_uuid}}/edit">{{object.title}}</a></td>
       <td>{{object.resource_type | default("undefined", False)}}</td>
+      <td>{% if object.is_under_review %}Under review{% else %}Draft{% endif %}</td>
       <td>{{object.created_date | truncate(10,False,'')}}</td>
-      <td><a href="/my/physical-samples/{{object.container_uuid}}/delete" class="fas fa-trash-can" title="Remove"></a></td>
+      <td>{% if not object.is_under_review %}<a href="/my/physical-samples/{{object.container_uuid}}/delete" class="fas fa-trash-can" title="Remove"></a>{% endif %}</td>
     </tr>
   {% endfor %}</tbody>
 </table>

--- a/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
+++ b/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
@@ -73,14 +73,16 @@
       <th>Type</th>
       <th>Status</th>
       <th>Published&nbsp;at</th>
+      <th>Actions</th>
     </tr>
   </thead>
   <tbody>{% for object in published_samples: %}
     <tr>
-      <td><a href="/my/physical-samples/{{object.container_uuid}}/edit">{{object.title}}</a></td>
+      <td><a href="/physical_sample/{{object.container_uuid}}">{{object.title}}</a></td>
       <td>{{object.resource_type | default("undefined", False)}}</td>
-      <td>Published</td>
+      <td>{% if object.has_draft %}Update under review{% else %}Published{% endif %}</td>
       <td>{{object.published_date | default(object.created_date, True) | truncate(10,False,'')}}</td>
+      <td>{% if not object.has_draft %}<a href="/my/physical-samples/{{object.container_uuid}}/edit" class="fas fa-pen" title="Edit (creates a draft update for review)"></a>{% endif %}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/src/djehuty/web/resources/html_templates/depositor/physical-sample-submitted-for-review.html
+++ b/src/djehuty/web/resources/html_templates/depositor/physical-sample-submitted-for-review.html
@@ -1,0 +1,15 @@
+{% extends "layout.html" %}
+{% block submenu %}
+<ul>
+  <li><a href="/my/physical-samples">&#8592; Go back</a>
+  <li class="active corporate-identity-submenu-active">Edit physical sample
+</ul>
+{% endblock %}
+{% block body %}
+<h1>Your physical sample has been submitted for review</h1>
+<p>Thank you for submitting your physical sample to {{site_name}}.  We received your submission.</p>
+<p>A reviewer will contact you about publishing it in the {{site_name}} repository.</p>
+<div class="center">
+  <a href="/my/physical-samples" class="button corporate-identity-standard-button">Go to physical samples overview</a>
+</div>
+{% endblock %}

--- a/src/djehuty/web/resources/html_templates/email/physical_sample_approved.html
+++ b/src/djehuty/web/resources/html_templates/email/physical_sample_approved.html
@@ -1,0 +1,8 @@
+{% extends "email/layout.html" %}
+{% block body %}
+<h1>Physical sample approved and published</h1>
+
+<p>Your physical sample with title <strong>{{title}}</strong> has been approved and published.</p>
+
+<p>This is an automated message. For further correspondence, either use the <a href="{{base_url}}/feedback">feedback form</a> or contact us by e-mail at <a href="mailto:{{support_email}}">{{support_email}}</a></p>
+{% endblock %}

--- a/src/djehuty/web/resources/html_templates/email/physical_sample_approved.txt
+++ b/src/djehuty/web/resources/html_templates/email/physical_sample_approved.txt
@@ -1,0 +1,8 @@
+Physical sample approved and published
+======================================
+
+Your physical sample with title "{{title}}" has been approved and published.
+
+This is an automated message. For further correspondence, either use the feedback form [1] or contact us by e-mail at {{support_email}}
+
+[1] {{base_url}}/feedback

--- a/src/djehuty/web/resources/html_templates/email/physical_sample_declined.html
+++ b/src/djehuty/web/resources/html_templates/email/physical_sample_declined.html
@@ -1,0 +1,8 @@
+{% extends "email/layout.html" %}
+{% block body %}
+<h1>Physical sample declined</h1>
+
+<p>Your physical sample with title <strong>{{title}}</strong> has been declined for publication.</p>
+
+<p>This is an automated message. For further correspondence, either use the <a href="{{base_url}}/feedback">feedback form</a> or contact us by e-mail at <a href="mailto:{{support_email}}">{{support_email}}</a></p>
+{% endblock %}

--- a/src/djehuty/web/resources/html_templates/email/physical_sample_declined.txt
+++ b/src/djehuty/web/resources/html_templates/email/physical_sample_declined.txt
@@ -1,0 +1,8 @@
+Physical sample declined
+========================
+
+Your physical sample with title "{{title}}" has been declined for publication.
+
+This is an automated message. For further correspondence, either use the feedback form [1] or contact us by e-mail at {{support_email}}
+
+[1] {{base_url}}/feedback

--- a/src/djehuty/web/resources/html_templates/email/physical_sample_submitted_notification.html
+++ b/src/djehuty/web/resources/html_templates/email/physical_sample_submitted_notification.html
@@ -1,0 +1,8 @@
+{% extends "email/layout.html" %}
+{% block body %}
+<h1>Request for review</h1>
+<p>{{account.first_name | default("", False)}} {{account.last_name | default("", False)}} sent a physical sample for your review.</p>
+<p>The physical sample is titled <strong>{{dataset.title}}</strong>.</p>
+<p>Its unique identifier is <code>{{dataset.uuid}}</code>.</p>
+<p>Visit <a href="{{base_url}}/review/overview">the reviewer dashboard</a> to review this physical sample.</p>
+{% endblock %}

--- a/src/djehuty/web/resources/html_templates/email/physical_sample_submitted_notification.txt
+++ b/src/djehuty/web/resources/html_templates/email/physical_sample_submitted_notification.txt
@@ -1,0 +1,10 @@
+Request for review
+
+{{account.first_name | default("", False)}} {{account.last_name | default("", False)}} sent a physical sample for your review.
+
+The physical sample is titled '{{dataset.title}}'.
+Its unique identifier is '{{dataset.uuid}}'.
+
+Visit the reviewer dashboard[1] to review this physical sample.
+
+[1] {{base_url}}/review/overview

--- a/src/djehuty/web/resources/html_templates/review/published.html
+++ b/src/djehuty/web/resources/html_templates/review/published.html
@@ -6,9 +6,17 @@
 </ul>
 {% endblock %}
 {% block body %}
+{%- if item_type == "physical-sample" %}
+<h1>The physical sample has been published</h1>
+<p>The physical sample has been published.  Have a nice day!</p>
+<div class="center">
+  <a href="/review/overview" class="button corporate-identity-standard-button">Back to review overview.</a>
+</div>
+{%- else %}
 <h1>The dataset has been published</h1>
 <p>The dataset has been published.  Have a nice day!</p>
 <div class="center">
   <a id="create-new-dataset" href="/datasets/{{container_uuid}}" class="button corporate-identity-standard-button">Go to dataset page.</a>
 </div>
+{%- endif %}
 {% endblock %}

--- a/src/djehuty/web/resources/sparql_templates/decline_draft_physical_sample.sparql
+++ b/src/djehuty/web/resources/sparql_templates/decline_draft_physical_sample.sparql
@@ -1,0 +1,28 @@
+{% extends "prefixes.sparql" %}
+{% block query %}
+DELETE {
+  GRAPH <{{state_graph}}> {
+    ?review        djht:status                   ?review_status .
+    ?draft_sample  djht:is_under_review          ?is_under_review .
+  }
+}
+INSERT {
+  GRAPH <{{state_graph}}> {
+    ?review        djht:status                   djht:ReviewRejected .
+    ?draft_sample  djht:is_under_review          "false"^^xsd:boolean ;
+                   djht:declined_date            ?now .
+  }
+}
+WHERE {
+  GRAPH <{{state_graph}}> {
+    ?container     rdf:type                      djht:PhysicalSampleContainer ;
+                   djht:draft                    ?draft_sample .
+    ?draft_sample  djht:is_under_review          ?is_under_review .
+    ?review        rdf:type                      djht:Review ;
+                   djht:dataset                  ?draft_sample ;
+                   djht:status                   ?review_status .
+    BIND(NOW() AS ?now)
+  }
+  FILTER (?container = <container:{{container_uuid}}>)
+}
+{% endblock %}

--- a/src/djehuty/web/resources/sparql_templates/decline_draft_physical_sample.sparql
+++ b/src/djehuty/web/resources/sparql_templates/decline_draft_physical_sample.sparql
@@ -19,8 +19,10 @@ WHERE {
                    djht:draft                    ?draft_sample .
     ?draft_sample  djht:is_under_review          ?is_under_review .
     ?review        rdf:type                      djht:Review ;
-                   djht:dataset                  ?draft_sample ;
-                   djht:status                   ?review_status .
+                   djht:dataset                  ?draft_sample .
+    {#- A review only gets a status once a reviewer is assigned to it.  Keep it
+     #- optional so that declining a freshly submitted #}
+    OPTIONAL { ?review djht:status                ?review_status . }
     BIND(NOW() AS ?now)
   }
   FILTER (?container = <container:{{container_uuid}}>)

--- a/src/djehuty/web/resources/sparql_templates/physical-samples.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical-samples.sparql
@@ -41,9 +41,17 @@ WHERE {
 
     OPTIONAL {
       ?review           rdf:type                  djht:Review ;
-                        djht:dataset              ?sample .
+                        djht:dataset              ?sample ;
+                        djht:request_date         ?review_submit_date .
       OPTIONAL { ?review  djht:status/rdfs:label  ?review_status . }
-      ?review           djht:request_date         ?review_submit_date .
+      # Only consider the most recent review, so samples that went through
+      # multiple decline/re-submit cycles do not appear once per review.
+      FILTER NOT EXISTS {
+        ?newer_review   rdf:type                  djht:Review ;
+                        djht:dataset              ?sample ;
+                        djht:request_date         ?newer_review_date .
+        FILTER (?newer_review_date > ?review_submit_date)
+      }
     }
     OPTIONAL { ?sample djht:is_under_review       ?is_under_review_tmp . }
     BIND(COALESCE(?is_under_review_tmp, "false"^^xsd:boolean) AS ?is_under_review)

--- a/src/djehuty/web/resources/sparql_templates/physical-samples.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical-samples.sparql
@@ -10,6 +10,8 @@ SELECT DISTINCT ?account_uuid ?container_uuid ?sample_uuid ?created_date
                 ?geolocation ?longitude ?latitude ?organizations
                 ?physical_storage_location ?sample_owner_name ?sample_owner_email
                 ?group_id ?private_link_is_expired
+                ?is_under_review (?review AS ?review_uri) ?review_submit_date
+                ?review_status
 {%endif%}
 WHERE {
   GRAPH <{{state_graph}}> {
@@ -36,6 +38,16 @@ WHERE {
     {%- endif %}
 
     ?sample         djht:title                ?title .
+
+    OPTIONAL {
+      ?review           rdf:type                  djht:Review ;
+                        djht:dataset              ?sample .
+      OPTIONAL { ?review  djht:status/rdfs:label  ?review_status . }
+      ?review           djht:request_date         ?review_submit_date .
+    }
+    OPTIONAL { ?sample djht:is_under_review       ?is_under_review_tmp . }
+    BIND(COALESCE(?is_under_review_tmp, "false"^^xsd:boolean) AS ?is_under_review)
+
     OPTIONAL { ?container djht:doi                ?container_doi . }
     OPTIONAL { ?sample djht:version               ?version . }
     OPTIONAL { ?sample djht:title                 ?title . }
@@ -69,6 +81,13 @@ WHERE {
   }
 {%- if account_uuid is not none: %}
 FILTER (?account = <account:{{account_uuid}}>)
+{%- endif %}
+{%- if is_under_review is not none: %}
+{%- if is_under_review: %}
+FILTER (?is_under_review = "true"^^xsd:boolean)
+{%- else %}
+FILTER (?is_under_review = "false"^^xsd:boolean)
+{%- endif %}
 {%- endif %}
 {% if filters is not none %}{{ filters | safe }}{% endif %}
 }

--- a/src/djehuty/web/resources/sparql_templates/physical-samples.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical-samples.sparql
@@ -83,7 +83,7 @@ WHERE {
     BIND(STRAFTER(STR(?container), "container:")    AS ?container_uuid)
     BIND(STRAFTER(STR(?sample), "physical-sample:") AS ?sample_uuid)
     BIND(STRAFTER(STR(?account), "account:")        AS ?account_uuid)
-    {%- if is_published %}
+    {%- if is_published or is_latest %}
     BIND (xsd:boolean (EXISTS { ?container djht:draft ?draft_dataset . }) AS ?has_draft)
     {%- endif %}
   }

--- a/src/djehuty/web/resources/sparql_templates/physical_sample_creators.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical_sample_creators.sparql
@@ -7,8 +7,13 @@ SELECT DISTINCT ?first_name      ?full_name        ?uuid
 WHERE {
   GRAPH <{{state_graph}}> {
     ?container         rdf:type                 djht:PhysicalSampleContainer .
-    ?item_uri          djht:container           ?container ;
-                       djht:creators/rdf:rest*  ?rest .
+    {%- if sample_uri is not none %}
+    BIND(<{{sample_uri}}> AS ?item_uri)
+    ?item_uri          djht:container           ?container .
+    {%- else %}
+    ?container         djht:draft               ?item_uri .
+    {%- endif %}
+    ?item_uri          djht:creators/rdf:rest*  ?rest .
     ?rest              rdf:first                ?creator ;
                        djht:index               ?order_index .
 

--- a/src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql
@@ -5,8 +5,13 @@ SELECT DISTINCT ?uuid ?date ?date_type ?created_date
 WHERE {
   GRAPH <{{state_graph}}> {
     ?container         rdf:type                 djht:PhysicalSampleContainer .
-    ?item_uri          djht:container           ?container ;
-                       djht:dates/rdf:rest*     ?rest .
+    {%- if sample_uri is not none %}
+    BIND(<{{sample_uri}}> AS ?item_uri)
+    ?item_uri          djht:container           ?container .
+    {%- else %}
+    ?container         djht:draft               ?item_uri .
+    {%- endif %}
+    ?item_uri          djht:dates/rdf:rest*     ?rest .
     ?rest              rdf:first                ?date_entry ;
                        djht:index               ?order_index .
 

--- a/src/djehuty/web/resources/sparql_templates/physical_sample_related_resources.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical_sample_related_resources.sparql
@@ -1,12 +1,17 @@
 {% extends "prefixes.sparql" %}
 {% block query %}
-SELECT DISTINCT ?uuid ?url ?type ?relation ?created_date
+SELECT DISTINCT ?uuid ?url ?type ?type_id ?relation ?relation_id ?created_date
                 (?rest AS ?originating_blank_node) ?order_index
 WHERE {
   GRAPH <{{state_graph}}> {
     ?container         rdf:type                 djht:PhysicalSampleContainer .
-    ?item_uri          djht:container           ?container ;
-                       djht:related_resources/rdf:rest* ?rest .
+    {%- if sample_uri is not none %}
+    BIND(<{{sample_uri}}> AS ?item_uri)
+    ?item_uri          djht:container           ?container .
+    {%- else %}
+    ?container         djht:draft               ?item_uri .
+    {%- endif %}
+    ?item_uri          djht:related_resources/rdf:rest* ?rest .
     ?rest              rdf:first                ?related ;
                        djht:index               ?order_index .
 
@@ -15,6 +20,9 @@ WHERE {
     ?related           djht:relation          ?relation_uri .
     ?relation_uri      rdfs:label             ?relation .
     ?related           djht:url               ?url .
+
+    BIND(STRAFTER(STR(?type_uri),     "PhysicalSampleRelatedResource") AS ?type_id)
+    BIND(STRAFTER(STR(?relation_uri), "PhysicalSampleRelatedResource") AS ?relation_id)
     ?related           djht:created_date      ?created_date .
 
     {%- if account_uuid is not none %}

--- a/src/djehuty/web/resources/sparql_templates/publish_draft_physical_sample.sparql
+++ b/src/djehuty/web/resources/sparql_templates/publish_draft_physical_sample.sparql
@@ -1,0 +1,66 @@
+{% extends "prefixes.sparql" %}
+{% block query %}
+DELETE {
+  GRAPH <{{state_graph}}> {
+    {%- if not first_publication %}
+    ?container     djht:latest_published_version ?latest_published_version .
+    ?append_node   rdf:rest                      ?nil_value .
+    {%- endif %}
+    ?container     djht:draft                    ?draft_sample .
+    ?draft_sample  djht:is_latest                ?is_latest .
+    ?draft_sample  djht:is_public                ?is_public .
+    ?draft_sample  djht:is_editable              ?is_editable .
+    ?draft_sample  djht:version                  ?version .
+    ?draft_sample  djht:is_under_review          ?is_under_review .
+
+    ?review        djht:status                   ?review_status .
+  }
+}
+INSERT {
+  GRAPH <{{state_graph}}> {
+    ?container     djht:latest_published_version <physical-sample:{{sample_uuid}}> .
+
+    ?draft_sample  djht:is_latest                "true"^^xsd:boolean ;
+                   djht:is_public                "true"^^xsd:boolean ;
+                   djht:is_editable              "false"^^xsd:boolean ;
+                   djht:is_under_review          "false"^^xsd:boolean ;
+                   djht:published_date           ?now ;
+                   djht:posted_date              ?now ;
+                   djht:version                  {{version}} .
+    ?review        djht:status                   djht:ReviewApproved .
+
+    {%- if first_publication %}
+    ?container     djht:published_versions       <{{blank_node}}> .
+    {%- else %}
+    ?append_node   rdf:rest                      <{{blank_node}}> .
+    {%- endif %}
+  }
+}
+WHERE {
+  GRAPH <{{state_graph}}> {
+    ?container     rdf:type                      djht:PhysicalSampleContainer ;
+                   djht:draft                    ?draft_sample .
+    ?review        rdf:type                      djht:Review ;
+                   djht:dataset                  ?draft_sample ;
+                   djht:status                   ?review_status .
+
+    {%- if not first_publication %}
+    ?container     djht:published_versions/rdf:rest* ?append_node .
+    {#- Working around a bug in Virtuoso.  Check whether this can be
+     #- simplified to: ?append_node rdf:rest rdf:nil . #}
+    ?append_node   rdf:rest ?nil_value .
+    FILTER (STR(?nil_value) = STR(rdf:nil))
+    {%- endif %}
+
+    OPTIONAL { ?container djht:latest_published_version ?latest_published_version . }
+    OPTIONAL { ?draft_sample djht:is_latest      ?is_latest . }
+    OPTIONAL { ?draft_sample djht:is_public      ?is_public . }
+    OPTIONAL { ?draft_sample djht:is_editable    ?is_editable . }
+    OPTIONAL { ?draft_sample djht:is_under_review ?is_under_review . }
+    OPTIONAL { ?draft_sample djht:version        ?version . }
+
+    BIND("{{timestamp}}"^^xsd:dateTime AS ?now)
+  }
+  FILTER (?container = <container:{{container_uuid}}>)
+}
+{% endblock %}

--- a/src/djehuty/web/resources/sparql_templates/publish_draft_physical_sample.sparql
+++ b/src/djehuty/web/resources/sparql_templates/publish_draft_physical_sample.sparql
@@ -1,12 +1,13 @@
 {% extends "prefixes.sparql" %}
 {% block query %}
+{#- Physical samples are not versioned.  Publishing a draft makes it the single
+ #- published record of its container.  When a published record already exists
+ #- (an update), it is replaced: the container keeps the same identity
+ #- (and therefore the same IGSN), no new version is created. #}
 DELETE {
   GRAPH <{{state_graph}}> {
-    {%- if not first_publication %}
-    ?container     djht:latest_published_version ?latest_published_version .
-    ?append_node   rdf:rest                      ?nil_value .
-    {%- endif %}
     ?container     djht:draft                    ?draft_sample .
+
     ?draft_sample  djht:is_latest                ?is_latest .
     ?draft_sample  djht:is_public                ?is_public .
     ?draft_sample  djht:is_editable              ?is_editable .
@@ -14,11 +15,19 @@ DELETE {
     ?draft_sample  djht:is_under_review          ?is_under_review .
 
     ?review        djht:status                   ?review_status .
+
+    {%- if not first_publication %}
+    ?container     djht:latest_published_version ?old_published .
+    ?container     djht:published_versions       ?old_cell .
+    ?old_published djht:is_latest                ?old_is_latest .
+    ?old_published djht:is_public                ?old_is_public .
+    {%- endif %}
   }
 }
 INSERT {
   GRAPH <{{state_graph}}> {
     ?container     djht:latest_published_version <physical-sample:{{sample_uuid}}> .
+    ?container     djht:published_versions       <{{blank_node}}> .
 
     ?draft_sample  djht:is_latest                "true"^^xsd:boolean ;
                    djht:is_public                "true"^^xsd:boolean ;
@@ -28,12 +37,6 @@ INSERT {
                    djht:posted_date              ?now ;
                    djht:version                  {{version}} .
     ?review        djht:status                   djht:ReviewApproved .
-
-    {%- if first_publication %}
-    ?container     djht:published_versions       <{{blank_node}}> .
-    {%- else %}
-    ?append_node   rdf:rest                      <{{blank_node}}> .
-    {%- endif %}
   }
 }
 WHERE {
@@ -45,19 +48,19 @@ WHERE {
                    djht:status                   ?review_status .
 
     {%- if not first_publication %}
-    ?container     djht:published_versions/rdf:rest* ?append_node .
-    {#- Working around a bug in Virtuoso.  Check whether this can be
-     #- simplified to: ?append_node rdf:rest rdf:nil . #}
-    ?append_node   rdf:rest ?nil_value .
-    FILTER (STR(?nil_value) = STR(rdf:nil))
+    {#- The container holds exactly one published record, so its
+     #- published_versions list has a single cell that we replace. #}
+    ?container     djht:published_versions       ?old_cell .
+    ?old_cell      rdf:first                     ?old_published .
+    OPTIONAL { ?old_published djht:is_latest     ?old_is_latest . }
+    OPTIONAL { ?old_published djht:is_public     ?old_is_public . }
     {%- endif %}
 
-    OPTIONAL { ?container djht:latest_published_version ?latest_published_version . }
-    OPTIONAL { ?draft_sample djht:is_latest      ?is_latest . }
-    OPTIONAL { ?draft_sample djht:is_public      ?is_public . }
-    OPTIONAL { ?draft_sample djht:is_editable    ?is_editable . }
+    OPTIONAL { ?draft_sample djht:is_latest       ?is_latest . }
+    OPTIONAL { ?draft_sample djht:is_public       ?is_public . }
+    OPTIONAL { ?draft_sample djht:is_editable     ?is_editable . }
     OPTIONAL { ?draft_sample djht:is_under_review ?is_under_review . }
-    OPTIONAL { ?draft_sample djht:version        ?version . }
+    OPTIONAL { ?draft_sample djht:version         ?version . }
 
     BIND("{{timestamp}}"^^xsd:dateTime AS ?now)
   }

--- a/src/djehuty/web/resources/sparql_templates/publish_draft_physical_sample.sparql
+++ b/src/djehuty/web/resources/sparql_templates/publish_draft_physical_sample.sparql
@@ -44,8 +44,10 @@ WHERE {
     ?container     rdf:type                      djht:PhysicalSampleContainer ;
                    djht:draft                    ?draft_sample .
     ?review        rdf:type                      djht:Review ;
-                   djht:dataset                  ?draft_sample ;
-                   djht:status                   ?review_status .
+                   djht:dataset                  ?draft_sample .
+    {#- A review only gets a status once a reviewer is assigned to it.  Keep it
+     #- optional so that publishing an unassigned review is not silently. #}
+    OPTIONAL { ?review djht:status                ?review_status . }
 
     {%- if not first_publication %}
     {#- The container holds exactly one published record, so its

--- a/src/djehuty/web/resources/sparql_templates/reviews.sparql
+++ b/src/djehuty/web/resources/sparql_templates/reviews.sparql
@@ -6,7 +6,7 @@ SELECT DISTINCT ?uuid ?request_date ?reminder_date ?assigned_to
                 ?published_date ?container_uuid ?dataset_version ?declined_date
                 ?reviewer_email ?reviewer_first_name ?reviewer_last_name
                 ?modified_date (?status_label AS ?status) ?has_published_version
-                ?last_seen_by_reviewer
+                ?last_seen_by_reviewer ?item_type
 WHERE {
   GRAPH <{{state_graph}}> {
     ?review             rdf:type                 djht:Review ;
@@ -59,7 +59,11 @@ WHERE {
     }
 
     BIND(STRAFTER(STR(?container_uri), "container:") AS ?container_uuid)
-    BIND(STRAFTER(STR(?dataset), "dataset:")  AS ?dataset_uuid)
+    BIND(IF(STRSTARTS(STR(?dataset), "physical-sample:"),
+            "physical-sample", "dataset")            AS ?item_type)
+    BIND(IF(STRSTARTS(STR(?dataset), "physical-sample:"),
+            STRAFTER(STR(?dataset), "physical-sample:"),
+            STRAFTER(STR(?dataset), "dataset:"))     AS ?dataset_uuid)
     BIND(STRAFTER(STR(?account), "account:")  AS ?account_uuid)
     BIND(STRAFTER(STR(?review),  "review:")   AS ?uuid)
     BIND(BOUND(?published_version)            AS ?has_published_version)

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -41,7 +41,7 @@ function gather_form_data (container_uuid) {
     return form_data;
 }
 
-function save_physical_sample (container_uuid, event, notify=true) {
+function save_physical_sample (container_uuid, event, notify=true, on_success=jQuery.noop) {
     event.preventDefault();
     event.stopPropagation();
 
@@ -56,6 +56,7 @@ function save_physical_sample (container_uuid, event, notify=true) {
         if (notify) {
             show_message ("success", "<p>Saved changes.</p>");
         }
+        on_success ();
     }).fail(function (jqXHR) {
         if (notify) {
             let json = jqXHR.responseJSON;
@@ -63,6 +64,101 @@ function save_physical_sample (container_uuid, event, notify=true) {
             if (json) { message = `<p>Failed to save draft: ${json.message}</p>`; }
             show_message ("failure", message);
         }
+    });
+}
+
+function submit_physical_sample (container_uuid, event) {
+    stop_event_propagation (event);
+    jQuery("#content").addClass("loader-top");
+    jQuery("#content-wrapper").css("opacity", "0.15");
+    save_physical_sample (container_uuid, event, false, function () {
+        let form_data = gather_form_data();
+        form_data["agreed_to_deposit_agreement"] = jQuery("#deposit_agreement").prop("checked");
+        form_data["agreed_to_publish"] = jQuery("#publish_agreement").prop("checked");
+        jQuery.ajax({
+            url:         `/v3/physical-samples/${container_uuid}/submit-for-review`,
+            type:        "PUT",
+            contentType: "application/json",
+            accept:      "application/json",
+            data:        JSON.stringify(form_data),
+        }).done(function () {
+            window.location.replace("/my/physical-samples/submitted-for-review");
+        }).fail(function (response) {
+            jQuery(".missing-required").removeClass("missing-required");
+            let error_messages = jQuery.parseJSON (response.responseText);
+            if (error_messages && error_messages.length > 0) {
+                let items = "";
+                for (let message of error_messages) {
+                    if (message.field_name == "group_id") {
+                        jQuery("#groups-wrapper").addClass("missing-required");
+                    } else if (message.field_name == "categories") {
+                        jQuery("#categories-wrapper").addClass("missing-required");
+                    } else if (message.field_name == "authors") {
+                        jQuery("#authors").addClass("missing-required");
+                    } else if (message.field_name == "tag") {
+                        jQuery("#tag").addClass("missing-required");
+                    } else if (message.field_name == "agreed_to_deposit_agreement") {
+                        jQuery("label[for='deposit_agreement']").addClass("missing-required");
+                    } else if (message.field_name == "agreed_to_publish") {
+                        jQuery("label[for='publish_agreement']").addClass("missing-required");
+                    } else {
+                        jQuery(`#${message.field_name}`).addClass("missing-required");
+                    }
+                    if (message.message) {
+                        items += `<li>${message.message}</li>`;
+                    }
+                }
+                show_message ("failure",
+                              `<p>Please correct the following before submitting:</p>` +
+                              `<ul>${items}</ul>`);
+            } else {
+                show_message ("failure", "<p>Please fill in all required fields.</p>");
+            }
+            jQuery("#content-wrapper").css("opacity", "1.0");
+            jQuery("#content").removeClass("loader-top");
+        });
+    });
+}
+
+function publish_physical_sample (container_uuid, event) {
+    stop_event_propagation (event);
+    jQuery("#content").addClass("loader-top");
+    jQuery("#content-wrapper").css("opacity", "0.15");
+    save_physical_sample (container_uuid, event, false, function () {
+        jQuery.ajax({
+            url:         `/v3/physical-samples/${container_uuid}/publish`,
+            type:        "POST",
+            accept:      "application/json",
+        }).done(function () {
+            window.location.replace("/logout");
+        }).fail(function (response, text_status, error_code) {
+            show_message ("failure",
+                          `<p>Could not publish due to error ` +
+                          `<code>${error_code}</code>.</p>`);
+            jQuery("#content-wrapper").css("opacity", "1.0");
+            jQuery("#content").removeClass("loader-top");
+        });
+    });
+}
+
+function decline_physical_sample (container_uuid, event) {
+    stop_event_propagation (event);
+    jQuery("#content").addClass("loader-top");
+    jQuery("#content-wrapper").css("opacity", "0.15");
+    save_physical_sample (container_uuid, event, false, function () {
+        jQuery.ajax({
+            accept:      "application/json",
+            type:        "POST",
+            url:         `/v3/physical-samples/${container_uuid}/decline`
+        }).done(function () {
+            window.location.replace("/logout");
+        }).fail(function (response, text_status, error_code) {
+            show_message ("failure",
+                          `<p>Could not decline due to error ` +
+                          `<code>${error_code}</code>.</p>`);
+            jQuery("#content-wrapper").css("opacity", "1.0");
+            jQuery("#content").removeClass("loader-top");
+        });
     });
 }
 
@@ -527,6 +623,9 @@ function activate (container_uuid, callback=jQuery.noop) {
     new Quill('#methods', { theme: '4tu' });
     jQuery("#delete").on("click", function (event) { delete_physical_sample (container_uuid, event); });
     jQuery("#save").on("click", function (event)   { save_physical_sample (container_uuid, event); });
+    jQuery("#submit").on("click", function (event) { submit_physical_sample (container_uuid, event); });
+    jQuery("#publish").on("click", function (event) { publish_physical_sample (container_uuid, event); });
+    jQuery("#decline").on("click", function (event) { decline_physical_sample (container_uuid, event); });
     jQuery("#preview").on("click", function (event) { preview_physical_sample (container_uuid, event); });
     jQuery("#authors").on("input", function (event) {
         return autocomplete_author (event, container_uuid);

--- a/src/djehuty/web/resources/static/js/review-overview.js
+++ b/src/djehuty/web/resources/static/js/review-overview.js
@@ -28,9 +28,16 @@ function assign_reviewer (event) {
     let identifiers = this.value.split(":");
     let dataset_uuid = identifiers[0];
     let reviewer_uuid = identifiers[1];
+    let item_type = jQuery(this).data("item-type");
+    let container_uuid = jQuery(this).data("container-uuid");
+
+    let assign_url = `/v3/datasets/${dataset_uuid}/assign-reviewer/${reviewer_uuid}`;
+    if (item_type == "physical-sample") {
+        assign_url = `/v3/physical-samples/${container_uuid}/assign-reviewer/${reviewer_uuid}`;
+    }
 
     jQuery.ajax({
-        url:         `/v3/datasets/${dataset_uuid}/assign-reviewer/${reviewer_uuid}`,
+        url:         assign_url,
         type:        "PUT",
         accept:      "application/json"
     }).done(function (response) {
@@ -81,10 +88,10 @@ function filter_status (event) {
     });
 }
 
-function copy_row (uuid, dataset_uuid, title, version, first_name, last_name,
+function copy_row (uuid, goto_url, title, version, first_name, last_name,
                    email, group_name, request_date, modified_date, published_date) {
     let escaped_title = title.replaceAll ('"', '""');
-    let text = `=HYPERLINK("${window.location.origin}/review/goto-dataset/${dataset_uuid}"; "${escaped_title}")\t${version}\t${first_name} ${last_name}\t${email}\t${group_name}\t\t${request_date}\t${modified_date}\t${published_date}\n`;
+    let text = `=HYPERLINK("${window.location.origin}${goto_url}"; "${escaped_title}")\t${version}\t${first_name} ${last_name}\t${email}\t${group_name}\t\t${request_date}\t${modified_date}\t${published_date}\n`;
     navigator.clipboard.writeText(text);
     jQuery(`#copy-btn-${uuid}`)
         .removeClass("fa-copy")
@@ -100,7 +107,10 @@ function copy_to_clipboard_event (event) {
     review = event.data["review"];
     published_date = event.data["published_date"];
     version = event.data["version"];
-    copy_row (review.uuid, review.dataset_uuid, review.dataset_title,
+    let goto_url = (review.item_type == "physical-sample")
+        ? `/review/goto-physical-sample/${review.container_uuid}`
+        : `/review/goto-dataset/${review.dataset_uuid}`;
+    copy_row (review.uuid, goto_url, review.dataset_title,
               version, review.submitter_first_name, review.submitter_last_name,
               review.submitter_email, review.group_name, review.request_date,
                           review.modified_date, published_date);
@@ -125,13 +135,22 @@ function render_overview_table () {
             published_date = null;
             version = "new";
             reviewer_html = "";
+            let is_physical_sample = (review.item_type == "physical-sample");
             if (review.status == "approved") {
                 status = review_approved;
                 published_date = review.published_date;
-                title_html = `<a href="/datasets/${review.container_uuid}/${review.dataset_version}">${review.dataset_title}</a>`;
+                if (is_physical_sample) {
+                    title_html = `${review.dataset_title}`;
+                } else {
+                    title_html = `<a href="/datasets/${review.container_uuid}/${review.dataset_version}">${review.dataset_title}</a>`;
+                }
             }
             else {
-                title_html = `<a href="/review/goto-dataset/${review.dataset_uuid}">${review.dataset_title}</a>`;
+                if (is_physical_sample) {
+                    title_html = `<a href="/review/goto-physical-sample/${review.container_uuid}">${review.dataset_title}</a>`;
+                } else {
+                    title_html = `<a href="/review/goto-dataset/${review.dataset_uuid}">${review.dataset_title}</a>`;
+                }
                 if (review.status == "assigned") { status = review_assigned; }
                 else if (review.status == "rejected") { status = review_rejected; }
                 else { status = review_unassigned; }
@@ -155,7 +174,7 @@ function render_overview_table () {
             if (review.status == "approved" || review.status == "rejected") {
                 reviewer_html = `${review.reviewer_first_name} ${review.reviewer_last_name}`;
             } else {
-                reviewer_html = '<select class="reviewer-selector"><option value="" hidden>Unassigned</option>';
+                reviewer_html = `<select class="reviewer-selector" data-item-type="${or_empty(review.item_type)}" data-container-uuid="${or_empty(review.container_uuid)}"><option value="" hidden>Unassigned</option>`;
                 for (reviewer of reviewers) {
                     reviewer_html += `<option value="${review.dataset_uuid}:${reviewer.uuid}"`;
                     if (review.reviewer_email == reviewer.email) { reviewer_html += "selected"; }

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -194,6 +194,7 @@ class WebServer:
             R("/physical_sample/<physical_sample_id>/<version>",                 self.ui_physical_sample),
             R("/private_datasets/<private_link_id>",                             self.ui_private_dataset),
             R("/private_collections/<private_link_id>",                          self.ui_private_collection),
+            R("/physical_sample/<physical_sample_id>",                           self.ui_physical_sample),
             R("/private_physical_sample/<private_link_id>",                      self.ui_private_physical_sample),
             R("/file/<dataset_id>/<file_id>",                                    self.ui_download_file),
             R("/collections/<collection_id>",                                    self.ui_collection),
@@ -3264,11 +3265,9 @@ class WebServer:
             return self.error_404 (request)
 
         try:
-            physical_sample = self.db.physical_samples (
-                container_uuid = container_uuid,
-                account_uuid   = account_uuid,
-                is_published   = False,
-                is_latest      = False)[0]
+            physical_sample = self.__editable_physical_sample_draft (container_uuid, account_uuid)
+            if physical_sample is None:
+                return self.error_403 (request)
 
             account = self.db.account_by_uuid (physical_sample["account_uuid"])
             groups  = self.__groups_for_account (physical_sample["account_uuid"])
@@ -3282,6 +3281,33 @@ class WebServer:
                 draft_doi  = f"{config.igsn_prefix}/{container_uuid}")
         except IndexError:
             return self.error_403 (request)
+
+    def __editable_physical_sample_draft (self, container_uuid, account_uuid):
+        """Returns the container's draft physical sample, creating one from the
+        published record when only a published version exists (an update)."""
+
+        try:
+            return self.db.physical_samples (
+                container_uuid = container_uuid,
+                account_uuid   = account_uuid,
+                is_published   = False,
+                is_latest      = False)[0]
+        except IndexError:
+            pass
+
+        # No draft yet: this is an update of a published sample.  Copy the
+        # published record into a fresh draft (same container, same IGSN).
+        if self.db.create_draft_from_published_physical_sample (container_uuid, account_uuid) is None:
+            return None
+
+        try:
+            return self.db.physical_samples (
+                container_uuid = container_uuid,
+                account_uuid   = account_uuid,
+                is_published   = False,
+                is_latest      = False)[0]
+        except IndexError:
+            return None
 
     def ui_delete_physical_sample (self, request, container_uuid):
         """Implements /my/physical-samples/<uuid>/delete."""
@@ -3960,6 +3986,9 @@ class WebServer:
                                   author_account_uuid = sample["account_uuid"],
                                   assigned_to = reviewer["uuid"],
                                   status      = "assigned"):
+
+            self.db.cache.invalidate_by_prefix ("physical-samples")
+            self.db.cache.invalidate_by_prefix (f"physical-samples_{sample['account_uuid']}")
             return self.respond_204 ()
 
         return self.error_500 ()
@@ -5134,9 +5163,10 @@ class WebServer:
 
         physical_sample["uri"] = f"physical-sample:{physical_sample['sample_uuid']}"
 
-        creators          = self.db.physical_sample_creators (container_uuid, account_uuid)
-        raw_dates         = self.db.physical_sample_dates (container_uuid, account_uuid)
-        related_resources = self.db.physical_sample_related_resources (container_uuid, account_uuid)
+        sample_uri        = physical_sample["uri"]
+        creators          = self.db.physical_sample_creators (container_uuid, None, sample_uri=sample_uri)
+        raw_dates         = self.db.physical_sample_dates (container_uuid, None, sample_uri=sample_uri)
+        related_resources = self.db.physical_sample_related_resources (container_uuid, None, sample_uri=sample_uri)
         tags              = self.db.tags (item_uri=physical_sample["uri"], limit=None)
 
         posted_date = value_or_none (physical_sample, "published_date")

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -151,13 +151,16 @@ class WebServer:
             R("/my/profile/connect-with-orcid",                                  self.ui_profile_connect_with_orcid),
             R("/my/physical-samples",                                            self.ui_my_physical_samples),
             R("/my/physical-samples/new",                                        self.ui_new_physical_sample),
+            R("/my/physical-samples/submitted-for-review",                       self.ui_physical_sample_submitted),
             R("/my/physical-samples/<container_uuid>/edit",                      self.ui_edit_physical_sample),
             R("/my/physical-samples/<container_uuid>/delete",                    self.ui_delete_physical_sample),
             R("/review/overview",                                                self.ui_review_overview),
             R("/review/goto-dataset/<dataset_id>",                               self.ui_review_impersonate_to_dataset),
+            R("/review/goto-physical-sample/<container_uuid>",                   self.ui_review_impersonate_to_physical_sample),
             R("/review/assign-to-me/<dataset_id>",                               self.ui_review_assign_to_me),
             R("/review/unassign/<dataset_id>",                                   self.ui_review_unassign),
             R("/review/published/<dataset_id>",                                  self.ui_review_published),
+            R("/review/physical-sample/published/<container_uuid>",              self.ui_review_physical_sample_published),
             R("/admin/approve-quota-request/<quota_request_uuid>",               self.ui_admin_approve_quota_request),
             R("/admin/dashboard",                                                self.ui_admin_dashboard),
             R("/admin/deny-quota-request/<quota_request_uuid>",                  self.ui_admin_deny_quota_request),
@@ -369,6 +372,10 @@ class WebServer:
             R("/v3/physical-samples/<container_uuid>/categories",                self.api_v3_physical_sample_categories),
             R("/v3/physical-samples/<container_uuid>/private_links",             self.api_private_physical_sample_private_links),
             R("/v3/physical-samples/<container_uuid>/private_links/<link_id>",   self.api_private_physical_sample_private_links_details),
+            R("/v3/physical-samples/<container_uuid>/submit-for-review",         self.api_v3_physical_sample_submit),
+            R("/v3/physical-samples/<container_uuid>/publish",                   self.api_v3_physical_sample_publish),
+            R("/v3/physical-samples/<container_uuid>/decline",                   self.api_v3_physical_sample_decline),
+            R("/v3/physical-samples/<container_uuid>/assign-reviewer/<reviewer_uuid>", self.api_v3_physical_samples_assign_reviewer),
 
             ## Data model exploratory
             ## ----------------------------------------------------------------
@@ -2274,6 +2281,17 @@ class WebServer:
 
         return self.__render_template (request, "depositor/submitted-for-review.html")
 
+    def ui_physical_sample_submitted (self, request):
+        """Implements /my/physical-samples/submitted-for-review."""
+        if not self.accepts_html (request):
+            return self.error_406 ("text/html")
+
+        _, error_response = self.__depositor_account_uuid (request)
+        if error_response is not None:
+            return error_response
+
+        return self.__render_template (request, "depositor/physical-sample-submitted-for-review.html")
+
     def ui_new_dataset (self, request):
         """Implements /my/datasets/new."""
         if not self.accepts_html (request):
@@ -3666,9 +3684,10 @@ class WebServer:
                 return None
 
             parameters = {
-                "is_published": is_published,
-                "is_latest":    is_latest,
-                "account_uuid": account_uuid,
+                "is_published":    is_published,
+                "is_latest":       is_latest,
+                "is_under_review": is_under_review,
+                "account_uuid":    account_uuid,
             }
             sample = None
             if validator.is_valid_uuid (identifier):
@@ -3680,6 +3699,255 @@ class WebServer:
             return sample
         except IndexError:
             return None
+
+    def api_v3_physical_sample_submit (self, request, container_uuid):
+        """Implements /v3/physical-samples/<id>/submit-for-review."""
+
+        account_uuid = self.default_authenticated_error_handling (request, "PUT",
+                                                                  "application/json",
+                                                                  self.db.is_depositor)
+
+        if isinstance (account_uuid, Response):
+            return account_uuid
+
+        if not validator.is_valid_uuid (container_uuid):
+            return self.error_404 (request)
+
+        sample = self.__physical_sample_by_id_or_uri (container_uuid,
+                                                      account_uuid    = account_uuid,
+                                                      is_published    = False,
+                                                      is_under_review = False)
+        if sample is None:
+            return self.error_404 (request)
+
+        record = request.get_json ()
+        try:
+            errors = []
+            agreed_to_deposit_agreement = validator.boolean_value (record, "agreed_to_deposit_agreement", True, False, errors)
+            agreed_to_publish = validator.boolean_value (record, "agreed_to_publish", True, False, errors)
+
+            if not agreed_to_deposit_agreement:
+                errors.append ({
+                    "field_name": "agreed_to_deposit_agreement",
+                    "message": "The physical sample cannot be published without agreeing to the Deposit Agreement."})
+
+            if not agreed_to_publish:
+                errors.append ({
+                    "field_name": "agreed_to_publish",
+                    "message": "The physical sample cannot be published without giving the reviewer permission to do so."})
+
+            creators = self.db.physical_sample_creators (container_uuid, account_uuid)
+            if not creators:
+                errors.append ({
+                    "field_name": "authors",
+                    "message": "The physical sample must have at least one creator."})
+
+            tags = self.db.tags (item_uri     = sample["uri"],
+                                 account_uuid = account_uuid)
+            if not tags:
+                errors.append ({
+                    "field_name": "tag",
+                    "message": "The physical sample must have at least one keyword."})
+
+            categories, category_errors = self.__category_list_from_request_input (record)
+            if category_errors:
+                errors += category_errors
+            if not categories:
+                errors.append ({
+                    "field_name": "categories",
+                    "message": "Please specify at least one category."})
+
+            parameters = {
+                "sample_uuid":          sample["uuid"],
+                "account_uuid":         account_uuid,
+                "container_uuid":       container_uuid,
+                "title":                validator.string_value  (record, "title",            3, 1000,  True,  errors),
+                "abstract":             validator.string_value  (record, "abstract",         0, 8000,  True,  errors, strip_html=False),
+                "methods":              validator.string_value  (record, "methods",          0, 8000,  False, errors, strip_html=False),
+                "resource_type":        validator.string_value  (record, "resource_type",    0, 512,   False, errors),
+                "subject":              validator.string_value  (record, "subject",          0, 512,   False, errors),
+                "publisher":            validator.string_value  (record, "publisher",        0, 10000, True,  errors),
+                "publication_year":     validator.string_value  (record, "publication_year", 0, 4,     True,  errors),
+                "alternate_identifier": validator.string_value  (record, "alternate_identifier", 0, 255, False, errors),
+                "organizations":        validator.string_value  (record, "organizations",    0, 2048,  True,  errors),
+                "physical_storage_location": validator.string_value (record, "physical_storage_location", 1, 2048, True, errors),
+                "geolocation":          validator.string_value  (record, "geolocation",      0, 255,   False, errors),
+                "longitude":            validator.string_value  (record, "longitude",        0, 64,    False, errors),
+                "latitude":             validator.string_value  (record, "latitude",         0, 64,    False, errors),
+                "sample_owner_name":    validator.string_value  (record, "sample_owner_name",  0, 255, True,  errors),
+                "sample_owner_email":   validator.string_value  (record, "sample_owner_email", 0, 255, True,  errors),
+                "group_id":             validator.integer_value (record, "group_id", 0, pow(2, 63), True, errors),
+                "categories":           categories,
+            }
+
+            if errors:
+                return self.error_400_list (request, errors)
+
+            account = self.db.account_by_uuid (sample["account_uuid"])
+            if not account:
+                return self.error_500 ()
+
+            if not self.db.update_physical_sample (**parameters):
+                return self.error_500 ()
+
+            if self.db.insert_review (sample["uri"]) is not None:
+                subject = f"Request for review: {sample['container_uuid']}"
+                self.__send_email_to_reviewers (subject, "physical_sample_submitted_notification",
+                                                account_email = value_or_none (account, "email"),
+                                                dataset = sample,
+                                                account = account)
+                return self.respond_204 ()
+
+        except validator.ValidationException as error:
+            return self.error_400 (request, error.message, error.code)
+        except (IndexError, KeyError):
+            pass
+
+        return self.error_500 ()
+
+    def api_v3_physical_sample_publish (self, request, container_uuid):
+        """Implements /v3/physical-samples/<id>/publish."""
+
+        account_uuid = self.default_authenticated_error_handling (request, "POST",
+                                                                  "application/json")
+        if isinstance (account_uuid, Response):
+            return account_uuid
+
+        reviewer_token  = self.token_from_cookie (request, self.impersonator_cookie_key)
+        submitter_token = self.token_from_request (request)
+        may_review_all = self.db.may_review (reviewer_token)
+        may_review_institution = self.db.may_review_institution (reviewer_token)
+        if not may_review_all and not may_review_institution:
+            # When using the API, the impersonator cookie isn't set,
+            # so we fall back to using the regular token.
+            may_review_all = self.db.may_review (submitter_token)
+            may_review_institution = self.db.may_review_institution (submitter_token)
+            if not may_review_all and not may_review_institution:
+                return self.error_403 (request)
+
+        sample = self.__physical_sample_by_id_or_uri (container_uuid,
+                                                      account_uuid = account_uuid,
+                                                      is_published = False)
+        if sample is None:
+            return self.error_403 (request)
+
+        reviewer_account = self.db.account_by_session_token (reviewer_token)
+        if may_review_institution:
+            if value_or (sample, "group_id", "A") != value_or (reviewer_account, "group_id", "not-A"):
+                return self.error_403 (request)
+
+        review_uri = value_or_none (sample, "review_uri")
+        if review_uri is not None and reviewer_account is not None:
+            if not self.db.update_review (review_uri,
+                                          author_account_uuid = sample["account_uuid"],
+                                          assigned_to = reviewer_account["uuid"],
+                                          status      = "assigned"):
+                self.log.error ("Unable to assign reviewer before publishing for %s.",
+                                container_uuid)
+
+        if self.db.publish_physical_sample (container_uuid, account_uuid):
+            try:
+                account = self.db.account_by_uuid (sample["account_uuid"])
+                subject = f"Approved: {sample['title']}"
+                parameters = {
+                    "base_url": config.base_url,
+                    "support_email": config.support_email_address,
+                    "title": sample["title"],
+                    "container_uuid": sample["container_uuid"]
+                }
+                self.__send_templated_email ([account["email"]], subject,
+                                             "physical_sample_approved", **parameters)
+            except (TypeError, IndexError, KeyError) as error:
+                self.log.error ("Unable to send approval e-mail for physical sample %s: %s.",
+                                sample["uuid"], error)
+
+            return self.respond_201 ({
+                "location": f"{config.base_url}/review/physical-sample/published/{container_uuid}"
+            })
+
+        return self.error_500 ()
+
+    def api_v3_physical_sample_decline (self, request, container_uuid):
+        """Implements /v3/physical-samples/<id>/decline."""
+
+        account_uuid = self.default_authenticated_error_handling (request, "POST", "application/json")
+        if isinstance (account_uuid, Response):
+            return account_uuid
+
+        reviewer_token = self.token_from_cookie (request, self.impersonator_cookie_key)
+        may_review_all = self.db.may_review (reviewer_token)
+        may_review_institution = self.db.may_review_institution (reviewer_token)
+        if not may_review_all and not may_review_institution:
+            return self.error_403 (request)
+
+        sample = self.__physical_sample_by_id_or_uri (container_uuid,
+                                                      account_uuid = account_uuid,
+                                                      is_published = False)
+        if sample is None:
+            return self.error_403 (request)
+
+        reviewer_account = self.db.account_by_session_token (reviewer_token)
+        if may_review_institution:
+            if value_or (sample, "group_id", "A") != value_or (reviewer_account, "group_id", "not-A"):
+                return self.error_403 (request)
+
+        if self.db.decline_physical_sample (container_uuid, account_uuid):
+            try:
+                account = self.db.account_by_uuid (sample["account_uuid"])
+                subject = f"Declined: {sample['title']}"
+                parameters = {
+                    "base_url": config.base_url,
+                    "support_email": config.support_email_address,
+                    "title": sample["title"]
+                }
+                self.__send_templated_email ([account["email"]], subject,
+                                             "physical_sample_declined", **parameters)
+            except (TypeError, IndexError, KeyError):
+                self.log.error ("Unable to send decline e-mail for physical sample: %s.",
+                                sample["uuid"])
+
+            return self.respond_201 ({
+                "location": f"{config.base_url}/review/overview"
+            })
+
+        return self.error_500 ()
+
+    def api_v3_physical_samples_assign_reviewer (self, request, container_uuid, reviewer_uuid):
+        """Implements /v3/physical-samples/<id>/assign-reviewer/<rid>."""
+
+        account_uuid = self.default_authenticated_error_handling (request, "PUT", "application/json")
+        if isinstance (account_uuid, Response):
+            return account_uuid
+
+        if not validator.is_valid_uuid (reviewer_uuid):
+            return self.error_403 (request)
+
+        account_token = self.token_from_cookie (request, self.cookie_key)
+        may_review_all = self.db.may_review (account_token)
+        may_review_institution = self.db.may_review_institution (account_token)
+        if not may_review_all and not may_review_institution:
+            return self.error_403 (request)
+
+        reviewer = self.db.account_by_uuid (reviewer_uuid)
+        sample   = None
+        try:
+            sample = self.db.physical_samples (container_uuid   = container_uuid,
+                                               is_published    = False,
+                                               is_latest       = False,
+                                               is_under_review = True)[0]
+        except (IndexError, TypeError):
+            pass
+
+        if sample is None or reviewer is None:
+            return self.error_403 (request)
+
+        if self.db.update_review (value_or_none (sample, "review_uri"),
+                                  author_account_uuid = sample["account_uuid"],
+                                  assigned_to = reviewer["uuid"],
+                                  status      = "assigned"):
+            return self.respond_204 ()
+
+        return self.error_500 ()
 
     def ui_review_overview (self, request):
         """Implements /review/overview."""
@@ -3763,6 +4031,65 @@ class WebServer:
 
         return self.__render_template (request, "review/published.html",
                                        container_uuid=dataset["container_uuid"])
+
+    def ui_review_impersonate_to_physical_sample (self, request, container_uuid):
+        """Implements /review/goto-physical-sample/<id>."""
+
+        account_uuid = self.default_authenticated_error_handling (request, "GET", "text/html",
+                                                                  self.db.may_impersonate)
+        if isinstance (account_uuid, Response):
+            return account_uuid
+
+        if not validator.is_valid_uuid (container_uuid):
+            return self.error_404 (request)
+
+        sample = None
+        try:
+            sample = self.db.physical_samples (container_uuid   = container_uuid,
+                                               is_published    = False,
+                                               is_latest       = False,
+                                               is_under_review = True)[0]
+        except (IndexError, TypeError):
+            pass
+
+        if sample is None:
+            return self.error_403 (request, (f"account:{account_uuid} attempted impersonation "
+                                             f"on physical-sample container:{container_uuid}."))
+
+        # Add a secondary cookie to go back to at one point.
+        response = redirect (f"/my/physical-samples/{sample['container_uuid']}/edit", code=302)
+        response.set_cookie (key    = self.impersonator_cookie_key,
+                             value  = self.token_from_request (request),
+                             secure = config.in_production)
+        response.set_cookie (key    = "redirect_to",
+                             value  = "/review/overview",
+                             secure = config.in_production)
+
+        # Create a new session for the user to be impersonated as.
+        new_token, _, _ = self.db.insert_session (sample["account_uuid"],
+                                                  name="Reviewer",
+                                                  override_mfa=True)
+        response.set_cookie (key    = self.cookie_key,
+                             value  = new_token,
+                             secure = config.in_production)
+        return response
+
+    def ui_review_physical_sample_published (self, request, container_uuid):
+        """Implements /review/physical-sample/published/<id>."""
+        account_uuid, error_response = self.__reviewer_account_uuid (request)
+        if error_response is not None:
+            self.log.error ("Account %s attempted a reviewer action.", account_uuid)
+            return error_response
+
+        sample = self.__physical_sample_by_id_or_uri (container_uuid,
+                                                      is_published = True,
+                                                      is_latest    = True)
+        if sample is None:
+            return self.error_403 (request)
+
+        return self.__render_template (request, "review/published.html",
+                                       container_uuid = sample["container_uuid"],
+                                       item_type      = "physical-sample")
 
     def __process_quota_request (self, request, quota_request_uuid, status):
         token = self.token_from_cookie (request)

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3203,12 +3203,27 @@ class WebServer:
         if error_response is not None:
             return error_response
 
-        drafts = self.db.physical_samples (account_uuid   = account_uuid,
-                                           is_published   = False,
-                                           is_latest      = False)
+        drafts = self.db.physical_samples (account_uuid    = account_uuid,
+                                           limit           = 10000,
+                                           is_published    = False,
+                                           is_latest       = False,
+                                           is_under_review = False)
+
+        review_samples = self.db.physical_samples (account_uuid    = account_uuid,
+                                                   limit           = 10000,
+                                                   is_published    = False,
+                                                   is_latest       = False,
+                                                   is_under_review = True)
+
+        published_samples = self.db.physical_samples (account_uuid    = account_uuid,
+                                                      limit           = 10000,
+                                                      is_latest       = True,
+                                                      is_under_review = False)
 
         return self.__render_template (request, "depositor/my-physical-samples.html",
-                                       drafts = drafts)
+                                       drafts = drafts,
+                                       review_samples=review_samples,
+                                       published_samples=published_samples)
 
     def ui_new_physical_sample (self, request):
         """Implements /my/physical-samples/new."""

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -194,7 +194,6 @@ class WebServer:
             R("/physical_sample/<physical_sample_id>/<version>",                 self.ui_physical_sample),
             R("/private_datasets/<private_link_id>",                             self.ui_private_dataset),
             R("/private_collections/<private_link_id>",                          self.ui_private_collection),
-            R("/physical_sample/<physical_sample_id>",                           self.ui_physical_sample),
             R("/private_physical_sample/<private_link_id>",                      self.ui_private_physical_sample),
             R("/file/<dataset_id>/<file_id>",                                    self.ui_download_file),
             R("/collections/<collection_id>",                                    self.ui_collection),
@@ -3317,6 +3316,7 @@ class WebServer:
             return account_uuid
 
         if not validator.is_valid_uuid (container_uuid):
+
             return self.error_404 (request)
 
         try:

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3754,15 +3754,22 @@ class WebServer:
         if not validator.is_valid_uuid (container_uuid):
             return self.error_404 (request)
 
-        sample = self.__physical_sample_by_id_or_uri (container_uuid,
-                                                      account_uuid    = account_uuid,
-                                                      is_published    = False,
-                                                      is_under_review = False)
-        if sample is None:
-            return self.error_404 (request)
-
-        record = request.get_json ()
+        ## Submitting is guarded so that two concurrent submits (a double click
+        ## or a second tab) cannot both pass the is_under_review check and each
+        ## insert a review for the same draft.
+        sample     = None
+        account    = None
+        review_uri = None
+        self.locks.lock (locks.LockTypes.SUBMIT_PHYSICAL_SAMPLE)
         try:
+            sample = self.__physical_sample_by_id_or_uri (container_uuid,
+                                                          account_uuid    = account_uuid,
+                                                          is_published    = False,
+                                                          is_under_review = False)
+            if sample is None:
+                return self.error_404 (request)
+
+            record = request.get_json ()
             errors = []
             agreed_to_deposit_agreement = validator.boolean_value (record, "agreed_to_deposit_agreement", True, False, errors)
             agreed_to_publish = validator.boolean_value (record, "agreed_to_publish", True, False, errors)
@@ -3831,20 +3838,24 @@ class WebServer:
             if not self.db.update_physical_sample (**parameters):
                 return self.error_500 ()
 
-            if self.db.insert_review (sample["uri"]) is not None:
-                subject = f"Request for review: {sample['container_uuid']}"
-                self.__send_email_to_reviewers (subject, "physical_sample_submitted_notification",
-                                                account_email = value_or_none (account, "email"),
-                                                dataset = sample,
-                                                account = account)
-                return self.respond_204 ()
+            review_uri = self.db.insert_review (sample["uri"])
 
         except validator.ValidationException as error:
             return self.error_400 (request, error.message, error.code)
         except (IndexError, KeyError):
-            pass
+            return self.error_500 ()
+        finally:
+            self.locks.unlock (locks.LockTypes.SUBMIT_PHYSICAL_SAMPLE)
 
-        return self.error_500 ()
+        if review_uri is None:
+            return self.error_500 ()
+
+        subject = f"Request for review: {sample['container_uuid']}"
+        self.__send_email_to_reviewers (subject, "physical_sample_submitted_notification",
+                                        account_email = value_or_none (account, "email"),
+                                        dataset = sample,
+                                        account = account)
+        return self.respond_204 ()
 
     def api_v3_physical_sample_publish (self, request, container_uuid):
         """Implements /v3/physical-samples/<id>/publish."""

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3915,9 +3915,11 @@ class WebServer:
                 self.log.error ("Unable to send approval e-mail for physical sample %s: %s.",
                                 sample["uuid"], error)
 
-            return self.respond_201 ({
-                "location": f"{config.base_url}/review/physical-sample/published/{container_uuid}"
-            })
+            location = f"{config.base_url}/physical_sample/{container_uuid}"
+            output = self.response (json.dumps({ "location": location }))
+            output.status_code = 201
+            output.headers["Location"] = location
+            return output
 
         return self.error_500 ()
 
@@ -3964,9 +3966,7 @@ class WebServer:
                 self.log.error ("Unable to send decline e-mail for physical sample: %s.",
                                 sample["uuid"])
 
-            return self.respond_201 ({
-                "location": f"{config.base_url}/review/overview"
-            })
+            return self.respond_204 ()
 
         return self.error_500 ()
 
@@ -3978,7 +3978,7 @@ class WebServer:
             return account_uuid
 
         if not validator.is_valid_uuid (reviewer_uuid):
-            return self.error_403 (request)
+            return self.error_400 (request, "Invalid reviewer UUID.", "InvalidReviewerUuid")
 
         if not validator.is_valid_uuid (container_uuid):
             return self.error_404 (request)

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3854,15 +3854,17 @@ class WebServer:
         if isinstance (account_uuid, Response):
             return account_uuid
 
-        reviewer_token  = self.token_from_cookie (request, self.impersonator_cookie_key)
-        submitter_token = self.token_from_request (request)
+        reviewer_token = self.token_from_cookie (request, self.impersonator_cookie_key)
         may_review_all = self.db.may_review (reviewer_token)
         may_review_institution = self.db.may_review_institution (reviewer_token)
         if not may_review_all and not may_review_institution:
-            # When using the API, the impersonator cookie isn't set,
-            # so we fall back to using the regular token.
-            may_review_all = self.db.may_review (submitter_token)
-            may_review_institution = self.db.may_review_institution (submitter_token)
+            # When using the API, the impersonator cookie isn't set, so we fall
+            # back to the caller's own token.  Keep using it as the reviewer's
+            # token from here on, otherwise the institutional check below has no
+            # reviewer to compare the sample against.
+            reviewer_token = self.token_from_request (request)
+            may_review_all = self.db.may_review (reviewer_token)
+            may_review_institution = self.db.may_review_institution (reviewer_token)
             if not may_review_all and not may_review_institution:
                 return self.error_403 (request)
 
@@ -3919,7 +3921,11 @@ class WebServer:
         may_review_all = self.db.may_review (reviewer_token)
         may_review_institution = self.db.may_review_institution (reviewer_token)
         if not may_review_all and not may_review_institution:
-            return self.error_403 (request)
+            reviewer_token = self.token_from_request (request)
+            may_review_all = self.db.may_review (reviewer_token)
+            may_review_institution = self.db.may_review_institution (reviewer_token)
+            if not may_review_all and not may_review_institution:
+                return self.error_403 (request)
 
         sample = self.__physical_sample_by_id_or_uri (container_uuid,
                                                       account_uuid = account_uuid,
@@ -3963,6 +3969,9 @@ class WebServer:
         if not validator.is_valid_uuid (reviewer_uuid):
             return self.error_403 (request)
 
+        if not validator.is_valid_uuid (container_uuid):
+            return self.error_404 (request)
+
         account_token = self.token_from_cookie (request, self.cookie_key)
         may_review_all = self.db.may_review (account_token)
         may_review_institution = self.db.may_review_institution (account_token)
@@ -3981,6 +3990,12 @@ class WebServer:
 
         if sample is None or reviewer is None:
             return self.error_403 (request)
+
+        ## An institutional reviewer may only act on samples of its own group,
+        if may_review_institution:
+            account = self.db.account_by_session_token (account_token)
+            if value_or (sample, "group_id", "A") != value_or (account, "group_id", "not-A"):
+                return self.error_403 (request)
 
         if self.db.update_review (value_or_none (sample, "review_uri"),
                                   author_account_uuid = sample["account_uuid"],


### PR DESCRIPTION
**Summary**

Add review and publish workflow for physical samples without the 
connection with the Datacite that is going to be in an separate branch

**Changes**
web: Add review and publish workflow for physical samples

* src/djehuty/web/wsgi.py: Add endpoints to submit a physical sample for
  review, list it in the review overview, and approve, decline or publish it.
* src/djehuty/web/database.py: Add methods to submit, decline and publish a
  physical sample under review and to query its review status.
* src/djehuty/web/formatter.py: Add item_type to the review record formatter
  to distinguish physical samples from datasets.
* src/djehuty/web/resources/sparql_templates/reviews.sparql: Return item_type
  and resolve the physical-sample identifier so samples appear in reviews.
* src/djehuty/web/resources/sparql_templates/physical-samples.sparql: Get
  review state and filter by it.
* src/djehuty/web/resources/sparql_templates/publish_draft_physical_sample.sparql:
  Add query to publish a draft physical sample.
* src/djehuty/web/resources/sparql_templates/decline_draft_physical_sample.sparql:
  Add query to decline a physical sample under review.
* src/djehuty/web/resources/sparql_templates/physical_sample_creators.sparql:
  Get creators from the draft when no sample URI is given.
* src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql:
  Get dates from the draft when no sample URI is given.
* src/djehuty/web/resources/sparql_templates/physical_sample_related_resources.sparql:
  Get related resources from the draft and return type and relations.
* src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html:
  Split the dashboard into drafts, review and published sections.
* src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html:
  Add the submit-for-review action to the physical sample editor.
* src/djehuty/web/resources/html_templates/depositor/physical-sample-submitted-for-review.html:
  Add confirmation page shown after submitting a sample for review.
* src/djehuty/web/resources/html_templates/review/published.html: Show a
  confirmation message that the physical sample was published.
* src/djehuty/web/resources/html_templates/email/physical_sample_submitted_notification.html:
  Add reviewer notification e-mail (HTML) for a submitted sample.
* src/djehuty/web/resources/html_templates/email/physical_sample_submitted_notification.txt:
  Add reviewer notification e-mail (text) for a submitted sample.
* src/djehuty/web/resources/html_templates/email/physical_sample_approved.html:
  Add depositor approval e-mail (HTML).
* src/djehuty/web/resources/html_templates/email/physical_sample_approved.txt:
  Add depositor approval e-mail (text).
* src/djehuty/web/resources/html_templates/email/physical_sample_declined.html:
  Add depositor decline e-mail (HTML).
* src/djehuty/web/resources/html_templates/email/physical_sample_declined.txt:
  Add depositor decline e-mail (text).
* src/djehuty/web/resources/static/js/edit-physical-sample.js: Handle
  submit-for-review and metadata updates on published samples.
* src/djehuty/web/resources/static/js/review-overview.js: Add review actions
  for physical samples in the review overview.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [ ] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**
Part of #41 

**Screenshots**

Review queue now received IGSN's.
<img width="700" alt="image" src="https://github.com/user-attachments/assets/3bc62f89-83b7-42fc-a409-cdd55ec4f196" />

User dashboard
<img width="700" alt="image" src="https://github.com/user-attachments/assets/3ccbf616-6838-44c5-b923-2676f0bdee32" />

**Notes**

- Forked from wip-feat-41-igsn-page