### PR TITLE
feat: admin users account merge

### DIFF
--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3318,7 +3318,7 @@ class SparqlInterface:
         """Returns containers owned by ACCOUNT_UUID for the merge preview."""
 
         query = self.__query_from_template ("account_containers_for_merge", {
-            "account_uuid": account_uuid
+            "account_uri": rdf.uuid_to_uri (account_uuid, "account")
         })
         return self.__run_query (query)
 
@@ -3326,8 +3326,8 @@ class SparqlInterface:
         """Reassign all containers from FROM_ACCOUNT_UUID to TO_ACCOUNT_UUID."""
 
         query = self.__query_from_template ("merge_account_ownership", {
-            "from_account_uuid": from_account_uuid,
-            "to_account_uuid":   to_account_uuid
+            "from_account_uri": rdf.uuid_to_uri (from_account_uuid, "account"),
+            "to_account_uri":   rdf.uuid_to_uri (to_account_uuid,   "account")
         })
         return self.__run_logged_query (query)
 

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3314,6 +3314,23 @@ class SparqlInterface:
 
         return None
 
+    def containers_for_account_merge (self, account_uuid):
+        """Returns containers owned by ACCOUNT_UUID for the merge preview."""
+
+        query = self.__query_from_template ("account_containers_for_merge", {
+            "account_uuid": account_uuid
+        })
+        return self.__run_query (query)
+
+    def merge_account_ownership (self, from_account_uuid, to_account_uuid):
+        """Reassign all containers from FROM_ACCOUNT_UUID to TO_ACCOUNT_UUID."""
+
+        query = self.__query_from_template ("merge_account_ownership", {
+            "from_account_uuid": from_account_uuid,
+            "to_account_uuid":   to_account_uuid
+        })
+        return self.__run_logged_query (query)
+
     def missing_checksummed_files_for_container (self, container_uuid):
         """
         Returns a list of file UUIDs and paths of files without checksums

--- a/src/djehuty/web/resources/html_templates/admin/merge_accounts.html
+++ b/src/djehuty/web/resources/html_templates/admin/merge_accounts.html
@@ -1,0 +1,69 @@
+{% extends "layout.html" %}
+{% block headers %}
+<script src="/static/js/jquery-3.6.0.min.js"></script>
+<script src="/static/js/utils.js?cache=1744290797"></script>
+<script src="/static/js/admin-merge-accounts.js"></script>
+<style nonce="{{nonce}}">
+#merge-form { max-width: 720px; }
+#merge-form .field { margin-bottom: 1em; }
+#merge-form label { display: block; font-weight: bold; margin-bottom: .25em; }
+#merge-form input[type="email"] { width: 100%; padding: .5em; box-sizing: border-box; }
+#merge-preview { margin-top: 2em; display: none; }
+#merge-preview .account-summary { background: #f4f4f4; padding: .75em 1em; border-radius: .25em; margin-bottom: 1em; }
+#merge-preview .account-summary .arrow { font-weight: bold; margin: 0 .5em; }
+#merge-containers-table td.type-tag { white-space: nowrap; }
+#merge-containers-table .flag { display: inline-block; padding: .1em .4em; border-radius: .25em; font-size: .8em; margin-right: .25em; }
+#merge-containers-table .flag.published { background: #e0f0e0; }
+#merge-containers-table .flag.draft { background: #f0e6c0; }
+#merge-confirm-wrapper { margin-top: 1em; }
+#merge-confirm-button.disabled { opacity: .5; pointer-events: none; }
+</style>
+{% endblock %}
+{% block submenu %}
+<ul>
+  <li><a href="/admin/dashboard">Dashboard</a>
+  <li class="active corporate-identity-submenu-active"><a href="/admin/users">Users</a>
+  <li><a href="/admin/exploratory">Exploratory</a>
+  <li><a href="/admin/reports">Reports</a>
+  {% if may_query %}<li><a href="/admin/sparql">Query</a>{% endif %}
+  {% if may_review_quotas %}<li><a href="/admin/quota-requests">Quota requests</a>{% endif %}
+</ul>
+{% endblock %}
+{% block body %}
+<h1>Merge accounts</h1>
+<p>Reassign ownership of all containers (datasets and collections) from a
+source account to a target account. The source account is not deleted.
+The change is performed as a single SPARQL UPDATE and recorded in the
+query audit log.</p>
+
+<div id="merge-form">
+  <div class="field">
+    <label for="from-email">From account (source e-mail)</label>
+    <input type="email" id="from-email" placeholder="from@example.org" autocomplete="off">
+  </div>
+  <div class="field">
+    <label for="to-email">To account (target e-mail)</label>
+    <input type="email" id="to-email" placeholder="to@example.org" autocomplete="off">
+  </div>
+  <div class="center">
+    <a id="merge-preview-button" href="#" class="button corporate-identity-standard-button">Load preview</a>
+  </div>
+</div>
+
+<div id="merge-preview">
+  <h2>Preview</h2>
+  <div class="account-summary">
+    <span id="preview-from"></span>
+    <span class="arrow">&rarr;</span>
+    <span id="preview-to"></span>
+  </div>
+  <p><span id="preview-count">0</span> container(s) will be moved.</p>
+  <table id="merge-containers-table" class="corporate-identity-table">
+    <thead><tr><th>Type</th><th>Title</th><th>DOI</th><th>State</th><th>Container UUID</th></tr></thead>
+    <tbody id="merge-containers-tbody"></tbody>
+  </table>
+  <div id="merge-confirm-wrapper" class="center">
+    <a id="merge-confirm-button" href="#" class="button corporate-identity-standard-button disabled">Confirm merge</a>
+  </div>
+</div>
+{% endblock %}

--- a/src/djehuty/web/resources/html_templates/admin/merge_accounts.html
+++ b/src/djehuty/web/resources/html_templates/admin/merge_accounts.html
@@ -17,6 +17,7 @@
 #merge-containers-table .flag.draft { background: #f0e6c0; }
 #merge-confirm-wrapper { margin-top: 1em; }
 #merge-confirm-button.disabled { opacity: .5; pointer-events: none; }
+.destructive-warning { color: #cc0000; font-weight: bold; margin-top: 1em; }
 </style>
 {% endblock %}
 {% block submenu %}
@@ -57,11 +58,16 @@ query audit log.</p>
     <span class="arrow">&rarr;</span>
     <span id="preview-to"></span>
   </div>
-  <p><span id="preview-count">0</span> container(s) will be moved.</p>
+  <p>The <span id="preview-count">0</span> container(s) below will be moved
+  from <strong id="preview-from-email"></strong> to
+  <strong id="preview-to-email"></strong>.</p>
   <table id="merge-containers-table" class="corporate-identity-table">
     <thead><tr><th>Type</th><th>Title</th><th>DOI</th><th>State</th><th>Container UUID</th></tr></thead>
     <tbody id="merge-containers-tbody"></tbody>
   </table>
+  <p class="destructive-warning">Warning: this is a destructive action that
+  cannot be undone from the UI. Ownership of the containers listed above will
+  be permanently reassigned.</p>
   <div id="merge-confirm-wrapper" class="center">
     <a id="merge-confirm-button" href="#" class="button corporate-identity-standard-button disabled">Confirm merge</a>
   </div>

--- a/src/djehuty/web/resources/html_templates/admin/users.html
+++ b/src/djehuty/web/resources/html_templates/admin/users.html
@@ -56,6 +56,7 @@ jQuery(document).ready(function () {
 </noscript>
 <div class="hide-for-javascript">
 <h1>Manage users<span class="no-select"> &nbsp;<a id="remove-cache" href="#" class="fas fa-sync"></a></span></h1>
+<p><a href="/admin/users/merge" class="button corporate-identity-standard-button">Merge accounts</a></p>
 <table id="users-table" class="corporate-identity-table">
   <thead><tr><th>Name</th><th>E-mail</th><th>Group</th><th>Actions</th></tr></thead>
   <tbody>

--- a/src/djehuty/web/resources/sparql_templates/account_containers_for_merge.sparql
+++ b/src/djehuty/web/resources/sparql_templates/account_containers_for_merge.sparql
@@ -1,0 +1,32 @@
+{% extends "prefixes.sparql" %}
+{% block query %}
+SELECT DISTINCT ?container_uuid ?container_type ?title ?doi
+                ?has_draft ?has_published
+WHERE {
+  GRAPH <{{state_graph}}> {
+    ?container       djht:account                  <account:{{account_uuid}}> .
+    ?container       rdf:type                      ?type .
+    FILTER (?type IN (djht:DatasetContainer, djht:CollectionContainer))
+
+    OPTIONAL { ?container djht:doi                      ?doi . }
+    OPTIONAL { ?container djht:draft                    ?draft_item . }
+    OPTIONAL { ?container djht:latest_published_version ?published_item . }
+
+    OPTIONAL {
+      ?container       djht:latest_published_version ?lpv .
+      ?lpv             djht:title                    ?published_title .
+    }
+    OPTIONAL {
+      ?container       djht:draft                    ?d .
+      ?d               djht:title                    ?draft_title .
+    }
+
+    BIND(STRAFTER(STR(?container), "container:") AS ?container_uuid)
+    BIND(STRAFTER(STR(?type), "https://ontologies.data.4tu.nl/djehuty/0.0.1/") AS ?container_type)
+    BIND(COALESCE(?published_title, ?draft_title, "") AS ?title)
+    BIND(BOUND(?draft_item) AS ?has_draft)
+    BIND(BOUND(?published_item) AS ?has_published)
+  }
+}
+ORDER BY ?container_type ?title
+{% endblock %}

--- a/src/djehuty/web/resources/sparql_templates/account_containers_for_merge.sparql
+++ b/src/djehuty/web/resources/sparql_templates/account_containers_for_merge.sparql
@@ -4,7 +4,7 @@ SELECT DISTINCT ?container_uuid ?container_type ?title ?doi
                 ?has_draft ?has_published
 WHERE {
   GRAPH <{{state_graph}}> {
-    ?container       djht:account                  <account:{{account_uuid}}> .
+    ?container       djht:account                  <{{account_uri}}> .
     ?container       rdf:type                      ?type .
     FILTER (?type IN (djht:DatasetContainer, djht:CollectionContainer))
 

--- a/src/djehuty/web/resources/sparql_templates/merge_account_ownership.sparql
+++ b/src/djehuty/web/resources/sparql_templates/merge_account_ownership.sparql
@@ -1,0 +1,20 @@
+{% extends "prefixes.sparql" %}
+{% block query %}
+DELETE {
+  GRAPH <{{state_graph}}> {
+    ?container       djht:account                  <account:{{from_account_uuid}}> .
+  }
+}
+INSERT {
+  GRAPH <{{state_graph}}> {
+    ?container       djht:account                  <account:{{to_account_uuid}}> .
+  }
+}
+WHERE {
+  GRAPH <{{state_graph}}> {
+    ?container       djht:account                  <account:{{from_account_uuid}}> .
+    ?container       rdf:type                      ?type .
+    FILTER (?type IN (djht:DatasetContainer, djht:CollectionContainer))
+  }
+}
+{% endblock %}

--- a/src/djehuty/web/resources/sparql_templates/merge_account_ownership.sparql
+++ b/src/djehuty/web/resources/sparql_templates/merge_account_ownership.sparql
@@ -2,17 +2,17 @@
 {% block query %}
 DELETE {
   GRAPH <{{state_graph}}> {
-    ?container       djht:account                  <account:{{from_account_uuid}}> .
+    ?container       djht:account                  <{{from_account_uri}}> .
   }
 }
 INSERT {
   GRAPH <{{state_graph}}> {
-    ?container       djht:account                  <account:{{to_account_uuid}}> .
+    ?container       djht:account                  <{{to_account_uri}}> .
   }
 }
 WHERE {
   GRAPH <{{state_graph}}> {
-    ?container       djht:account                  <account:{{from_account_uuid}}> .
+    ?container       djht:account                  <{{from_account_uri}}> .
     ?container       rdf:type                      ?type .
     FILTER (?type IN (djht:DatasetContainer, djht:CollectionContainer))
   }

--- a/src/djehuty/web/resources/static/js/admin-merge-accounts.js
+++ b/src/djehuty/web/resources/static/js/admin-merge-accounts.js
@@ -1,0 +1,116 @@
+let merge_preview_state = null;
+
+function render_account_summary (account) {
+    let name = `${account.first_name || ""} ${account.last_name || ""}`.trim();
+    let email = account.email || "(no e-mail)";
+    let label = name ? `${name} &lt;${email}&gt;` : email;
+    return `${label} <code>${account.uuid}</code>`;
+}
+
+function render_containers_table (containers) {
+    let tbody = jQuery("#merge-containers-tbody");
+    tbody.empty();
+    if (containers.length === 0) {
+        tbody.append('<tr><td colspan="5"><em>No containers owned by the source account.</em></td></tr>');
+        return;
+    }
+    containers.forEach(function (row) {
+        let flags = "";
+        if (row.has_published === true || row.has_published === "true") {
+            flags += '<span class="flag published">published</span>';
+        }
+        if (row.has_draft === true || row.has_draft === "true") {
+            flags += '<span class="flag draft">draft</span>';
+        }
+        let doi = row.doi ? `<a href="https://doi.org/${row.doi}" target="_blank" rel="noopener">${row.doi}</a>` : "-";
+        let title = row.title ? row.title : "<em>(untitled)</em>";
+        tbody.append(`<tr>
+            <td class="type-tag">${row.container_type || "-"}</td>
+            <td>${title}</td>
+            <td>${doi}</td>
+            <td>${flags || "-"}</td>
+            <td><code>${row.container_uuid}</code></td>
+        </tr>`);
+    });
+}
+
+function load_preview (event) {
+    stop_event_propagation (event);
+    let from_email = jQuery("#from-email").val();
+    let to_email = jQuery("#to-email").val();
+    if (!from_email || !to_email) {
+        show_message ("failure", "<p>Both e-mail addresses are required.</p>");
+        return;
+    }
+    jQuery("#merge-confirm-button").addClass("disabled");
+    jQuery.ajax({
+        url:         "/admin/users/merge/preview",
+        type:        "POST",
+        contentType: "application/json",
+        accept:      "application/json",
+        data:        JSON.stringify({ "from_email": from_email, "to_email": to_email }),
+        dataType:    "json"
+    }).done(function (data) {
+        merge_preview_state = data;
+        jQuery("#preview-from").html (render_account_summary (data.from_account));
+        jQuery("#preview-to").html (render_account_summary (data.to_account));
+        jQuery("#preview-count").text (data.containers.length);
+        render_containers_table (data.containers);
+        jQuery("#merge-preview").show();
+        if (data.containers.length > 0) {
+            jQuery("#merge-confirm-button").removeClass("disabled");
+        }
+    }).fail(function (xhr) {
+        merge_preview_state = null;
+        jQuery("#merge-preview").hide();
+        let message = "Failed to load preview.";
+        try {
+            let body = JSON.parse (xhr.responseText);
+            if (body && body.message) { message = body.message; }
+        } catch (e) { /* keep default */ }
+        show_message ("failure", `<p>${message}</p>`);
+    });
+}
+
+function confirm_merge (event) {
+    stop_event_propagation (event);
+    if (jQuery("#merge-confirm-button").hasClass("disabled")) { return; }
+    if (merge_preview_state === null) { return; }
+    let count = merge_preview_state.containers.length;
+    let from_email = merge_preview_state.from_account.email || merge_preview_state.from_account.uuid;
+    let to_email = merge_preview_state.to_account.email || merge_preview_state.to_account.uuid;
+    if (!confirm (`Move ${count} container(s) from ${from_email} to ${to_email}? This cannot be undone from the UI.`)) {
+        return;
+    }
+    jQuery("#merge-confirm-button").addClass("disabled");
+    jQuery.ajax({
+        url:         "/admin/users/merge/execute",
+        type:        "POST",
+        contentType: "application/json",
+        accept:      "application/json",
+        data:        JSON.stringify({
+            "from_account_uuid": merge_preview_state.from_account.uuid,
+            "to_account_uuid":   merge_preview_state.to_account.uuid
+        }),
+        dataType:    "json"
+    }).done(function (data) {
+        show_message ("success", `<p>Moved ${data.moved_containers} container(s).</p>`);
+        merge_preview_state = null;
+        jQuery("#merge-preview").hide();
+        jQuery("#from-email").val("");
+        jQuery("#to-email").val("");
+    }).fail(function (xhr) {
+        let message = "Failed to merge accounts.";
+        try {
+            let body = JSON.parse (xhr.responseText);
+            if (body && body.message) { message = body.message; }
+        } catch (e) { /* keep default */ }
+        show_message ("failure", `<p>${message}</p>`);
+        jQuery("#merge-confirm-button").removeClass("disabled");
+    });
+}
+
+jQuery(document).ready(function () {
+    jQuery("#merge-preview-button").on("click", load_preview);
+    jQuery("#merge-confirm-button").on("click", confirm_merge);
+});

--- a/src/djehuty/web/resources/static/js/admin-merge-accounts.js
+++ b/src/djehuty/web/resources/static/js/admin-merge-accounts.js
@@ -54,6 +54,8 @@ function load_preview (event) {
         merge_preview_state = data;
         jQuery("#preview-from").html (render_account_summary (data.from_account));
         jQuery("#preview-to").html (render_account_summary (data.to_account));
+        jQuery("#preview-from-email").text (data.from_account.email || data.from_account.uuid);
+        jQuery("#preview-to-email").text (data.to_account.email || data.to_account.uuid);
         jQuery("#preview-count").text (data.containers.length);
         render_containers_table (data.containers);
         jQuery("#merge-preview").show();

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -151,6 +151,9 @@ class WebServer:
             R("/admin/dashboard",                                                self.ui_admin_dashboard),
             R("/admin/deny-quota-request/<quota_request_uuid>",                  self.ui_admin_deny_quota_request),
             R("/admin/users",                                                    self.ui_admin_users),
+            R("/admin/users/merge",                                              self.ui_admin_users_merge),
+            R("/admin/users/merge/preview",                                      self.ui_admin_users_merge_preview),
+            R("/admin/users/merge/execute",                                      self.ui_admin_users_merge_execute),
             R("/admin/exploratory",                                              self.ui_admin_exploratory),
             R("/admin/quota-requests",                                           self.ui_admin_quota_requests),
             R("/admin/update-published-dataset",                                  self.ui_admin_update_published_dataset),
@@ -3303,6 +3306,118 @@ class WebServer:
         accounts = self.db.accounts()
         return self.__render_template (request, "admin/users.html",
                                        accounts = accounts)
+
+    def ui_admin_users_merge (self, request):
+        """Implements /admin/users/merge."""
+        if not self.accepts_html (request):
+            return self.error_406 ("text/html")
+
+        token = self.token_from_cookie (request)
+        if not self.db.may_administer (token):
+            return self.error_403 (request)
+
+        return self.__render_template (request, "admin/merge_accounts.html")
+
+    def __lookup_account_for_merge (self, email):
+        """Returns (account, error_message). Exactly one of the two is None."""
+        if not isinstance (email, str) or not email.strip():
+            return None, "E-mail address is required."
+        account = self.db.account_by_email (email.strip())
+        if account is None:
+            return None, f"No account found for '{email}'."
+        return account, None
+
+    def ui_admin_users_merge_preview (self, request):
+        """Implements POST /admin/users/merge/preview."""
+        if request.method != "POST":
+            return self.error_405 (["POST"])
+
+        token = self.token_from_cookie (request)
+        if not self.db.may_administer (token):
+            return self.error_403 (request)
+
+        try:
+            parameters = request.get_json()
+        except BadRequest:
+            return self.error_400 (request, "Invalid JSON body.", 400)
+
+        from_email = value_or_none (parameters, "from_email")
+        to_email   = value_or_none (parameters, "to_email")
+
+        from_account, error = self.__lookup_account_for_merge (from_email)
+        if error is not None:
+            return self.error_400 (request, f"Source account: {error}", 400)
+
+        to_account, error = self.__lookup_account_for_merge (to_email)
+        if error is not None:
+            return self.error_400 (request, f"Target account: {error}", 400)
+
+        if from_account["uuid"] == to_account["uuid"]:
+            return self.error_400 (request, "Source and target accounts are the same.", 400)
+
+        containers = self.db.containers_for_account_merge (from_account["uuid"])
+
+        return self.response (json.dumps({
+            "from_account": {
+                "uuid":       from_account["uuid"],
+                "email":      from_account.get("email"),
+                "first_name": from_account.get("first_name"),
+                "last_name":  from_account.get("last_name"),
+            },
+            "to_account": {
+                "uuid":       to_account["uuid"],
+                "email":      to_account.get("email"),
+                "first_name": to_account.get("first_name"),
+                "last_name":  to_account.get("last_name"),
+            },
+            "containers": containers,
+        }))
+
+    def ui_admin_users_merge_execute (self, request):
+        """Implements POST /admin/users/merge/execute."""
+        if request.method != "POST":
+            return self.error_405 (["POST"])
+
+        token = self.token_from_cookie (request)
+        if not self.db.may_administer (token):
+            return self.error_403 (request)
+
+        try:
+            parameters = request.get_json()
+        except BadRequest:
+            return self.error_400 (request, "Invalid JSON body.", 400)
+
+        from_uuid = value_or_none (parameters, "from_account_uuid")
+        to_uuid   = value_or_none (parameters, "to_account_uuid")
+
+        if not validator.is_valid_uuid (from_uuid):
+            return self.error_400 (request, "Invalid source account UUID.", 400)
+        if not validator.is_valid_uuid (to_uuid):
+            return self.error_400 (request, "Invalid target account UUID.", 400)
+        if from_uuid == to_uuid:
+            return self.error_400 (request, "Source and target accounts are the same.", 400)
+
+        from_account = self.db.account_by_uuid (from_uuid)
+        to_account   = self.db.account_by_uuid (to_uuid)
+        if from_account is None:
+            return self.error_400 (request, "Source account does not exist.", 400)
+        if to_account is None:
+            return self.error_400 (request, "Target account does not exist.", 400)
+
+        container_count = len (self.db.containers_for_account_merge (from_uuid))
+        if not self.db.merge_account_ownership (from_uuid, to_uuid):
+            self.log.error ("Account merge from %s to %s failed.", from_uuid, to_uuid)
+            return self.error_500 ("Failed to merge accounts.")
+
+        self.log.info ("Merged %s containers from account %s to account %s.",
+                       container_count, from_uuid, to_uuid)
+        self.db.cache.invalidate_all ()
+
+        return self.response (json.dumps({
+            "moved_containers": container_count,
+            "from_account_uuid": from_uuid,
+            "to_account_uuid":   to_uuid,
+        }))
 
     def ui_admin_exploratory (self, request):
         """Implements /admin/exploratory."""

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3382,6 +3382,9 @@ class WebServer:
         if not self.db.may_administer (token):
             return self.error_403 (request)
 
+        admin_account = self.db.account_by_session_token (token)
+        admin_uuid = value_or_none (admin_account, "uuid")
+
         try:
             parameters = request.get_json()
         except BadRequest:
@@ -3404,13 +3407,18 @@ class WebServer:
         if to_account is None:
             return self.error_400 (request, "Target account does not exist.", 400)
 
-        container_count = len (self.db.containers_for_account_merge (from_uuid))
+        containers = self.db.containers_for_account_merge (from_uuid)
+        container_uuids = [value_or_none (container, "container_uuid")
+                           for container in containers]
+        container_count = len (containers)
         if not self.db.merge_account_ownership (from_uuid, to_uuid):
             self.log.error ("Account merge from %s to %s failed.", from_uuid, to_uuid)
             return self.error_500 ("Failed to merge accounts.")
 
-        self.log.info ("Merged %s containers from account %s to account %s.",
-                       container_count, from_uuid, to_uuid)
+        self.log.info ("Admin %s merged %s containers from account %s to "
+                       "account %s. Moved containers: %s.",
+                       admin_uuid, container_count, from_uuid, to_uuid,
+                       ", ".join (filter (None, container_uuids)) or "(none)")
         self.db.cache.invalidate_all ()
 
         return self.response (json.dumps({

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -6,6 +6,7 @@ markers =
     admin: Tests for admin panel functionality
     admin_embargo: Tests for embargo, access control, and private links
     admin_license: Tests for admin license-change workflow
+    admin_merge_accounts: Test for admin user merge accounts
     dataset: Tests for dataset operations
     files: Tests for file upload, download, and management
     review: Tests for publication and review workflow

--- a/tests/e2e/tests/test_admin_merge_accounts.py
+++ b/tests/e2e/tests/test_admin_merge_accounts.py
@@ -1,0 +1,328 @@
+"""
+Admin "merge accounts" tests.
+
+Covers:
+    - /admin/users/merge page rendering and admin-only access
+    - "Merge accounts" entry link on /admin/users
+    - JSON validation on /admin/users/merge/preview
+    - JSON validation on /admin/users/merge/execute
+    - Non-admin gets 403 on every merge endpoint
+    - Full UI flow: source account creates a draft, admin merges,
+      ownership is reassigned in the SPARQL store
+
+Run with:
+    cd tests/e2e && python -m pytest tests/test_admin_merge_accounts.py -v
+"""
+
+import pytest
+import requests
+from playwright.sync_api import Page, expect
+
+from config import ADMIN_EMAIL, SPARQL_GRAPH, SPARQL_URL
+from helpers.accounts import get_account_uuid, get_non_admin_account
+from helpers.dataset import create_draft_dataset, get_container_uuid_from_url
+from helpers.impersonation import impersonate, stop_impersonation
+from pages.dataset_editor_page import DatasetEditorPage
+
+
+# ---------------------------------------------------------------------------
+# Local SPARQL helper
+# ---------------------------------------------------------------------------
+
+
+def get_container_owner_uuid(container_uuid: str) -> str | None:
+    """Return the ``djht:account`` UUID currently set on a container, or None."""
+    query = f"""
+        PREFIX djht: <https://ontologies.data.4tu.nl/djehuty/0.0.1/>
+        SELECT ?owner WHERE {{
+          GRAPH <{SPARQL_GRAPH}> {{
+            <container:{container_uuid}> djht:account ?account .
+          }}
+          BIND(STRAFTER(STR(?account), "account:") AS ?owner)
+        }} LIMIT 1
+    """
+    response = requests.get(
+        SPARQL_URL,
+        params={"query": query},
+        headers={"Accept": "application/sparql-results+json"},
+        timeout=15,
+    )
+    response.raise_for_status()
+    bindings = response.json()["results"]["bindings"]
+    return bindings[0]["owner"]["value"] if bindings else None
+
+
+# ---------------------------------------------------------------------------
+# Page-level / access control
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.admin
+@pytest.mark.admin_merge_accounts
+class TestAdminMergeAccountsPage:
+    """Verify the merge-accounts page renders and is admin-gated."""
+
+    def test_merge_page_accessible(self, admin_page: Page, screenshot):
+        """Admin can load /admin/users/merge and sees the form."""
+        response = admin_page.goto("/admin/users/merge")
+        assert response is not None
+        assert response.status == 200
+        screenshot(admin_page, "merge-page")
+
+        expect(admin_page.locator("body")).to_contain_text("Merge accounts")
+        expect(admin_page.locator("#from-email")).to_be_visible()
+        expect(admin_page.locator("#to-email")).to_be_visible()
+        expect(admin_page.locator("#merge-preview-button")).to_be_visible()
+        expect(admin_page.locator("#merge-preview")).to_be_hidden()
+
+    def test_users_page_has_merge_button(self, admin_page: Page, screenshot):
+        """The /admin/users page links to the merge page."""
+        admin_page.goto("/admin/users")
+        admin_page.wait_for_load_state("domcontentloaded")
+        screenshot(admin_page, "users-page-with-merge-button")
+
+        merge_link = admin_page.locator("a[href='/admin/users/merge']")
+        expect(merge_link).to_be_visible()
+        expect(merge_link).to_contain_text("Merge accounts")
+
+    def test_non_admin_gets_403_on_merge_page(self, admin_page: Page, screenshot):
+        """A non-admin user receives 403 on /admin/users/merge."""
+        non_admin_uuid = get_non_admin_account()["uuid"]
+        impersonate(admin_page, non_admin_uuid)
+
+        response = admin_page.goto("/admin/users/merge")
+        assert response is not None
+        screenshot(admin_page, "non-admin-merge-403")
+        assert response.status == 403
+
+        stop_impersonation(admin_page)
+
+
+# ---------------------------------------------------------------------------
+# JSON API validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.admin
+@pytest.mark.admin_merge_accounts
+class TestAdminMergeAccountsApi:
+    """Verify validation on /admin/users/merge/{preview,execute}."""
+
+    def _post_json(self, admin_page: Page, path: str, body: dict):
+        return admin_page.request.post(
+            path,
+            data=body,
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+        )
+
+    def test_preview_rejects_get(self, admin_page: Page):
+        """GET on the preview endpoint should not be allowed."""
+        response = admin_page.request.get("/admin/users/merge/preview")
+        assert response.status == 405
+
+    def test_preview_requires_emails(self, admin_page: Page):
+        """An empty body should produce a 400 about the missing source email."""
+        response = self._post_json(admin_page, "/admin/users/merge/preview", {})
+        assert response.status == 400
+        body = response.json()
+        assert "E-mail address is required" in body["message"]
+
+    def test_preview_unknown_source_email(self, admin_page: Page):
+        """Preview returns 400 when the source email isn't an account."""
+        response = self._post_json(
+            admin_page,
+            "/admin/users/merge/preview",
+            {
+                "from_email": "no-such-account@example.org",
+                "to_email":   ADMIN_EMAIL,
+            },
+        )
+        assert response.status == 400
+        body = response.json()
+        assert "No account found" in body["message"]
+        assert "Source account" in body["message"]
+
+    def test_preview_unknown_target_email(self, admin_page: Page):
+        """Preview returns 400 when the target email isn't an account."""
+        response = self._post_json(
+            admin_page,
+            "/admin/users/merge/preview",
+            {
+                "from_email": ADMIN_EMAIL,
+                "to_email":   "no-such-account@example.org",
+            },
+        )
+        assert response.status == 400
+        assert "Target account" in response.json()["message"]
+
+    def test_preview_same_account(self, admin_page: Page):
+        """Preview returns 400 when source and target are the same account."""
+        response = self._post_json(
+            admin_page,
+            "/admin/users/merge/preview",
+            {"from_email": ADMIN_EMAIL, "to_email": ADMIN_EMAIL},
+        )
+        assert response.status == 400
+        assert "same" in response.json()["message"].lower()
+
+    def test_execute_rejects_get(self, admin_page: Page):
+        """GET on the execute endpoint should not be allowed."""
+        response = admin_page.request.get("/admin/users/merge/execute")
+        assert response.status == 405
+
+    def test_execute_invalid_uuid(self, admin_page: Page):
+        """Execute returns 400 when a UUID is malformed."""
+        response = self._post_json(
+            admin_page,
+            "/admin/users/merge/execute",
+            {"from_account_uuid": "not-a-uuid", "to_account_uuid": "also-not"},
+        )
+        assert response.status == 400
+        assert "Invalid source account UUID" in response.json()["message"]
+
+    def test_execute_same_uuid(self, admin_page: Page):
+        """Execute returns 400 when source and target UUIDs are equal."""
+        admin_uuid = get_account_uuid(ADMIN_EMAIL)
+        assert admin_uuid is not None
+        response = self._post_json(
+            admin_page,
+            "/admin/users/merge/execute",
+            {"from_account_uuid": admin_uuid, "to_account_uuid": admin_uuid},
+        )
+        assert response.status == 400
+        assert "same" in response.json()["message"].lower()
+
+    def test_non_admin_preview_403(self, admin_page: Page):
+        """A non-admin POSTing to preview is denied."""
+        non_admin_uuid = get_non_admin_account()["uuid"]
+        impersonate(admin_page, non_admin_uuid)
+        try:
+            response = self._post_json(
+                admin_page,
+                "/admin/users/merge/preview",
+                {"from_email": ADMIN_EMAIL, "to_email": "x@example.org"},
+            )
+            assert response.status == 403
+        finally:
+            stop_impersonation(admin_page)
+
+    def test_non_admin_execute_403(self, admin_page: Page):
+        """A non-admin POSTing to execute is denied."""
+        non_admin_uuid = get_non_admin_account()["uuid"]
+        impersonate(admin_page, non_admin_uuid)
+        try:
+            response = self._post_json(
+                admin_page,
+                "/admin/users/merge/execute",
+                {
+                    "from_account_uuid": non_admin_uuid,
+                    "to_account_uuid":   non_admin_uuid,
+                },
+            )
+            assert response.status == 403
+        finally:
+            stop_impersonation(admin_page)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end merge flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.admin
+@pytest.mark.admin_merge_accounts
+class TestAdminMergeAccountsFlow:
+    """Run the full preview-and-execute flow and verify SPARQL state."""
+
+    def _create_draft_as(self, page: Page, account_uuid: str) -> str:
+        """Impersonate ACCOUNT_UUID, create a draft, return its container UUID."""
+        impersonate(page, account_uuid)
+        try:
+            url = create_draft_dataset(page)
+            container_uuid = get_container_uuid_from_url(url)
+        finally:
+            stop_impersonation(page)
+        return container_uuid
+
+    def test_preview_lists_source_containers(
+        self, admin_page: Page, screenshot
+    ):
+        """Preview must return the source account's containers."""
+        non_admin = get_non_admin_account()
+        admin_uuid = get_account_uuid(ADMIN_EMAIL)
+        assert admin_uuid is not None
+
+        container_uuid = self._create_draft_as(admin_page, non_admin["uuid"])
+
+        admin_page.goto("/admin/users/merge")
+        admin_page.locator("#from-email").fill(non_admin["email"])
+        admin_page.locator("#to-email").fill(ADMIN_EMAIL)
+        screenshot(admin_page, "merge-form-filled")
+
+        admin_page.locator("#merge-preview-button").click()
+        admin_page.locator("#merge-preview").wait_for(state="visible")
+        screenshot(admin_page, "merge-preview-shown")
+
+        table = admin_page.locator("#merge-containers-table")
+        expect(table).to_contain_text(container_uuid)
+        count_text = admin_page.locator("#preview-count").inner_text()
+        assert int(count_text) >= 1
+
+        # The merge confirm button should be enabled (no longer .disabled)
+        confirm_button = admin_page.locator("#merge-confirm-button")
+        expect(confirm_button).not_to_have_class("disabled")
+
+        # Clean up: admin merges into self so it can be deleted in next test path.
+        # Here we leave the container with the non-admin and delete it directly
+        # by re-impersonating.
+        impersonate(admin_page, non_admin["uuid"])
+        try:
+            admin_page.goto(f"/my/datasets/{container_uuid}/edit")
+            admin_page.wait_for_load_state("domcontentloaded")
+            DatasetEditorPage(admin_page).delete()
+        finally:
+            stop_impersonation(admin_page)
+
+    def test_execute_reassigns_container_ownership(
+        self, admin_page: Page, screenshot
+    ):
+        """After confirming the merge, the container's djht:account changes."""
+        non_admin = get_non_admin_account()
+        admin_uuid = get_account_uuid(ADMIN_EMAIL)
+        assert admin_uuid is not None
+
+        container_uuid = self._create_draft_as(admin_page, non_admin["uuid"])
+
+        # Sanity: container starts owned by the source (non-admin) account.
+        assert get_container_owner_uuid(container_uuid) == non_admin["uuid"]
+
+        admin_page.goto("/admin/users/merge")
+        admin_page.locator("#from-email").fill(non_admin["email"])
+        admin_page.locator("#to-email").fill(ADMIN_EMAIL)
+        admin_page.locator("#merge-preview-button").click()
+        admin_page.locator("#merge-preview").wait_for(state="visible")
+        screenshot(admin_page, "merge-before-confirm")
+
+        # Accept the JavaScript confirm() dialog the page raises.
+        admin_page.once("dialog", lambda dialog: dialog.accept())
+        admin_page.locator("#merge-confirm-button").click()
+
+        # Wait for the success message bar to appear and the preview to hide.
+        admin_page.locator("#message.success").wait_for(state="visible")
+        admin_page.locator("#merge-preview").wait_for(state="hidden")
+        screenshot(admin_page, "merge-after-confirm")
+
+        # The container is now owned by the target (admin) account.
+        assert get_container_owner_uuid(container_uuid) == admin_uuid
+
+        # Form inputs are cleared on success.
+        assert admin_page.locator("#from-email").input_value() == ""
+        assert admin_page.locator("#to-email").input_value() == ""
+
+        # Clean up: admin owns the container now, so it can delete it directly.
+        admin_page.goto(f"/my/datasets/{container_uuid}/edit")
+        admin_page.wait_for_load_state("domcontentloaded")
+        DatasetEditorPage(admin_page).delete()


### PR DESCRIPTION
**Summary**                                                                                                                                                         
                                                                                                                                                                      
  Add an admin "Merge accounts" feature that reassigns ownership of every `DatasetContainer` and `CollectionContainer` from a source account to a target account in a single SPARQL `DELETE/INSERT`. The source account is not deleted, only the `djht:account` link on owned containers is rewritten.                                    
                                                                                                                                                                      
  This consolidates duplicate accounts (typically an institutional account plus an ORCID-linked one) without losing the underlying datasets or collections. The operation is gated to admins, runs through the existing query audit log when enabled (so it can be replayed onto a restored backup), and invalidates the in-memory cache on success.                                                                                                                                                   
                                                                                                                                                                    
  **Changes**
  - `src/djehuty/web/wsgi.py`: register `/admin/users/merge`, `/admin/users/merge/preview`, and `/admin/users/merge/execute`; add the matching admin-gated handlers. Preview returns JSON with both accounts and the source's containers; execute runs the UPDATE, invalidates the cache, and returns the number of containers moved.    
  - `src/djehuty/web/database.py`: add `containers_for_account_merge` and `merge_account_ownership`; the latter routes through `__log_query` when query audit logging is enabled.                                                                                                                                                         
  - `src/djehuty/web/resources/sparql_templates/account_containers_for_merge.sparql`: select datasets and collections owned by an account, with draft and published flags plus best-available title and DOI.                                                                                                                            
  - `src/djehuty/web/resources/sparql_templates/merge_account_ownership.sparql`: single `DELETE/INSERT` that flips `djht:account` from the source to the target on every owned container.                                                                                                                                              
  - `src/djehuty/web/resources/html_templates/admin/merge_accounts.html`: the merge form, preview table, and confirm button.                                        
  - `src/djehuty/web/resources/html_templates/admin/users.html`: add a "Merge accounts" button under the Manage users heading.                                        
  - `src/djehuty/web/resources/static/js/admin-merge-accounts.js`: preview/execute jQuery flow with a `confirm()` guard and message-bar feedback.                     
  - `tests/e2e/tests/test_admin_merge_accounts.py`: Playwright tests for page rendering and admin gating, JSON validation on both POST endpoints, and an end-to-end   
  merge that asserts the container's `djht:account` was rewritten in SPARQL.                                                                                          
                                                                                                                                                                      
  **Approval Checklist**                                                                                                                                              
  - [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).                                         
  - [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).                         
  - [x] Code style and conventions were respected.                                                                                                                    
  - [x] Documentation has been updated where needed (README, docs, or examples).                                                                                      
  - [x] Review approved by at least one maintainer.                                                                                                                   
  - [x] Merge readiness (PR is squashed into a single commit and follows the [commit                                                                                
  template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).                                                           
   
  **Issue Reference (optional - PRs may not be associated with an issue)**                                                                                            
                                                                                                                                                                    
Closes #160 

  **Screenshots (optional)**
                                                                                                                                                                      

  **Notes (optional)**                                                                                                                                                