### PR TITLE
Feature #41 | Add action to download QR code image for published samples

### DIFF
--- a/guix.scm.in
+++ b/guix.scm.in
@@ -50,6 +50,7 @@
           python-rdflib
           python-pillow
           python-pygit2
+          python-qrcode
           python-requests
           python-werkzeug))
    (home-page "https://github.com/4TUResearchData/djehuty")

--- a/pyproject.toml.in
+++ b/pyproject.toml.in
@@ -20,6 +20,7 @@ dependencies    = [
     "Werkzeug>=2.0.2",
     "defusedxml>=0.7.1",
     "pillow>=9.4.0",
+    "qrcode>=8.2",
 ]
 classifiers     = [
     "Programming Language :: Python :: 3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ requests>=2.26.0
 Werkzeug>=2.0.2
 defusedxml>=0.7.1
 pillow>=9.4.0
+qrcode>=8.2

--- a/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
+++ b/src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html
@@ -82,7 +82,7 @@
       <td>{{object.resource_type | default("undefined", False)}}</td>
       <td>{% if object.has_draft %}Update under review{% else %}Published{% endif %}</td>
       <td>{{object.published_date | default(object.created_date, True) | truncate(10,False,'')}}</td>
-      <td>{% if not object.has_draft %}<a href="/my/physical-samples/{{object.container_uuid}}/edit" class="fas fa-pen" title="Edit (creates a draft update for review)"></a>{% endif %}</td>
+      <td><a href="/physical_sample/{{object.container_uuid}}/qr-code" class="fas fa-qrcode" title="Download QR code (links to the IGSN)" download></a>{% if not object.has_draft %} <a href="/my/physical-samples/{{object.container_uuid}}/edit" class="fas fa-pen" title="Edit (creates a draft update for review)"></a>{% endif %}</td>
     </tr>
   {% endfor %}
   </tbody>

--- a/src/djehuty/web/resources/static/css/main.css
+++ b/src/djehuty/web/resources/static/css/main.css
@@ -469,6 +469,7 @@ a.far, a.fab, a.fas { text-decoration: none; }
 .fa-angle-up::before { content: "\f106"; }
 .fa-angle-down::before { content: "\f107"; }
 .fa-circle-exclamation::before { content: "\f06a"; }
+.fa-qrcode::before { content: "\f029"; }
 .fa-empty::before {}
 
 .img-fa img {

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -200,6 +200,7 @@ class WebServer:
             R("/physical_sample/<physical_sample_id>/<version>",                 self.ui_physical_sample),
             R("/private_datasets/<private_link_id>",                             self.ui_private_dataset),
             R("/private_collections/<private_link_id>",                          self.ui_private_collection),
+            R("/physical_sample/<physical_sample_id>/qr-code",                   self.ui_physical_sample_qr_code),
             R("/private_physical_sample/<private_link_id>",                      self.ui_private_physical_sample),
             R("/file/<dataset_id>/<file_id>",                                    self.ui_download_file),
             R("/collections/<collection_id>",                                    self.ui_collection),
@@ -5558,6 +5559,35 @@ class WebServer:
                                        member           = member,
                                        member_url_name  = member_url_name,
                                        page_title       = physical_sample["title"])
+
+    def ui_physical_sample_qr_code (self, request, physical_sample_id):
+        """Implements /physical_sample/<id>/qr-code (downloadable QR image)."""
+
+        handler = self.default_error_handling (request, "GET", "image/png")
+        if handler is not None:
+            return handler
+
+        try:
+            physical_sample = self.db.physical_samples (
+                container_uuid = physical_sample_id,
+                is_published   = True,
+                is_latest      = True)[0]
+        except IndexError:
+            return self.error_404 (request)
+
+        sample_doi = value_or_none (physical_sample, "doi")
+        if sample_doi is None and config.igsn_prefix is not None:
+            sample_doi = f"{config.igsn_prefix}/{physical_sample_id}"
+        if sample_doi is None:
+            return self.error_404 (request)
+
+        qr_buf = BytesIO()
+        qrcode.make (f"https://doi.org/{sample_doi}").save (qr_buf, format="PNG")
+
+        filename = f"{sample_doi.replace('/', '_')}.png"
+        response = self.response (qr_buf.getvalue(), mimetype="image/png")
+        response.headers["Content-disposition"] = f"attachment; filename={filename}"
+        return response
 
     def ui_author (self, request, author_uuid):
         """Implements /authors/<id>."""

--- a/uv.lock
+++ b/uv.lock
@@ -405,6 +405,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pygit2", version = "1.18.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pygit2", version = "1.19.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "qrcode" },
     { name = "rdflib" },
     { name = "requests" },
     { name = "werkzeug" },
@@ -435,6 +436,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=9.4.0" },
     { name = "pygit2", specifier = ">=1.6.1" },
+    { name = "qrcode", specifier = ">=8.2" },
     { name = "rdflib", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.26.0" },
     { name = "werkzeug", specifier = ">=2.0.2" },
@@ -1297,6 +1299,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Summary**

Add option for the user to download QR code image for published samples

**Changes**
web: Add action to download QR code for published samples

* src/djehuty/web/wsgi.py: Add a route and handler that generate a PNG qrcode
  linking to the physical sample IGSN..
* src/djehuty/web/resources/html_templates/depositor/my-physical-samples.html:
  Add a download action to the published table.
* src/djehuty/web/resources/static/css/main.css: Add the fa-qrcode code.


**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**
Part of #41 

**Screenshots **

Published list with action button 
<img width="700" alt="image" src="https://github.com/user-attachments/assets/e3027559-5df7-4877-a05f-956461dc9ad8" />

**Note**
Forked from wip-feat-41-igsn-ui-fix