### PR TITLE
style: lint and format web config helpers with ruff

### DIFF
--- a/justfile
+++ b/justfile
@@ -198,7 +198,7 @@ test *args="":
         --output=/app/test-results {{ args }}
 
 # Paths already cleaned and enforced by ruff (extended per sub-issue)
-lint_paths := "src/djehuty/utils"
+lint_paths := "src/djehuty/utils src/djehuty/web/config src/djehuty/web/locks.py src/djehuty/web/email_handler.py"
 
 # Lint and check formatting of cleaned paths
 lint:

--- a/src/djehuty/web/config/json_parser.py
+++ b/src/djehuty/web/config/json_parser.py
@@ -16,7 +16,6 @@ import re
 
 from defusedxml import ElementTree
 
-
 _SECRET_REF_RE = re.compile(r"^\$\{(env|file):([^}]+)\}$")
 
 
@@ -44,9 +43,7 @@ def _resolve_reference(value):
         with open(target, "r", encoding="utf-8") as handle:
             return handle.read().strip()
     except OSError as exc:
-        raise ConfigurationError(
-            f"could not read secret file '{target}': {exc}"
-        ) from exc
+        raise ConfigurationError(f"could not read secret file '{target}': {exc}") from exc
 
 
 class JsonConfigElement:

--- a/src/djehuty/web/email_handler.py
+++ b/src/djehuty/web/email_handler.py
@@ -5,10 +5,11 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
+
 class EmailInterface:
     """This class implements sending e-mail and e-mail templates."""
 
-    def __init__ (self):
+    def __init__(self):
         self.smtp_server = None
         self.from_address = None
         self.smtp_username = None
@@ -18,19 +19,18 @@ class EmailInterface:
         self.log = logging.getLogger(__name__)
         self.subject_prefix = None
 
-    def is_properly_configured (self):
+    def is_properly_configured(self):
         """Procedure to bail early on a misconfigured instance of this class."""
-        return (self.smtp_server is not None and
-                self.from_address is not None)
+        return self.smtp_server is not None and self.from_address is not None
 
-    def send_email (self, recipient, subject, plaintext, html):
+    def send_email(self, recipient, subject, plaintext, html):
         """Procedure to send an email."""
 
-        if not self.is_properly_configured ():
-            self.log.error ("E-mail server not properly configured.")
+        if not self.is_properly_configured():
+            self.log.error("E-mail server not properly configured.")
             return False
 
-        message = MIMEMultipart ("alternative")
+        message = MIMEMultipart("alternative")
         message["From"] = self.from_address
         message["To"] = recipient
         if self.subject_prefix:
@@ -38,43 +38,56 @@ class EmailInterface:
         else:
             message["Subject"] = subject
 
-        message.attach (MIMEText (plaintext, "plain"))
-        message.attach (MIMEText (html, "html"))
+        message.attach(MIMEText(plaintext, "plain"))
+        message.attach(MIMEText(html, "html"))
 
         try:
-            connection = smtplib.SMTP (self.smtp_server, self.smtp_port, timeout=10)
-        except (smtplib.SMTPConnectError, smtplib.SMTPException,
-                smtplib.SMTPServerDisconnected, ConnectionRefusedError) as error:
-            self.log.error ("Connecting to the e-mail server failed: %s", error)
+            connection = smtplib.SMTP(self.smtp_server, self.smtp_port, timeout=10)
+        except (
+            smtplib.SMTPConnectError,
+            smtplib.SMTPException,
+            smtplib.SMTPServerDisconnected,
+            ConnectionRefusedError,
+        ) as error:
+            self.log.error("Connecting to the e-mail server failed: %s", error)
             return False
 
         connection.ehlo()
         if self.do_starttls:
-            connection.starttls ()
+            connection.starttls()
         elif self.smtp_username is not None and self.smtp_password is not None:
-            self.log.error ("The e-mail interface hasn't been tested without STARTTLS.")
-            self.log.error ("Please review the code before continuing.")
+            self.log.error("The e-mail interface hasn't been tested without STARTTLS.")
+            self.log.error("Please review the code before continuing.")
             return False
         else:
-            self.log.warning ("STARTTLS is not enabled. Please review your e-mail settings.")
+            self.log.warning("STARTTLS is not enabled. Please review your e-mail settings.")
 
         if self.smtp_username is not None and self.smtp_password is not None:
             try:
-                connection.login (self.smtp_username, self.smtp_password)
+                connection.login(self.smtp_username, self.smtp_password)
             except smtplib.SMTPAuthenticationError:
-                self.log.error ("Wrong credentials for authenticating to the e-mail server.")
+                self.log.error("Wrong credentials for authenticating to the e-mail server.")
                 return False
-            except (smtplib.SMTPHeloError, smtplib.SMTPServerDisconnected,
-                    smtplib.SMTPNotSupportedError, smtplib.SMTPException) as error:
-                self.log.error ("Authenticating to the e-mail server failed: %s", error)
+            except (
+                smtplib.SMTPHeloError,
+                smtplib.SMTPServerDisconnected,
+                smtplib.SMTPNotSupportedError,
+                smtplib.SMTPException,
+            ) as error:
+                self.log.error("Authenticating to the e-mail server failed: %s", error)
                 return False
 
         try:
-            connection.sendmail (self.from_address, recipient, message.as_string())
-        except (smtplib.SMTPRecipientsRefused, smtplib.SMTPHeloError, smtplib.SMTPSenderRefused,
-                smtplib.SMTPDataError, smtplib.SMTPNotSupportedError,
-                smtplib.SMTPServerDisconnected) as error:
-            self.log.error ("Sending e-mail failed: %s", error)
+            connection.sendmail(self.from_address, recipient, message.as_string())
+        except (
+            smtplib.SMTPRecipientsRefused,
+            smtplib.SMTPHeloError,
+            smtplib.SMTPSenderRefused,
+            smtplib.SMTPDataError,
+            smtplib.SMTPNotSupportedError,
+            smtplib.SMTPServerDisconnected,
+        ) as error:
+            self.log.error("Sending e-mail failed: %s", error)
             return False
 
         connection.close()

--- a/src/djehuty/web/locks.py
+++ b/src/djehuty/web/locks.py
@@ -2,6 +2,7 @@
 
 from enum import Enum
 from threading import Lock
+
 from djehuty.web.config import config
 
 try:
@@ -9,12 +10,15 @@ try:
 except ModuleNotFoundError:
     pass
 
+
 class LockTypes(Enum):
     """Enumeration of lock types."""
-    FILE_LIST     = 1
+
+    FILE_LIST = 1
     PRIVATE_LINKS = 2
-    AUTHORS       = 3
+    AUTHORS = 3
     SUBMIT_DATASET = 4
+
 
 class Locks:
     """This class implements multiple locks"""
@@ -22,12 +26,13 @@ class Locks:
     ## Only ever allow one instance of this class to exist,
     ## so that we prevent re-initializing locks.
     _instance = None
-    def __new__ (cls):
+
+    def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__ (self):
+    def __init__(self):
         self.locks = {
             LockTypes.FILE_LIST: Lock(),
             LockTypes.PRIVATE_LINKS: Lock(),
@@ -35,7 +40,7 @@ class Locks:
             LockTypes.SUBMIT_DATASET: Lock(),
         }
 
-    def lock (self, lock_type):
+    def lock(self, lock_type):
         """Lock critical section LOCK_TYPE."""
 
         if config.using_uwsgi:
@@ -44,7 +49,7 @@ class Locks:
             lock = self.locks.get(lock_type)
             lock.acquire(blocking=True, timeout=30)
 
-    def unlock (self, lock_type):
+    def unlock(self, lock_type):
         """Unlock critical section LOCK_TYPE."""
         if config.using_uwsgi:
             uwsgi.unlock(lock_type.value)


### PR DESCRIPTION
> **Note:** Stacked on #173: rebased already.

**Summary**

Next slice of the incremental Ruff rollout (#66): lints and formats the `src/djehuty/web/` configuration and helper files (config/ subpackage, locks.py, email_handler.py) and adds them to the enforced scope. The diff is small: config/__init__.py and config/runtime.py were already clean, and the rest needed only import sorting and light reformatting.

**Changes**
- `src/djehuty/web/config/json_parser.py`, `email_handler.py`,  `locks.py`: apply `ruff check --fix` (import sorting) and `ruff format`. No functional changes.
- `justfile`: add the three paths to `lint_paths` so `just lint` and CI enforce them.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Closes #142 (part of #66)

**Screenshots**

Green CI run on my fork with the Lint job covering the extended scope:
https://github.com/641e16/djehuty/actions/runs/29333781145

**Notes**

- `src/djehuty/web/config.py` is deliberately **excluded**: it has been shadowed (unreachable) since the config/ package was introduced in 6ace7fe2 — every `djehuty.web.config` import resolves to the package. Removing it is a functional change, proposed separately in #176.
- Verified: `just lint` green on the full scope; unit tests 157/157  (config/runtime.py and json_parser.py have real test coverage).
