### PR TITLE
Feature #41 | Connect physical sample with datacite

### DIFF
--- a/doc/running-djehuty.tex
+++ b/doc/running-djehuty.tex
@@ -20,7 +20,16 @@ configuration file, for which an example is available at
   \t{allow-crawlers}         & Set to 1 to allow crawlers in the \t{robots.txt},
                                otherwise set to 0.\\
   \t{production}             & Performs extra checks before starting. Enable
-                               this when running a production instance.\\
+                               this when running a production instance.  It
+                               also gates the registration of persistent
+                               identifiers: DOIs and IGSNs are only registered at
+                               DataCite when \t{production} is set to 1.  This
+                               element takes an attribute \t{pre-production},
+                               and when set to 1, \t{djehuty} runs the full
+                               publication workflow but skips register the
+                               identifiers and sending depositor e-mails, so a
+                               staging instance can be exercised without
+                               registering real DOIs or IGSNs.\\
   \t{live-reload}            & When set to 1, it reloads Python code on-the-fly.
                                We recommend to set it to 0 when running in
                                production.\\
@@ -422,6 +431,51 @@ djehuty web --config-file=config.xml --apply-transactions
   \t{password}                & The password to authenticate with to DataCite.\\
   \t{prefix}                  & The DOI prefix to use when registering a DOI.
 \end{tabularx}
+
+  The \t{datacite} node is used for datasets and collections.  Physical
+  samples are registered separately, under the \t{igsn} node described in
+  the next section.
+
+\section{Configuring IGSN registration for physical samples}
+
+  In addition to datasets and collections, \t{djehuty} can publish physical
+  samples and assign each one an IGSN (International Generic Sample Number).
+  IGSNs are registered through DataCite, but from a \emph{separate} DataCite
+  repository than the one used for datasets and collections.  DataCite issues
+  this repository its own repository identifier, password and prefix, so the
+  \t{igsn} node is configured independently from the \t{datacite} node and
+  the two prefixes differ: the \t{datacite} prefix is used for dataset and
+  collection DOIs, while the \t{igsn} prefix is used for sample IGSNs.
+
+  Configure it under the \t{igsn} node.  The following parameters can be
+  configured:
+
+\begin{tabularx}{\textwidth}{*{1}{!{\VRule[-1pt]}l}!{\VRule[-1pt]}X}
+  \headrow
+  \textbf{Option}             & \textbf{Description}\\
+  \t{api-url}                 & The URL of the API endpoint of DataCite.\\
+  \t{repository-id}           & The repository identifier given by DataCite
+                                for the IGSN repository.\\
+  \t{password}                & The password to authenticate with to the IGSN
+                                repository.\\
+  \t{prefix}                  & The prefix to use when registering an IGSN.
+                                This must be the prefix assigned to the IGSN
+                                repository, and differs from the \t{datacite}
+                                prefix.
+\end{tabularx}
+
+  Setting the \t{prefix} is what enables the physical-sample feature: when an
+  \t{igsn} prefix is configured, the physical-sample deposit, review and
+  publication workflow becomes available in the user interface.  When the
+  prefix is unset, the feature stays hidden.
+
+  Note that an IGSN is only registered at DataCite when the \t{production}
+  element is set to 1 \emph{and} its \t{pre-production} attribute is not set
+  (or set to 0).  On a non-production or pre-production instance, samples can
+  still be moved through the publication workflow, but no IGSN is registered.
+
+  The physical-sample feature also renders a QR code for each sample, which
+  requires the \t{qrcode} Python package to be installed.
 
 \section{Configuring Handle registration}
 

--- a/etc/djehuty/djehuty-example-config.json
+++ b/etc/djehuty/djehuty-example-config.json
@@ -56,6 +56,12 @@
       "password": "",
       "prefix": "10.5438"
     },
+    "igsn": {
+      "api-url": "https://api.datacite.org",
+      "repository-id": "",
+      "password": "",
+      "prefix": "10.XXXXX"
+    },
     "handle": {
       "url": "https://epic-pid.storage.surfsara.nl:800X/api/handles",
       "index": "XXX",

--- a/etc/djehuty/djehuty-example-config.xml
+++ b/etc/djehuty/djehuty-example-config.xml
@@ -70,6 +70,15 @@
     <password><!-- Password for this repository ID. --></password>
     <prefix>10.5438</prefix>
   </datacite>
+  <!-- Physical samples are registered as IGSNs through a separate DataCite
+       repository, with its own repository-id, password and prefix.  Setting
+       the prefix enables the physical-sample workflow. -->
+  <igsn>
+    <api-url>https://api.datacite.org</api-url>
+    <repository-id><!-- Repository ID received from DataCite for the IGSN repository. --></repository-id>
+    <password><!-- Password for this repository ID. --></password>
+    <prefix>10.XXXXX</prefix>
+  </igsn>
   <handle>
     <url>https://epic-pid.storage.surfsara.nl:800X/api/handles</url>
     <index>XXX</index>

--- a/src/djehuty/web/resources/sparql_templates/update_doi_after_publishing.sparql
+++ b/src/djehuty/web/resources/sparql_templates/update_doi_after_publishing.sparql
@@ -12,7 +12,7 @@ INSERT {
 }
 WHERE {
   GRAPH <{{state_graph}}> {
-    ?item      rdf:type          djht:{{item_type.capitalize()}} .
+    ?item      rdf:type          djht:{{ item_type.replace("-", " ").title().replace(" ", "") }} .
     OPTIONAL { ?item djht:doi ?doi . }
   }
   FILTER (?item = <{{item_type}}:{{item_uuid}}>)

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -7702,15 +7702,6 @@ class WebServer:
         if data is None:
             return False
 
-        ## Persist the IGSN on the draft so it carries over into the published
-        ## record.  Shares update_doi_after_publishing with datasets/collections.
-        if not self.db.update_doi_after_publishing (sample["sample_uuid"],
-                                                    "physical-sample", doi):
-            self.log.error ("Saving IGSN %s on sample %s failed.", doi, container_uuid)
-            return False
-        self.db.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
-        self.db.cache.invalidate_by_prefix ("physical-samples")
-
         parameters = self.__physical_sample_datacite_parameters (sample, doi)
         xml = str (xml_formatter.datacite_physical_sample (parameters, indent=False),
                    encoding="utf-8")
@@ -7738,10 +7729,19 @@ class WebServer:
                                      auth    = (repository_id, password),
                                      timeout = 60,
                                      json    = json_data)
-            if response.status_code == 201:
-                return True
-            if response.status_code == 200:
-                self.log.warning ("IGSN %s already active, updated", doi)
+            if response.status_code in (200, 201):
+                if response.status_code == 200:
+                    self.log.warning ("IGSN %s already active, updated", doi)
+
+                ## Persist the IGSN on the draft only once DataCite accepted it,
+                ## so a failed registration doesn't leave a draft carrying an
+                ## IGSN.
+                if not self.db.update_doi_after_publishing (sample["sample_uuid"],
+                                                            "physical-sample", doi):
+                    self.log.error ("Saving IGSN %s on sample %s failed.", doi, container_uuid)
+                    return False
+                self.db.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+                self.db.cache.invalidate_by_prefix ("physical-samples")
                 return True
 
             self.log.error ("DataCite responded with %s (%s)",

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3906,6 +3906,12 @@ class WebServer:
                 self.log.error ("Unable to assign reviewer before publishing for %s.",
                                 container_uuid)
 
+        ## Register the IGSN at DataCite before flipping the draft to published,
+        if (config.igsn_prefix is not None
+                and config.in_production and not config.in_preproduction):
+            if not self.__register_physical_sample_doi (sample, account_uuid):
+                return self.error_500 ((f"Registering IGSN for {container_uuid} failed."))
+
         if self.db.publish_physical_sample (container_uuid, account_uuid):
             try:
                 account = self.db.account_by_uuid (sample["account_uuid"])
@@ -7436,24 +7442,35 @@ class WebServer:
 
         return self.error_500 ()
 
-    def __datacite_reserve_doi (self, doi=None):
+    def __datacite_credentials (self, use_igsn=False):
+        """Returns the (api_url, repository_id, password, prefix) tuple to use
+        when talking to DataCite.  Physical samples are registered through the
+        IGSN repository; datasets and collections through the regular one."""
+        if use_igsn:
+            return (config.igsn_url, config.igsn_id,
+                    config.igsn_password, config.igsn_prefix)
+        return (config.datacite_url, config.datacite_id,
+                config.datacite_password, config.datacite_prefix)
+
+    def __datacite_reserve_doi (self, doi=None, use_igsn=False):
         """
         Reserve a DOI at DataCite and return its API response on success or
         None on failure.
         """
 
+        api_url, repository_id, password, prefix = self.__datacite_credentials (use_igsn)
         headers = {
             "Accept": "application/vnd.api+json",
             "Content-Type": "application/vnd.api+json"
         }
-        attributes = { "doi": doi } if doi else { "prefix": config.datacite_prefix }
+        attributes = { "doi": doi } if doi else { "prefix": prefix }
         json_data = { "data": { "type": "dois", "attributes": attributes } }
 
         try:
-            response = requests.post(f"{config.datacite_url}/dois",
+            response = requests.post(f"{api_url}/dois",
                                      headers = headers,
-                                     auth    = (config.datacite_id,
-                                                config.datacite_password),
+                                     auth    = (repository_id,
+                                                password),
                                      timeout = 60,
                                      json    = json_data)
             data = None
@@ -7627,6 +7644,110 @@ class WebServer:
                             response.status_code, response.text)
         except requests.exceptions.ConnectionError:
             self.log.error ("Failed to update a DOI due to a connection error.")
+
+        return False
+
+    def __physical_sample_datacite_parameters (self, sample, doi):
+        """Collect the parameters needed to render a physical sample's DataCite
+        (IGSN) metadata."""
+
+        container_uuid = sample["container_uuid"]
+        sample_uri = f"physical-sample:{sample['sample_uuid']}"
+
+        creators   = self.db.physical_sample_creators (container_uuid, None, sample_uri=sample_uri)
+        categories = self.db.categories (item_uri=sample_uri, limit=None)
+        tags       = [tag["tag"] for tag in self.db.tags (item_uri=sample_uri, limit=None)]
+        dates      = self.db.physical_sample_dates (container_uuid, None, sample_uri=sample_uri)
+        related    = self.db.physical_sample_related_resources (container_uuid, None, sample_uri=sample_uri)
+
+        lat = self_or_value_or_none (sample, "latitude")
+        lon = self_or_value_or_none (sample, "longitude")
+        lat_valid, lon_valid = decimal_coords (lat, lon)
+
+        ## A sample is published "now"; the IGSN's Issued date and publication
+        ## year follow from that.
+        published_date = date.today().isoformat()
+
+        return {
+            "item"              : sample,
+            "doi"               : doi,
+            "creators"          : creators,
+            "categories"        : categories,
+            "tags"              : tags,
+            "dates"             : dates,
+            "related_resources" : related,
+            "organizations"     : self.parse_organizations (value_or (sample, "organizations", "")),
+            "published_date"    : published_date,
+            "published_year"    : published_date[:4],
+            "coordinates"       : {"lat_valid": lat_valid, "lon_valid": lon_valid},
+        }
+
+    def __register_physical_sample_doi (self, sample, account_uuid):
+        """Reserves and registers the IGSN for a physical sample at DataCite.
+
+        Physical samples are not versioned, so there is a single IGSN per
+        container.  Returns True on success, False otherwise."""
+
+        container_uuid = sample["container_uuid"]
+        if config.igsn_prefix is None or config.igsn_url is None:
+            self.log.error ("IGSN is not configured; cannot register sample %s.",
+                            container_uuid)
+            return False
+
+        doi = f"{config.igsn_prefix}/{container_uuid}"
+
+        ## Reserve the DOI.  An 'errors' payload means it was already reserved,
+        ## harmless when (re)publishing.
+        data = self.__datacite_reserve_doi (doi, use_igsn=True)
+        if data is None:
+            return False
+
+        ## Persist the IGSN on the draft so it carries over into the published
+        ## record.  Shares update_doi_after_publishing with datasets/collections.
+        if not self.db.update_doi_after_publishing (sample["sample_uuid"],
+                                                    "physical-sample", doi):
+            self.log.error ("Saving IGSN %s on sample %s failed.", doi, container_uuid)
+            return False
+        self.db.cache.invalidate_by_prefix (f"physical-samples_{account_uuid}")
+        self.db.cache.invalidate_by_prefix ("physical-samples")
+
+        parameters = self.__physical_sample_datacite_parameters (sample, doi)
+        xml = str (xml_formatter.datacite_physical_sample (parameters, indent=False),
+                   encoding="utf-8")
+        xml = '<?xml version="1.0" encoding="UTF-8"?>' + xml.split('?>', 1)[1] #Datacite is very choosy about this
+        encoded_bytes = base64.b64encode (xml.encode ("utf-8"))
+
+        api_url, repository_id, password, _ = self.__datacite_credentials (use_igsn=True)
+        headers = {
+            "Accept": "application/vnd.api+json",
+            "Content-Type": "application/vnd.api+json"
+        }
+        json_data = {
+            "data": {
+                "attributes": {
+                    "event": "publish", #does no harm when already published
+                    "url": f"{config.base_url}/physical_sample/{container_uuid}",
+                    "xml": str (encoded_bytes, "utf-8")
+                }
+            }
+        }
+
+        try:
+            response = requests.put (f"{api_url}/dois/{doi}",
+                                     headers = headers,
+                                     auth    = (repository_id, password),
+                                     timeout = 60,
+                                     json    = json_data)
+            if response.status_code == 201:
+                return True
+            if response.status_code == 200:
+                self.log.warning ("IGSN %s already active, updated", doi)
+                return True
+
+            self.log.error ("DataCite responded with %s (%s)",
+                            response.status_code, response.text)
+        except requests.exceptions.ConnectionError:
+            self.log.error ("Failed to register IGSN %s due to a connection error.", doi)
 
         return False
 

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -1020,6 +1020,15 @@ class WebServer:
         self.log.audit (audit_log_message)
         return response
 
+    def error_502 (self, audit_log_message=None):
+        """Procedure to respond with HTTP 502."""
+        response = self.response ("")
+        response.status_code = 502
+        if audit_log_message is None:
+            audit_log_message = "Received an invalid response from an external service (HTTP 502)."
+        self.log.audit (audit_log_message)
+        return response
+
     def error_authorization_failed (self, request):
         """Procedure to handle authorization failures."""
         if self.accepts_html (request, strict=True):
@@ -3910,7 +3919,7 @@ class WebServer:
         if (config.igsn_prefix is not None
                 and config.in_production and not config.in_preproduction):
             if not self.__register_physical_sample_doi (sample, account_uuid):
-                return self.error_500 ((f"Registering IGSN for {container_uuid} failed."))
+                return self.error_502 ((f"Registering IGSN for {container_uuid} failed."))
 
         if self.db.publish_physical_sample (container_uuid, account_uuid):
             try:

--- a/src/djehuty/web/xml_formatter.py
+++ b/src/djehuty/web/xml_formatter.py
@@ -357,3 +357,151 @@ def datacite (parameters, indent=True):
     """Procedure to create a DataCite XML string from PARAMETERS.
        For registration at Datacite, set indent to False"""
     return serialize_tree_to_string (datacite_tree(parameters), indent=indent)
+
+## DataCite dateType values that DataCite's schema accepts for physical samples.
+## "Destroyed" is captured internally but has no DataCite equivalent, so it is
+## mapped to "Other".
+DATACITE_SAMPLE_DATE_TYPES = {
+    "Collected": "Collected",
+    "Issued":    "Issued",
+    "Other":     "Other",
+    "Destroyed": "Other",
+}
+
+def datacite_physical_sample_tree (parameters, debug=False):
+    """Procedure to create a DataCite XML tree for a physical sample (IGSN)."""
+    if parameters is None:
+        return None
+    parameters = scrub (parameters)
+    namespaces = {'': 'http://datacite.org/schema/kernel-4'}
+    schemas    = {'': 'http://schema.datacite.org/meta/kernel-4.4/metadata.xsd'}
+    maker = ElementMaker (namespaces)
+    root = maker.root ('resource', schemas=schemas)
+    item = parameters['item']
+
+    #01 identifier
+    maker.child (root, 'identifier', {'identifierType': 'DOI'}, parameters['doi'])
+
+    #02 creators
+    orcid_att = {'nameIdentifierScheme': 'https://orcid.org/'}
+    personal_att = {'nameType': 'Personal'}
+    if "creators" in parameters:
+        creators_element = maker.child (root, 'creators')
+        for creator in parameters['creators']:
+            creator_att = personal_att if 'orcid_id' in creator else {}
+            creator_element = maker.child (creators_element, 'creator')
+            maker.child_option (creator_element, 'creatorName', creator, 'full_name', creator_att)
+            maker.child_option (creator_element, 'givenName', creator, 'first_name')
+            maker.child_option (creator_element, 'familyName', creator, 'last_name')
+            maker.child_option (creator_element, 'nameIdentifier', creator, 'orcid_id', orcid_att)
+
+    #03 titles
+    maker.child (maker.child (root, 'titles'), 'title', {}, item['title'])
+
+    #04 publisher
+    maker.child (root, 'publisher', {}, value_or (item, 'publisher', '4TU.ResearchData'))
+
+    #05 publicationYear
+    maker.child (root, 'publicationYear', {}, value_or (parameters, 'published_year', None))
+
+    #06 resourceType
+    maker.child (root, 'resourceType', {'resourceTypeGeneral': 'PhysicalObject'},
+                 value_or (item, 'resource_type', 'Physical Object'))
+
+    #07 subjects (categories + keywords)
+    has_categories = 'categories' in parameters
+    has_tags = 'tags' in parameters
+    if has_categories or has_tags:
+        subjects_element = maker.child (root, 'subjects')
+        if has_categories:
+            for cat in parameters['categories']:
+                maker.child (
+                    subjects_element,
+                    'subject',
+                    { 'subjectScheme'     :
+                      'Australian and New Zealand Standard Research Classification (ANZSRC), 2008',
+                      'classificationCode': cat['classification_code'] },
+                    cat['title']
+                )
+        if has_tags:
+            for tag in parameters['tags']:
+                maker.child (subjects_element, 'subject', {}, tag)
+
+    #08 contributors (organizations)
+    if 'organizations' in parameters:
+        contributors_element = maker.child (root, 'contributors')
+        for name in parameters['organizations']:
+            contributor_element = maker.child (contributors_element, 'contributor',
+                                               {'contributorType': 'Other'})
+            maker.child (contributor_element, 'contributorName',
+                         {'nameType': 'Organizational'}, name)
+
+    #09 dates (Issued is captured automatically; others come from the events list)
+    dates_element = maker.child (root, 'dates')
+    if 'published_date' in parameters:
+        maker.child (dates_element, 'date', {'dateType': 'Issued'},
+                     parameters['published_date'])
+    for entry in value_or (parameters, 'dates', []):
+        date_value = value_or_none (entry, 'date')
+        if not date_value:
+            continue
+        date_type = DATACITE_SAMPLE_DATE_TYPES.get (value_or (entry, 'date_type', 'Other'), 'Other')
+        maker.child (dates_element, 'date', {'dateType': date_type}, str (date_value)[:10])
+
+    #10 alternateIdentifiers
+    if 'alternate_identifier' in item:
+        maker.child (maker.child (root, 'alternateIdentifiers'),
+                     'alternateIdentifier',
+                     {'alternateIdentifierType': 'Local accession number'},
+                     item['alternate_identifier'])
+
+    #11 relatedIdentifiers
+    if 'related_resources' in parameters:
+        relations_element = maker.child (root, 'relatedIdentifiers')
+        for resource in parameters['related_resources']:
+            url = value_or_none (resource, 'url')
+            if not url:
+                continue
+            type_id = value_or (resource, 'type_id', 'URL')
+            identifier_type = 'DOI' if type_id in ('IGSNDOI', 'OtherDOI') else 'URL'
+            relation_type = value_or (resource, 'relation_id', 'IsPartOf')
+            maker.child (relations_element, 'relatedIdentifier',
+                         {'relatedIdentifierType': identifier_type,
+                          'relationType': relation_type}, url)
+
+    #12 descriptions (Abstract, Methods, physical storage as TechnicalInfo)
+    descriptions_element = maker.child (root, 'descriptions')
+    if 'abstract' in item:
+        maker.child (descriptions_element, 'description',
+                     {'descriptionType': 'Abstract'}, item['abstract'])
+    if 'methods' in item:
+        maker.child (descriptions_element, 'description',
+                     {'descriptionType': 'Methods'}, item['methods'])
+    if 'physical_storage_location' in item:
+        maker.child (descriptions_element, 'description',
+                     {'descriptionType': 'TechnicalInfo'}, item['physical_storage_location'])
+
+    #13 geoLocations
+    has_geo = 'geolocation' in item
+    coordinates = value_or (parameters, 'coordinates', {})
+    has_point = 'lat_valid' in coordinates and 'lon_valid' in coordinates
+    if has_geo or has_point:
+        geo_element = maker.child (maker.child (root, 'geoLocations'), 'geoLocation')
+        if has_geo:
+            maker.child (geo_element, 'geoLocationPlace', {}, item['geolocation'])
+        if has_point:
+            point_element = maker.child (geo_element, 'geoLocationPoint')
+            maker.child (point_element, 'pointLongitude', {}, coordinates['lon_valid'])
+            maker.child (point_element, 'pointLatitude', {}, coordinates['lat_valid'])
+
+    #debug
+    if debug:
+        param_strings = [f'{key:<15}: {val}' for key, val in parameters.items()]
+        root.insert (0, ElementTree.Comment ('DEBUG\n' + '\n'.join (param_strings)))
+
+    return root
+
+def datacite_physical_sample (parameters, indent=True):
+    """Procedure to create a DataCite XML string for a physical sample.
+       For registration at DataCite, set indent to False."""
+    return serialize_tree_to_string (datacite_physical_sample_tree (parameters), indent=indent)

--- a/src/djehuty/web/xml_formatter.py
+++ b/src/djehuty/web/xml_formatter.py
@@ -4,7 +4,7 @@ and other XML formats.
 """
 
 from xml.etree import ElementTree
-from djehuty.utils.convenience import value_or, value_or_none
+from djehuty.utils.convenience import value_or, value_or_none, normalize_doi
 
 class ElementMaker:
     '''
@@ -463,11 +463,20 @@ def datacite_physical_sample_tree (parameters, debug=False):
             if not url:
                 continue
             type_id = value_or (resource, 'type_id', 'URL')
-            identifier_type = 'DOI' if type_id in ('IGSNDOI', 'OtherDOI') else 'URL'
+            identifier = url
+            identifier_type = 'URL'
+            ## DataCite validates values typed as a DOI against the '10.x/y'
+            ## pattern, so strip the resolver prefix and only claim the DOI
+            ## type when what remains actually is a DOI.
+            if type_id in ('IGSNDOI', 'OtherDOI'):
+                doi = normalize_doi (url)
+                if doi and doi.startswith ('10.'):
+                    identifier = doi
+                    identifier_type = 'DOI'
             relation_type = value_or (resource, 'relation_id', 'IsPartOf')
             maker.child (relations_element, 'relatedIdentifier',
                          {'relatedIdentifierType': identifier_type,
-                          'relationType': relation_type}, url)
+                          'relationType': relation_type}, identifier)
 
     #12 descriptions (Abstract, Methods, physical storage as TechnicalInfo)
     descriptions_element = maker.child (root, 'descriptions')


### PR DESCRIPTION
**Summary**

When publishing a physical sample. Actually connecting with datacite.

**Changes**
web: Register an IGSN at DataCite when publishing a physical sample.

* src/djehuty/web/wsgi.py: Register an IGSN at DataCite when a physical
   sample is published and store the returned DOI on the sample.
* src/djehuty/web/xml_formatter.py: Add a DataCite XML formatter for physical
   samples (IGSN), mapping the data types to DataCite values.
* src/djehuty/web/resources/sparql_templates/update_doi_after_publishing.sparql:
   Update the doi in the "physical-sample"after the publications.
* etc/djehuty/djehuty-example-config.xml: Add an example "igsn" repository
   configuration block.
* doc/running-djehuty.tex: Document the physical sample IGSN/DataCite config.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Part of #41 

**Notes (optional)**

- Forked from wip-feat-41-igsn-review