### PR TITLE
Feature #41| Issued date as published date on physical sample xml datacite format

### DIFF
--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -469,7 +469,6 @@ function render_dates (container_uuid) {
         row += '<option value="" disabled="disabled" selected="selected">Date type</option>';
         row += '<option value="collected">Collected</option>';
         row += '<option value="destroyed">Destroyed</option>';
-        row += '<option value="issued">Issued</option>';
         row += '<option value="other">Other</option>';
         row += '</select></td>';
         row += '<td><a class="form-button corporate-identity-standard-button add-date-button" href="#">Add</a></td></tr>';

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3597,7 +3597,9 @@ class WebServer:
                 return self.error_405 (["GET", "POST"])
 
             record = request.get_json()
-            types  = ["collected", "destroyed", "issued", "other"]
+            ## "issued" is intentionally omitted: the Issued date is set
+            ## automatically to the publication date and cannot be entered by hand.
+            types  = ["collected", "destroyed", "other"]
             errors = []
 
             if not isinstance (record, list):
@@ -3936,6 +3938,19 @@ class WebServer:
                                           assigned_to = reviewer_account["uuid"],
                                           status      = "assigned"):
                 self.log.error ("Unable to assign reviewer before publishing for %s.",
+                                container_uuid)
+
+        ## Persist the Issued date (= the publication date) on the first
+        ## publication.  It is captured automatically rather than entered by the
+        ## depositor, and it is kept as-is on later updates so the original issue
+        ## date is preserved.
+        existing_dates = self.db.physical_sample_dates (container_uuid, account_uuid)
+        if not any (value_or (entry, "date_type", "") == "Issued"
+                    for entry in existing_dates):
+            if self.db.add_date_to_physical_sample (container_uuid, "issued",
+                                                    date.today().isoformat(),
+                                                    account_uuid) is None:
+                self.log.error ("Failed to record Issued date for physical sample %s.",
                                 container_uuid)
 
         ## Register the IGSN at DataCite before flipping the draft to published,

--- a/src/djehuty/web/xml_formatter.py
+++ b/src/djehuty/web/xml_formatter.py
@@ -446,6 +446,10 @@ def datacite_physical_sample_tree (parameters, debug=False):
         if not date_value:
             continue
         date_type = DATACITE_SAMPLE_DATE_TYPES.get (value_or (entry, 'date_type', 'Other'), 'Other')
+        ## The Issued date is emitted above from the publication date; skip the
+        ## persisted copy so it is not written twice.
+        if date_type == 'Issued':
+            continue
         maker.child (dates_element, 'date', {'dateType': date_type}, str (date_value)[:10])
 
     #10 alternateIdentifiers


### PR DESCRIPTION
**Summary**
To send to Datacite format, the Issued date should be only the 
published date and the user should not be able to add/edit it.

**Changes**

web: Issued date as published date on physical sample.

* src/djehuty/web/resources/static/js/edit-physical-sample.js: Remove the
  Issued option from the date type options so it cannot be entered by the user.
* src/djehuty/web/wsgi.py: Drop issued from the accepted date types and
  record the issued date as the publication date in the
  database on the first publication of a physical sample.
* src/djehuty/web/xml_formatter.py: Skip the persisted issued date when
  building the DataCite tree so it is not written twice.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**
Part of #41 

**Screenshots**

Before: Datacite xml wrong (more than one issued)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/e5c2b455-2dc1-420c-b190-51ba350bfc29" />

After: Datacite xml with only one issued data
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d2388c3d-386f-45a2-9d59-7d3be9bbe8e8" />

**Notes**

- Forked from wip-feat-41-igsn-qrcode-download