### PR TITLE
Feature #41 | UI fixes for the physical samples

### DIFF
--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -250,6 +250,8 @@ jQuery(document).ready(function (){
 <label class="no-head" for="publish_agreement">I agree that my physical sample will be published once it is approved by a reviewer.</label><span class="required-field">&#8727;</span>
 {%- endif %}
 
+<p class="no-margin"><a class="hide-for-javascript save-button button" id="save_bottom" href="#">Save draft</a></p>
+
 </div>
 </div>
 

--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -178,7 +178,7 @@ jQuery(document).ready(function (){
 <input type="text" id="publisher" name="publisher" value="{% if object["publisher"] %}{{object["publisher"]}}{% else %}{{site_name}}{% endif %}" />
 
 <label for="publication_year">Publication year</label><div class="fas fa-question-circle help-icon"><span class="help-text">Enter the year that a sample was first made available to the research community.</span></div><span class="required-field">&#8727;</span>
-<input type="text" id="publication_year" name="publication_year" value="{{object["publication_year"]}}" />
+<input type="text" id="publication_year" name="publication_year" value="{{current_year}}" readonly />
 
 <h3 class="corporate-identity-h3">Findability</h3>
 <label for="tag">Keywords</label><div class="fas fa-question-circle help-icon"><span class="help-text">Add keywords that will help make your resource more discoverable. For IGSN IDs, this is the materials that compose the sample. Use a semicolon (;) or hit return after each keyword you enter.</span></div><span class="required-field">&#8727;</span>

--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -161,12 +161,17 @@ jQuery(document).ready(function (){
 {%- if not groups: %}
 <p>No group association found.  Please contact <a href="mailto:{{support_email_address}}">support</a>.</p>
 {%- else %}
-{%- for group in groups if group.id == account.group_id %}
-{%- if loop.first %}
+{%- set selected_group = object.group_id | default(account.group_id, true) %}
+{%- for group in groups: %}
 <h4>{{group.name}}</h4>
-<input class="subitem-checkbox" type="radio" name="groups" value="{{group.id}}" id="group_{{group.id}}" checked="checked"><!--
+<div id="subgroups_{{group.id}}" class="subgroup-wrapper">
+<input class="subitem-checkbox" type="radio" name="groups" value="{{group.id}}" id="group_{{group.id}}" {% if selected_group == group.id: %}checked="checked"{% endif %}><!--
 --><label class="subitem-label no-head" for="group_{{group.id}}">{{group.name}}</label><br>
-{%- endif %}
+{%- for sub in group.subgroups: %}
+<input class="subitem-checkbox" type="radio" name="groups" value="{{sub.id}}" id="group_{{sub.id}}" {% if selected_group == sub.id: %}checked="checked"{% endif %}><!--
+--><label class="subitem-label no-head" for="group_{{sub.id}}">{{sub.name}}</label><br>
+{%- endfor %}
+</div>
 {%- endfor %}
 {%- endif %}
 </div>

--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -201,7 +201,7 @@ jQuery(document).ready(function (){
   <input type="text" id="latitude" name="latitude" placeholder="Example: 52.893" value="{{object["latitude"] | default("", True)}}" />
 </div>
 
-<label>Dates</label><div class="fas fa-question-circle help-icon"><span class="help-text">This property may be used to log events relevant to the physical sample. Enter the date, and select the date type.</span></div>
+<label>Dates</label><div class="fas fa-question-circle help-icon"><span class="help-text">Different dates relevant to the physical sample. Enter the date, and select the date type. For depicting date ranges, use the slash mark (/) between the starting date and ending date, e.g. 2010/2012.</span></div>
 <div class="options-wrapper">
   <table id="physical-sample-dates">
     <thead>

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -238,6 +238,73 @@ function add_author (author_uuid, container_uuid) {
     }).fail(function () { show_message ("failure", `<p>Failed to add ${author_uuid}.</p>`); });
 }
 
+function submit_new_author (container_uuid) {
+    let first_name = jQuery("#author_first_name").val();
+    let last_name = jQuery("#author_last_name").val();
+    jQuery("#author_first_name").removeClass("missing-required");
+    jQuery("#author_last_name").removeClass("missing-required");
+
+    if (first_name == "" && last_name == "") {
+        let error_message = "<p>You must enter at least one of the first or last names.</p>";
+        jQuery("#author_first_name").addClass("missing-required");
+        show_message ("failure", `${error_message}`);
+        return false;
+    }
+
+    let authors = [{
+        "name":       `${first_name} ${last_name}`,
+        "first_name": first_name,
+        "last_name":  last_name,
+        "email":      jQuery("#author_email").val(),
+        "orcid_id":   jQuery("#author_orcid").val()
+    }];
+
+    jQuery.ajax({
+        url:         `/v3/physical-samples/${container_uuid}/creators`,
+        type:        "POST",
+        contentType: "application/json",
+        accept:      "application/json",
+        data:        JSON.stringify({ "authors": authors }),
+    }).done(function () {
+        jQuery("#authors-ac").remove();
+        jQuery("#authors").removeClass("input-for-ac");
+        jQuery("#authors").val("");
+        render_authors (container_uuid);
+    }).fail(function () { show_message ("failure", `<p>Failed to add author.</p>`); });
+    return true;
+}
+
+function submit_new_author_event (event) {
+    stop_event_propagation (event);
+    submit_new_author (event.data["item_id"]);
+}
+
+function new_author (container_uuid) {
+    let banner = `<br><span><i>Enter the details of the author you want to add.</i></span>`;
+    jQuery("#new-author-description").after(banner).remove();
+    let html = jQuery("<div/>", { "id": "new-author-form" });
+    html.append(jQuery ("<label/>", { "for": "author_first_name" }).text("First name"));
+    html.append(jQuery ("<span/>", { "class": "required-field" }).text("*"));
+    html.append(jQuery ("<input/>", { "type": "text", "id": "author_first_name", "name": "author_first_name" }));
+    html.append(jQuery ("<label/>", { "for": "author_last_name" }).text("Last name"));
+    html.append(jQuery ("<span/>", { "class": "required-field" }).text("*"));
+    html.append(jQuery ("<input/>", { "type": "text", "id": "author_last_name", "name": "author_last_name" }));
+    html.append(jQuery ("<label/>", { "for": "author_email" }).text("E-mail address"));
+    html.append(jQuery ("<input/>", { "type": "text", "id": "author_email", "name": "author_email" }));
+    html.append(jQuery ("<label/>", { "for": "author_orcid" }).text("ORCID"));
+    html.append(jQuery ("<input/>", { "type": "text", "id": "author_orcid", "name": "author_orcid" }));
+
+    let button_wrapper = jQuery("<div/>", { "id": "new-author", "class": "a-button" });
+    let anchor = jQuery("<a/>", { "href": "#" }).text("Add author");
+    anchor.on ("click", { "item_id": container_uuid }, submit_new_author_event);
+    button_wrapper.append(anchor);
+
+    html.append(button_wrapper);
+    jQuery("#authors-ac ul").remove();
+    jQuery("#new-author").remove();
+    jQuery("#authors-ac").append(html);
+}
+
 function remove_author_event (event) {
     stop_event_propagation (event);
     remove_author (event.data["author_uuid"], event.data["container_uuid"]);

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -468,10 +468,8 @@ function render_dates (container_uuid) {
         row += '<td><select name="dateType" id="dateType">';
         row += '<option value="" disabled="disabled" selected="selected">Date type</option>';
         row += '<option value="collected">Collected</option>';
-        row += '<option value="created">Created</option>';
         row += '<option value="destroyed">Destroyed</option>';
         row += '<option value="issued">Issued</option>';
-        row += '<option value="updated">Updated</option>';
         row += '<option value="other">Other</option>';
         row += '</select></td>';
         row += '<td><a class="form-button corporate-identity-standard-button add-date-button" href="#">Add</a></td></tr>';

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -468,8 +468,10 @@ function render_dates (container_uuid) {
         row += '<td><select name="dateType" id="dateType">';
         row += '<option value="" disabled="disabled" selected="selected">Date type</option>';
         row += '<option value="collected">Collected</option>';
+        row += '<option value="created">Created</option>';
         row += '<option value="destroyed">Destroyed</option>';
         row += '<option value="issued">Issued</option>';
+        row += '<option value="updated">Updated</option>';
         row += '<option value="other">Other</option>';
         row += '</select></td>';
         row += '<td><a class="form-button corporate-identity-standard-button add-date-button" href="#">Add</a></td></tr>';

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -692,6 +692,7 @@ function activate (container_uuid, callback=jQuery.noop) {
     new Quill('#methods', { theme: '4tu' });
     jQuery("#delete").on("click", function (event) { delete_physical_sample (container_uuid, event); });
     jQuery("#save").on("click", function (event)   { save_physical_sample (container_uuid, event); });
+    jQuery("#save_bottom").on("click", function (event)   { save_physical_sample (container_uuid, event); });
     jQuery("#submit").on("click", function (event) { submit_physical_sample (container_uuid, event); });
     jQuery("#publish").on("click", function (event) { publish_physical_sample (container_uuid, event); });
     jQuery("#decline").on("click", function (event) { decline_physical_sample (container_uuid, event); });

--- a/src/djehuty/web/resources/static/js/review-overview.js
+++ b/src/djehuty/web/resources/static/js/review-overview.js
@@ -140,7 +140,7 @@ function render_overview_table () {
                 status = review_approved;
                 published_date = review.published_date;
                 if (is_physical_sample) {
-                    title_html = `${review.dataset_title}`;
+                    title_html = `<a href="/physical_sample/${review.container_uuid}">${review.dataset_title}</a>`;
                 } else {
                     title_html = `<a href="/datasets/${review.container_uuid}/${review.dataset_version}">${review.dataset_title}</a>`;
                 }

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3423,7 +3423,7 @@ class WebServer:
                     "resource_type":        validator.string_value (record, "resource_type", 0, 512,  False),
                     "subject":              validator.string_value (record, "subject",       0, 512,  False),
                     "organizations":        validator.string_value (record, "organizations", 0, 2048, False),
-                    "physical_storage_location":   validator.string_value (record, "physical_storage_location", 1, 2048, True),
+                    "physical_storage_location":   validator.string_value (record, "physical_storage_location", 0, 2048, False),
                     "geolocation":          validator.string_value (record, "geolocation",   0, 255,  False),
                     "longitude":            validator.string_value (record, "longitude",     0, 64,   False),
                     "latitude":             validator.string_value (record, "latitude",      0, 64,   False),

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3600,7 +3600,7 @@ class WebServer:
                 return self.error_405 (["GET", "POST"])
 
             record = request.get_json()
-            types  = ["collected", "destroyed", "issued", "other"]
+            types  = ["collected", "created", "destroyed", "issued", "updated", "other"]
             errors = []
 
             if not isinstance (record, list):

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3482,12 +3482,8 @@ class WebServer:
                 if errors:
                     return self.error_400_list (request, errors)
 
-                try:
-                    item = self.db.container_items (container_uuid = container_uuid,
-                                                    account_uuid   = account_uuid,
-                                                    is_published   = None,
-                                                    is_latest      = None)[0]
-                except (IndexError, KeyError):
+                item = self.__editable_physical_sample_draft (container_uuid, account_uuid)
+                if item is None:
                     return self.error_404 (request)
 
                 existing_creators = self.db.physical_sample_creators (container_uuid, account_uuid)
@@ -3496,7 +3492,7 @@ class WebServer:
                     existing_creators))
 
                 creators = existing_creators + new_creators
-                if self.db.update_item_list (item["uuid"], account_uuid, creators, "creators"):
+                if self.db.update_item_list (item["sample_uuid"], account_uuid, creators, "creators"):
                     return self.respond_204 ()
 
                 return self.error_500 ()
@@ -3552,17 +3548,16 @@ class WebServer:
         if account_uuid is None:
             return self.error_authorization_failed (request)
 
-        try:
-            item = self.db.container_items (container_uuid = container_uuid,
-                                             account_uuid   = account_uuid,
-                                             is_published   = None,
-                                             is_latest      = None)[0]
+        item = self.__editable_physical_sample_draft (container_uuid, account_uuid)
+        if item is None:
+            return self.error_404 (request)
 
+        try:
             creators = self.db.physical_sample_creators (container_uuid, account_uuid)
             creators.remove (next (filter (lambda c: c["uuid"] == creator_uuid, creators)))
             creators = list (map (lambda c: URIRef (uuid_to_uri (c["uuid"], "author")), creators))
 
-            if self.db.update_item_list (item["uuid"], account_uuid, creators, "creators"):
+            if self.db.update_item_list (item["sample_uuid"], account_uuid, creators, "creators"):
                 return self.respond_204 ()
 
             return self.error_500 ()
@@ -3646,18 +3641,17 @@ class WebServer:
         if account_uuid is None:
             return self.error_authorization_failed (request)
 
-        try:
-            item = self.db.container_items (container_uuid = container_uuid,
-                                             account_uuid   = account_uuid,
-                                             is_published   = None,
-                                             is_latest      = None)[0]
+        item = self.__editable_physical_sample_draft (container_uuid, account_uuid)
+        if item is None:
+            return self.error_404 (request)
 
+        try:
             dates = self.db.physical_sample_dates (container_uuid, account_uuid)
             dates.remove (next (filter (lambda d: d["uuid"] == date_uuid, dates)))
             dates = list (map (lambda d: URIRef (uuid_to_uri (d["uuid"],
                                                  "physical-sample-date")), dates))
 
-            if self.db.update_item_list (item["uuid"], account_uuid, dates, "dates"):
+            if self.db.update_item_list (item["sample_uuid"], account_uuid, dates, "dates"):
                 return self.respond_204 ()
 
             return self.error_500 ()
@@ -3742,18 +3736,17 @@ class WebServer:
         if account_uuid is None:
             return self.error_authorization_failed (request)
 
-        try:
-            item = self.db.container_items (container_uuid = container_uuid,
-                                             account_uuid   = account_uuid,
-                                             is_published   = None,
-                                             is_latest      = None)[0]
+        item = self.__editable_physical_sample_draft (container_uuid, account_uuid)
+        if item is None:
+            return self.error_404 (request)
 
+        try:
             resources = self.db.physical_sample_related_resources (container_uuid, account_uuid)
             resources.remove (next (filter (lambda r: r["uuid"] == resource_uuid, resources)))
             resources = list (map (lambda r: URIRef (uuid_to_uri (r["uuid"],
                                                      "physical-sample-related-resource")), resources))
 
-            if self.db.update_item_list (item["uuid"], account_uuid, resources, "related_resources"):
+            if self.db.update_item_list (item["sample_uuid"], account_uuid, resources, "related_resources"):
                 return self.respond_204 ()
 
             return self.error_500 ()

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3601,7 +3601,7 @@ class WebServer:
                 return self.error_405 (["GET", "POST"])
 
             record = request.get_json()
-            types  = ["collected", "created", "destroyed", "issued", "updated", "other"]
+            types  = ["collected", "destroyed", "issued", "other"]
             errors = []
 
             if not isinstance (record, list):

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3488,7 +3488,7 @@ class WebServer:
                                                     is_published   = None,
                                                     is_latest      = None)[0]
                 except (IndexError, KeyError):
-                    return self.error_500 ()
+                    return self.error_404 (request)
 
                 existing_creators = self.db.physical_sample_creators (container_uuid, account_uuid)
                 existing_creators = list (map (

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -5526,7 +5526,7 @@ class WebServer:
 
         qr_code_svg = None
         sample_doi  = value_or_none (physical_sample, "doi")
-        if sample_doi is None and private_view:
+        if sample_doi is None and config.igsn_prefix is not None:
             sample_doi = f"{config.igsn_prefix}/{container_uuid}"
         if sample_doi:
             qr_buf = BytesIO()

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -5527,7 +5527,7 @@ class WebServer:
 
         qr_code_svg = None
         sample_doi  = value_or_none (physical_sample, "doi")
-        if sample_doi is None and config.igsn_prefix is not None:
+        if sample_doi is None and private_view and config.igsn_prefix is not None:
             sample_doi = f"{config.igsn_prefix}/{container_uuid}"
         if sample_doi:
             qr_buf = BytesIO()

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3471,8 +3471,36 @@ class WebServer:
                 return self.error_405 (["GET", "POST"])
 
             record = request.get_json()
-            validated = []
             errors = []
+
+            # A dictionary payload with an "authors" field creates a brand-new
+            # author record and links it as a creator, mirroring the dataset
+            # author flow.  A list payload links existing authors by UUID.
+            if isinstance (record, dict):
+                new_creators, errors = self.__author_list_from_request_input (record, account_uuid)
+                if errors:
+                    return self.error_400_list (request, errors)
+
+                try:
+                    item = self.db.container_items (container_uuid = container_uuid,
+                                                    account_uuid   = account_uuid,
+                                                    is_published   = None,
+                                                    is_latest      = None)[0]
+                except (IndexError, KeyError):
+                    return self.error_500 ()
+
+                existing_creators = self.db.physical_sample_creators (container_uuid, account_uuid)
+                existing_creators = list (map (
+                    lambda creator: URIRef (uuid_to_uri (creator["uuid"], "author")),
+                    existing_creators))
+
+                creators = existing_creators + new_creators
+                if self.db.update_item_list (item["uuid"], account_uuid, creators, "creators"):
+                    return self.respond_204 ()
+
+                return self.error_500 ()
+
+            validated = []
             if not isinstance (record, list):
                 return self.error_400 (request, message = "Expected a list.",
                                                 code    = "UnexpectedContent")

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3293,7 +3293,8 @@ class WebServer:
                 account    = account,
                 groups     = groups,
                 categories = self.db.categories_tree(),
-                draft_doi  = f"{config.igsn_prefix}/{container_uuid}")
+                draft_doi  = f"{config.igsn_prefix}/{container_uuid}",
+                current_year = datetime.now().strftime("%Y"))
         except IndexError:
             return self.error_403 (request)
 
@@ -3859,7 +3860,7 @@ class WebServer:
                 "resource_type":        validator.string_value  (record, "resource_type",    0, 512,   False, errors),
                 "subject":              validator.string_value  (record, "subject",          0, 512,   False, errors),
                 "publisher":            validator.string_value  (record, "publisher",        0, 10000, True,  errors),
-                "publication_year":     validator.string_value  (record, "publication_year", 0, 4,     True,  errors),
+                "publication_year":     datetime.now().strftime("%Y"),
                 "alternate_identifier": validator.string_value  (record, "alternate_identifier", 0, 255, False, errors),
                 "organizations":        validator.string_value  (record, "organizations",    0, 2048,  True,  errors),
                 "physical_storage_location": validator.string_value (record, "physical_storage_location", 1, 2048, True, errors),

--- a/src/djehuty/web/xml_formatter.py
+++ b/src/djehuty/web/xml_formatter.py
@@ -363,7 +363,9 @@ def datacite (parameters, indent=True):
 ## mapped to "Other".
 DATACITE_SAMPLE_DATE_TYPES = {
     "Collected": "Collected",
+    "Created":   "Created",
     "Issued":    "Issued",
+    "Updated":   "Updated",
     "Other":     "Other",
     "Destroyed": "Other",
 }

--- a/src/djehuty/web/xml_formatter.py
+++ b/src/djehuty/web/xml_formatter.py
@@ -363,9 +363,7 @@ def datacite (parameters, indent=True):
 ## mapped to "Other".
 DATACITE_SAMPLE_DATE_TYPES = {
     "Collected": "Collected",
-    "Created":   "Created",
     "Issued":    "Issued",
-    "Updated":   "Updated",
     "Other":     "Other",
     "Destroyed": "Other",
 }


### PR DESCRIPTION
**Summary**

Implementing UI fixes form the physical sample feature.
- Insert account as a creator in physical sample draft
- Create a new author record from a physical sample.
- Add Created and Updated physical sample date 
- Add link for published physical sample in review overview
- Add qrcode in published physical sample page
- Fix physical sample publication year to current year
- Allow saving physical sample draft without required fields
- Add Save draft button at the end of the physical
- Show selectable group list on the physical sample

**Changes**

web: Refine the physical sample edit form and review overview.

* src/djehuty/web/wsgi.py: Insert the account as a creator on a new physical
   sample draft, allow saving a draft without the required fields, add a QR
   code to the published sample page and pass the current year to the editor.
* src/djehuty/web/resources/static/js/edit-physical-sample.js: Add a form to
   create a new author record, and add the Created and Updated date-type options.
* src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html:
   List all groups and subgroups as options, make the, publication year read-only 
   and default it to the current year, add a Save draft button at the bottom.
* src/djehuty/web/resources/static/js/review-overview.js: Link an approved
   physical sample to its published page in the review overview.
* src/djehuty/backup/database.py: Add the Created and Updated physical sample
   date-type labels.
* src/djehuty/web/xml_formatter.py: Map the Created and Updated date types to
   their DataCite equivalents.


**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [ ] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Part of #41 

**Notes**

- Forked from wip-feat-41-igsn-datacite 