### PR TITLE
github: issue-template: Add documentation issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/04_documentation.yml
+++ b/.github/ISSUE_TEMPLATE/04_documentation.yml
@@ -1,0 +1,44 @@
+name: "📚 Documentation"
+description: Report missing, outdated, or unclear documentation, or propose a documentation improvement.
+title: "[DOCUMENTATION]:"
+labels: ["\U0001F4DA documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this to report documentation that is missing, outdated, unclear, or broken, or to propose a documentation improvement.
+  - type: textarea
+    attributes:
+      label: Description
+      description: A clear and short description of the documentation change.
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Type of documentation issue
+      options:
+        - Missing documentation
+        - Outdated / incorrect
+        - Unclear / confusing
+        - Broken link or typo
+        - Migration / tooling
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Affected documentation
+      description: Which page(s) or section(s)? Link to the hosted docs or the source file.
+      placeholder: |
+        e.g. https://djehuty.4tu.nl/#x1-100004
+        e.g. the source file for the affected section
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Proposed change
+      description: What do the docs currently say (or omit), and how should they change?
+      placeholder: |
+        1. Current documentation or gap:
+        2. Proposed change:
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/04_documentation.yml
+++ b/.github/ISSUE_TEMPLATE/04_documentation.yml
@@ -22,8 +22,9 @@ body:
         - Unclear / confusing
         - Broken link or typo
         - Migration / tooling
+        - Other
     validations:
-      required: false
+      required: true
   - type: textarea
     attributes:
       label: Affected documentation


### PR DESCRIPTION
**Summary**

Adds a dedicated issue template for documentation-related issues. Documentation work (e.g. #134, #154) is currently filed under the `improvement` template/label, which makes it harder to identify. A dedicated template with a `documentation` label gives these issues a consistent structure and makes them easier to find.

**Changes**
- `.github/ISSUE_TEMPLATE/04_documentation.yml`: new issue form for documentation issues (missing, outdated, unclear, broken, or migration/tooling), with an optional type dropdown, an affected-documentation field, and a proposed-change field.
- 
**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
~~- [ ] Documentation has been updated where needed (README, docs, or examples).~~
- [ ] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).
