### PR TITLE
Release version v26.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ news section (`doc/news.tex`) is regenerated at release time by `just news`.
 
 Commit links point to <https://github.com/4TUResearchData/djehuty>.
 
+## [v26.3.1]
+
+This patch release includes 12 commits focused on maintenance and bug fixes.
+It updates multiple Python, Docker, and GitHub Actions dependencies, improves
+the image build process, deprecates Python 3.9 support, and fixes an issue that
+could generate duplicate groups in the database.
+
+### Incremental improvements
+
+- Deprecate Python 3.9 support. ([6b25918](https://github.com/4TUResearchData/djehuty/commit/6b25918bb9112bd3f69c5bec3f74ad8c0399decd))
+- Make the production Docker image build the same way as the development image.
+([b651c96](https://github.com/4TUResearchData/djehuty/commit/b651c969d1226cad6e6d1c8d2c878dae3a69b048))
+- Update the Docker base image to the latest patched python version.([60ce009](https://github.com/4TUResearchData/djehuty/commit/60ce009cb8468b53c6922e91a789aabca9ac8221))
+- Update GitHub Actions dependencies.([4995863](https://github.com/4TUResearchData/djehuty/commit/4995863f654cafc5d9c282b36b21272e80248eac),
+[0aef7c8](https://github.com/4TUResearchData/djehuty/commit/0aef7c8bab2154d56c71bcf35b890290087f7436))
+- Update Python dependencies for security and performance. ([bc89ceb](https://github.com/4TUResearchData/djehuty/commit/bc89cebc71c0db10a27c253122b52cf9b618c097),
+[64a0ef5](https://github.com/4TUResearchData/djehuty/commit/64a0ef52a1777cb8cd174318810e9e7364cdeda0),
+[ee4ef99](https://github.com/4TUResearchData/djehuty/commit/ee4ef99c4fc5989f827e937268871a44e911e3be),
+[b30a44c](https://github.com/4TUResearchData/djehuty/commit/b30a44c6dd22941e480fb32ee69aa88414c0dbbe))
+
+### Bugfixes
+
+- Fix an issue where `start` could generate duplicate groups in the database. ([2ffafde](https://github.com/4TUResearchData/djehuty/commit/2ffafde812ec8653275c530437aa05c597e00e5a))
+
 ## [v26.3]
 
 The third release of 2026 consists of 21 commits made by 3 authors.

--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ artifacts; coverage from each shard is combined into a single report.
 
 ---
 ### Contact information
-- **Maintainers**: g.kuhn@tudelft.nl
+- **Maintainers**: a.e.wilczynska@tudelft.nl, g.kuhn@tudelft.nl, k.f.deAraujo@tudelft.nl
 - **Security issues**: djehuty@4tu.nl

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(djehuty, 26.3)
+AC_INIT(djehuty, 26.3.1)
 AM_INIT_AUTOMAKE([foreign tar-ustar])
 AM_PATH_PYTHON([3.10])
 AC_CONFIG_FILES([

--- a/doc/contact.tex
+++ b/doc/contact.tex
@@ -22,16 +22,24 @@
   \href{https://github.com/4TUResearchData/djehuty?tab=security-ov-file#readme}{security policy}
   document and e-mail us at \href{mailto:djehuty@4tu.nl.}{djehuty@4tu.nl.}.
 
-\section*{Contact the team}
+\section*{Contact the maintainers}
 
   If you have questions, suggestions, or would like to contribute to the Djehuty project,
   please contact the project team via the
   \href{https://github.com/4TUResearchData/djehuty}{GitHub repository}
   or via email:
 
+\textbf{Aleksandra Wilczynska}\\~
+\href{mailto:a.e.wilczynska@tudelft.nl}{a.e.wilczynska@tudelft.nl}\\~
+Data Solutions Engineer @ TU Delft
+
 \textbf{Gabriela Kuhn}\\~
 \href{mailto:g.kuhn@tudelft.nl}{g.kuhn@tudelft.nl}\\~
 Software Engineer @ TU Delft
+
+\textbf{Kairo de Araujo}\\~
+\href{mailto:k.f.deAraujo@tudelft.nl}{k.f.deAraujo@tudelft.nl}\\~
+Senior Software Engineer @ TU Delft
 
 \textbf{For General Questions about 4TU ResearchData}\\~
 \href{mailto:researchdata@4tu.nl}{researchdata@4tu.nl}

--- a/doc/news.tex
+++ b/doc/news.tex
@@ -5,6 +5,38 @@
 \fi
 \chapter*{News}
 
+\labelWithConsistentHTMLTag{release-26-3-1}
+\section*{Release notes for \texttt{v26.3.1}.}
+
+  This patch release includes 12 commits focused on maintenance and bug fixes.
+It updates multiple Python, Docker, and GitHub Actions dependencies, improves
+the image build process, deprecates Python 3.9 support, and fixes an issue that
+could generate duplicate groups in the database.
+
+\subsection*{Incremental improvements}
+\begin{itemize}
+\item{Deprecate Python 3.9 support.
+    (\commitLink{6b25918bb9112bd3f69c5bec3f74ad8c0399decd}).}
+\item{Make the production Docker image build the same way as the development image.
+    (\commitLink{b651c969d1226cad6e6d1c8d2c878dae3a69b048}).}
+\item{Update the Docker base image to the latest patched python version.
+    (\commitLink{60ce009cb8468b53c6922e91a789aabca9ac8221}).}
+\item{Update GitHub Actions dependencies.
+    (\commitLink{4995863f654cafc5d9c282b36b21272e80248eac},
+    \commitLink{0aef7c8bab2154d56c71bcf35b890290087f7436}).}
+\item{Update Python dependencies for security and performance.
+    (\commitLink{bc89cebc71c0db10a27c253122b52cf9b618c097},
+    \commitLink{64a0ef52a1777cb8cd174318810e9e7364cdeda0},
+    \commitLink{ee4ef99c4fc5989f827e937268871a44e911e3be},
+    \commitLink{b30a44c6dd22941e480fb32ee69aa88414c0dbbe}).}
+\end{itemize}
+
+\subsection*{Bugfixes}
+\begin{itemize}
+\item{Fix an issue where \code{start} could generate duplicate groups in the database.
+    (\commitLink{2ffafde812ec8653275c530437aa05c597e00e5a}).}
+\end{itemize}
+
 \labelWithConsistentHTMLTag{release-26-3}
 \section*{Release notes for \texttt{v26.3}.}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend   = "setuptools.build_meta"
 
 [project]
 name            = "djehuty"
-version         = "26.3"
+version         = "26.3.1"
 authors         = [{ name="Roel Janssen", email="r.r.e.janssen@tudelft.nl" }]
 description     = "The 4TU.ResearchData and Nikhef data repository system"
 readme          = "README.md"


### PR DESCRIPTION
**Summary**

This patch release  v26.3.1 includes 10 commits focused on maintenance and bug fixes.

**Changes**

* pyproject.toml: Bump version to v26.3.1
* configure.ac: Bump version to v26.3.1
* CHANGELOG.md: Add release notes for v26.3.1
* doc/news.tex: Add release notes for v26.3.1
* README.md: Update maintainers contact
* doc/contact.tex: Update maintainers contact


**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).


**Notes**
`just docs-html` for build the documentation