### PR TITLE
Release version v26.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ news section (`doc/news.tex`) is regenerated at release time by `just news`.
 
 Commit links point to <https://github.com/4TUResearchData/djehuty>.
 
+## [v26.3.3]
+
+This patch release fixes the Djehuty container image, which failed to start
+because the published wheel shipped none of the bundled resources. Both the
+container image and the Python wheel are now complete.
+
+### Bugfixes
+
+- Fix the djehuty container image and improves the python whells. ([e53aa4a](https://github.com/4TUResearchData/djehuty/commit/e53aa4a6f0ef4468ed0f65109f1198c0bd0802ca))
+
 ## [v26.3.2]
 
 This patch release includes 5 commits focused on security, maintenance and dependencies.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(djehuty, 26.3.2)
+AC_INIT(djehuty, 26.3.3)
 AM_INIT_AUTOMAKE([foreign tar-ustar])
 AM_PATH_PYTHON([3.10])
 AC_CONFIG_FILES([

--- a/doc/news.tex
+++ b/doc/news.tex
@@ -5,6 +5,19 @@
 \fi
 \chapter*{News}
 
+\labelWithConsistentHTMLTag{release-26-3-3}
+\section*{Release notes for \texttt{v26.3.3}.}
+
+  This patch release fixes the Djehuty container image, which failed to start
+because the published wheel shipped none of the bundled resources. Both the
+container image and the Python wheel are now complete.
+
+\subsection*{Bugfixes}
+\begin{itemize}
+\item{Fix the djehuty container image and improves the python whells.
+    (\commitLink{e53aa4a6f0ef4468ed0f65109f1198c0bd0802ca}).}
+\end{itemize}
+
 \labelWithConsistentHTMLTag{release-26-3-2}
 \section*{Release notes for \texttt{v26.3.2}.}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend   = "setuptools.build_meta"
 
 [project]
 name            = "djehuty"
-version         = "26.3.2"
+version         = "26.3.3"
 authors         = [{ name="Roel Janssen", email="r.r.e.janssen@tudelft.nl" }]
 description     = "The 4TU.ResearchData and Nikhef data repository system"
 readme          = "README.md"


### PR DESCRIPTION
**Summary**

This patch release fixes the Djehuty container image, which failed to start
because the published wheel shipped none of the bundled resources. Both the
container image and the Python wheel are now complete.

**Changes**
* pyproject.toml: Bump version to v26.3.3
* configure.ac: Bump version to v26.3.3
* CHANGELOG.md: Add release notes for v26.3.3
* doc/news.tex: Add release notes for v26.3.3

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).