### PR TITLE
Bugfix | Prevent a missing boto3 installation from breaking start-up

### DIFF
--- a/src/djehuty/web/s3.py
+++ b/src/djehuty/web/s3.py
@@ -22,10 +22,10 @@ class S3ClientFactory:
 
     _clients = {}
     _lock = threading.Lock()
-    _boto_config = Config(retries = { "total_max_attempts": 30,
-                                      "mode": "standard" },
-                          max_pool_connections = 25,
-                          read_timeout = 120)
+
+    # Built on first use rather than at class-definition time, so that importing
+    # this module without boto3 installed doesn't raise a NameError.
+    _boto_config = None
 
     @classmethod
     def get_client(cls, endpoint, access_key, secret_key):
@@ -42,6 +42,12 @@ class S3ClientFactory:
                     logging.getLogger (__name__).info (
                         "Creating new S3 client for endpoint: %s", endpoint
                     )
+
+                    if cls._boto_config is None:
+                        cls._boto_config = Config(retries = { "total_max_attempts": 30,
+                                                              "mode": "standard" },
+                                                  max_pool_connections = 25,
+                                                  read_timeout = 120)
 
                     cls._clients[cache_key] = boto3.client(
                         "s3",


### PR DESCRIPTION
**Summary**

As boto3 is a optional dependency, this build the boto config on first use rather than when the module is imported, so an installation without boto3 can can start up.

**Changes**
* src/djehuty/web/s3.py: Add a "lazy start" for boto config.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).