### PR TITLE
fix: djehuty container images and improve python wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,12 +84,40 @@ jobs:
         with:
           context: .
           file: docker/Dockerfile
-          push: ${{ inputs.push_image }}
-          load: ${{ !inputs.push_image }}
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Guard against wheels built without the bundled resources (SPARQL/HTML
+      # templates); an image missing them crashes on startup.
+      - name: Smoke test the production image
+        run: |
+          IMAGE=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+          docker run --rm "$IMAGE" djehuty --version
+          expected=$(find src/djehuty/web/resources src/djehuty/backup/resources -type f | wc -l)
+          packaged=$(docker run --rm -i --entrypoint python "$IMAGE" - <<'PY'
+          import djehuty, os
+          root = os.path.dirname(djehuty.__file__)
+          print(sum(len(files) for pkg in ("web", "backup")
+                    for _, _, files in os.walk(os.path.join(root, pkg, "resources"))))
+          PY
+          )
+          echo "resource files: ${packaged} packaged, ${expected} in src"
+          [ "$packaged" -eq "$expected" ]
+
+      - name: Push Docker image
+        if: inputs.push_image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
 
       - name: Start dev environment (just dev)
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,12 +97,13 @@ jobs:
         run: |
           IMAGE=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
           docker run --rm "$IMAGE" djehuty --version
-          expected=$(find src/djehuty/web/resources src/djehuty/backup/resources -type f | wc -l)
+          expected=$(find src/djehuty/web/resources src/djehuty/backup/resources src/djehuty/schema/migrations -type f | wc -l)
           packaged=$(docker run --rm -i --entrypoint python "$IMAGE" - <<'PY'
           import djehuty, os
           root = os.path.dirname(djehuty.__file__)
-          print(sum(len(files) for pkg in ("web", "backup")
-                    for _, _, files in os.walk(os.path.join(root, pkg, "resources"))))
+          dirs = ("web/resources", "backup/resources", "schema/migrations")
+          print(sum(len(files) for d in dirs
+                    for _, _, files in os.walk(os.path.join(root, *d.split("/")))))
           PY
           )
           echo "resource files: ${packaged} packaged, ${expected} in src"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,7 @@ jobs:
           - search
           - git
           - citation
+          - security
     uses: ./.github/workflows/e2e.yml
     with:
       marker: ${{ matrix.marker }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ djehuty = "djehuty.ui:main"
 [tool.setuptools.package-data]
 "djehuty.web"    = ["resources/**"]
 "djehuty.backup" = ["resources/**"]
+"djehuty.schema" = ["migrations/**"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=42",
+    "setuptools>=83.0.0",
     "wheel"
 ]
 build-backend   = "setuptools.build_meta"
@@ -36,6 +36,11 @@ classifiers     = [
 
 [project.scripts]
 djehuty = "djehuty.ui:main"
+
+# Ship all bundled resources
+[tool.setuptools.package-data]
+"djehuty.web"    = ["resources/**"]
+"djehuty.backup" = ["resources/**"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
**Summary**

Container images built from docker/Dockerfile ship no djehuty/web/resources
because the image build context has no MANIFEST.in, which was the only place
package data was declared. The resulting wheel contains only .py files and
djehuty crashes at startup with TemplateNotFound. Affects the 26.3.1 and
26.3.2 images on GHCR.

**Changes**
- .github/workflows/build.yml: add smoke test
- .github/workflows/ci.yml: fix missing test group
- pyproject.toml: fix resources

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #ISSUE_NUMBER

**Screenshots (optional)**

Before/After visuals, UI changes, or relevant logs.

**Notes (optional)**

Additional context, caveats, or follow-up tasks.