### PR TITLE
style: lint and format web cache and I/O helpers with ruff, enforce

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,9 @@ include = [
     "src/djehuty/ui.py",
     "src/djehuty/__init__.py",
     "tests/**/*.py",
+    "src/djehuty/web/cache.py",
+    "src/djehuty/web/s3.py",
+    "src/djehuty/web/zipfly.py",
 ]
 
 [tool.ruff.lint]

--- a/src/djehuty/web/cache.py
+++ b/src/djehuty/web/cache.py
@@ -6,25 +6,26 @@ serializable by means of 'json.dumps' and deseralizeable by means of
 """
 
 import glob
-import os
-import logging
 import hashlib
 import json
+import logging
+import os
+
 
 class CacheLayer:
     """This class provides the caching layer."""
 
-    def __init__ (self, storage_path):
-        self.storage     = storage_path
-        self.log         = logging.getLogger(__name__)
+    def __init__(self, storage_path):
+        self.storage = storage_path
+        self.log = logging.getLogger(__name__)
 
-    def make_key (self, input_string):
+    def make_key(self, input_string):
         """Procedure to turn 'input_string' into a short, unique identifier."""
         if input_string is None:
             return None
 
-        md5 = hashlib.new ("md5", usedforsecurity=False)
-        md5.update (input_string.encode('utf-8'))
+        md5 = hashlib.new("md5", usedforsecurity=False)
+        md5.update(input_string.encode("utf-8"))
         return md5.hexdigest()
 
     def cache_is_ready(self):
@@ -40,58 +41,58 @@ class CacheLayer:
 
         return False
 
-    def cached_value (self, prefix, key, is_raw=False):
+    def cached_value(self, prefix, key, is_raw=False):
         """Returns the cached value or None."""
         try:
-            filename = os.path.join (self.storage, f"{prefix}_{key}")
-            with open(filename, "r", encoding = "utf-8") as cache_file:
+            filename = os.path.join(self.storage, f"{prefix}_{key}")
+            with open(filename, "r", encoding="utf-8") as cache_file:
                 cached = cache_file.read()
                 if is_raw:
                     return cached
-                return json.loads (cached)
+                return json.loads(cached)
         except OSError:
-            self.log.debug ("No cached response for %s.", key)
+            self.log.debug("No cached response for %s.", key)
         except json.decoder.JSONDecodeError:
-            self.log.error ("Possible cache corruption at %s.", filename)
+            self.log.error("Possible cache corruption at %s.", filename)
 
         return None
 
-    def cache_value (self, prefix, key, value, query=None, is_raw=False):
+    def cache_value(self, prefix, key, value, query=None, is_raw=False):
         """Procedure to store 'value' as a cache."""
         try:
-            cache_filename = os.path.join (self.storage, f"{prefix}_{key}")
-            cache_fd = os.open (cache_filename, os.O_WRONLY | os.O_CREAT, 0o600)
-            with open(cache_fd, "w", encoding = "utf-8") as cache_file:
+            cache_filename = os.path.join(self.storage, f"{prefix}_{key}")
+            cache_fd = os.open(cache_filename, os.O_WRONLY | os.O_CREAT, 0o600)
+            with open(cache_fd, "w", encoding="utf-8") as cache_file:
                 if is_raw:
-                    cache_file.write (value)
+                    cache_file.write(value)
                 else:
-                    cache_file.write (json.dumps(value))
-                if os.name != 'nt':
-                    os.fchmod (cache_fd, 0o400)  # pylint: disable=no-member
+                    cache_file.write(json.dumps(value))
+                if os.name != "nt":
+                    os.fchmod(cache_fd, 0o400)  # pylint: disable=no-member
 
             if query is not None:
-                query_filename = os.path.join (self.storage, f"{prefix}_{key}.sparql")
-                query_fd = os.open (query_filename, os.O_WRONLY | os.O_CREAT, 0o600)
-                with open(query_fd, "w", encoding = "utf-8") as query_file:
+                query_filename = os.path.join(self.storage, f"{prefix}_{key}.sparql")
+                query_fd = os.open(query_filename, os.O_WRONLY | os.O_CREAT, 0o600)
+                with open(query_fd, "w", encoding="utf-8") as query_file:
                     query_file.write(query)
-                    if os.name != 'nt':
-                        os.fchmod (query_fd, 0o400)  # pylint: disable=no-member
+                    if os.name != "nt":
+                        os.fchmod(query_fd, 0o400)  # pylint: disable=no-member
         except OSError:
-            self.log.warning ("Failed to save cache for %s.", key)
+            self.log.warning("Failed to save cache for %s.", key)
 
         return value
 
-    def invalidate_by_prefix (self, prefix):
+    def invalidate_by_prefix(self, prefix):
         """Procedure to remove all cache items belonging to 'prefix'."""
         for file_path in glob.glob(os.path.join(self.storage, f"{prefix}_*")):
             try:
                 os.remove(file_path)
             except FileNotFoundError:
-                self.log.warning ("Trying to remove %s multiple times.", file_path)
+                self.log.warning("Trying to remove %s multiple times.", file_path)
 
         return True
 
-    def invalidate_all (self):
+    def invalidate_all(self):
         """Procedure to remove all cache items."""
 
         if not isinstance(self.storage, str):
@@ -101,12 +102,12 @@ class CacheLayer:
             return False
 
         files = glob.glob(os.path.join(self.storage, "*"))
-        self.log.info ("Removing %d files.", len(files))
+        self.log.info("Removing %d files.", len(files))
         for file_path in files:
             try:
                 os.remove(file_path)
             except FileNotFoundError:
-                self.log.warning ("Trying to remove %s multiple times.", file_path)
+                self.log.warning("Trying to remove %s multiple times.", file_path)
             except IsADirectoryError:
                 pass
 

--- a/src/djehuty/web/s3.py
+++ b/src/djehuty/web/s3.py
@@ -1,18 +1,23 @@
 """This module implements interaction with an S3 endpoint."""
 
 import logging
-import uuid
 import os
 import threading
+import uuid
 from datetime import datetime
-from djehuty.web.config import config
+
 from djehuty.utils.convenience import value_or
+from djehuty.web.config import config
 
 try:
     import boto3
-    from botocore.exceptions import ClientError, PartialCredentialsError
-    from botocore.exceptions import ResponseStreamingError, ReadTimeoutError
     from botocore.config import Config
+    from botocore.exceptions import (
+        ClientError,
+        PartialCredentialsError,
+        ReadTimeoutError,
+        ResponseStreamingError,
+    )
     from urllib3.exceptions import IncompleteRead
 except (ImportError, ModuleNotFoundError):
     pass
@@ -20,15 +25,17 @@ except (ImportError, ModuleNotFoundError):
 DEFAULT_CHUNK_SIZE = 32768
 DEFAULT_OFFSET = 0
 
+
 class S3ClientFactory:
     """Thread-safe singleton manager for boto3 S3 clients."""
 
     _clients = {}
     _lock = threading.Lock()
-    _boto_config = Config(retries = { "total_max_attempts": 30,
-                                      "mode": "standard" },
-                          max_pool_connections = 25,
-                          read_timeout = 120)
+    _boto_config = Config(
+        retries={"total_max_attempts": 30, "mode": "standard"},
+        max_pool_connections=25,
+        read_timeout=120,
+    )
 
     @classmethod
     def get_client(cls, endpoint, access_key, secret_key):
@@ -42,7 +49,7 @@ class S3ClientFactory:
             with cls._lock:
                 # Double-check after acquiring lock
                 if cache_key not in cls._clients:
-                    logging.getLogger (__name__).info (
+                    logging.getLogger(__name__).info(
                         "Creating new S3 client for endpoint: %s", endpoint
                     )
 
@@ -51,15 +58,26 @@ class S3ClientFactory:
                         endpoint_url=endpoint,
                         aws_access_key_id=access_key,
                         aws_secret_access_key=secret_key,
-                        config=cls._boto_config
+                        config=cls._boto_config,
                     )
         return cls._clients[cache_key]
+
 
 class S3DownloadStreamer:
     """Generator to stream the contents of a file stored in S3."""
 
-    def __init__ (self, endpoint, bucket, access_key, secret_key, filename, name,
-                  chunk_size=DEFAULT_CHUNK_SIZE, offset=DEFAULT_OFFSET, end=None):
+    def __init__(
+        self,
+        endpoint,
+        bucket,
+        access_key,
+        secret_key,
+        filename,
+        name,
+        chunk_size=DEFAULT_CHUNK_SIZE,
+        offset=DEFAULT_OFFSET,
+        end=None,
+    ):
         self.client = None
         self.endpoint = endpoint
         self.bucket = bucket
@@ -69,7 +87,7 @@ class S3DownloadStreamer:
         self.chunk_size = chunk_size
         self.offset = offset
         self.end = end
-        self.log = logging.getLogger (__name__)
+        self.log = logging.getLogger(__name__)
         self.original_filename = name
         self.content_length = 0
         self.total_length = 0
@@ -79,79 +97,86 @@ class S3DownloadStreamer:
         self.file_object = None
         self.file_contents = None
 
-    def __range_header (self):
+    def __range_header(self):
         """Builds the outbound S3 Range header for the current offset/end."""
         if self.end is not None:
             return f"bytes={self.offset}-{self.end}"
         return f"bytes={self.offset}-"
 
-    def connect (self):
+    def connect(self):
         """Initialize procedure that can be recalled."""
         self.client = S3ClientFactory.get_client(
-            endpoint=self.endpoint,
-            access_key=self.access_key,
-            secret_key=self.secret_key
+            endpoint=self.endpoint, access_key=self.access_key, secret_key=self.secret_key
         )
         try:
-            request_arguments = { "Bucket": self.bucket,
-                                  "Key":    self.filename,
-                                  "Range":  self.__range_header () }
+            request_arguments = {
+                "Bucket": self.bucket,
+                "Key": self.filename,
+                "Range": self.__range_header(),
+            }
             if self.etag is not None:
                 request_arguments["IfMatch"] = self.etag
-            self.file_object   = self.client.get_object (**request_arguments)
+            self.file_object = self.client.get_object(**request_arguments)
             self.file_contents = self.file_object["Body"]
         except ClientError as error:
-            if error.response.get ("Error", {}).get ("Code") == "PreconditionFailed":
-                self.log.error ("Object s3://%s/%s changed during download.",
-                                self.bucket, self.filename)
+            if error.response.get("Error", {}).get("Code") == "PreconditionFailed":
+                self.log.error(
+                    "Object s3://%s/%s changed during download.", self.bucket, self.filename
+                )
             else:
-                self.log.error ("An S3 download stream error occurred: %s", error)
+                self.log.error("An S3 download stream error occurred: %s", error)
             return
         except KeyError as error:
-            self.log.error ("An S3 download stream error occurred: %s", error)
+            self.log.error("An S3 download stream error occurred: %s", error)
             return
 
         try:
             http_headers = self.file_object["ResponseMetadata"]["HTTPHeaders"]
-            self.content_type   = value_or (http_headers, "content-type", self.content_type)
+            self.content_type = value_or(http_headers, "content-type", self.content_type)
             ## On a ranged request 'content-length' is the slice size, not the
             ## whole object; the total is only in 'content-range'.
-            self.content_length = int(value_or (http_headers, "content-length", 0))
-            self.etag           = value_or (http_headers, "etag", None)
-            self.total_length   = self.__total_from_headers (http_headers)
-            modified = datetime.strptime (value_or (http_headers, "last-modified",
-                                                    "Tue, 01 Jan 1980 12:00:00 GMT"),
-                                          "%a, %d %b %Y %H:%M:%S %Z")
-            self.last_modified  = (modified.year, modified.month, modified.day,
-                                   modified.hour, modified.minute, modified.second)
+            self.content_length = int(value_or(http_headers, "content-length", 0))
+            self.etag = value_or(http_headers, "etag", None)
+            self.total_length = self.__total_from_headers(http_headers)
+            modified = datetime.strptime(
+                value_or(http_headers, "last-modified", "Tue, 01 Jan 1980 12:00:00 GMT"),
+                "%a, %d %b %Y %H:%M:%S %Z",
+            )
+            self.last_modified = (
+                modified.year,
+                modified.month,
+                modified.day,
+                modified.hour,
+                modified.minute,
+                modified.second,
+            )
         except (KeyError, TypeError):
-            self.log.warning ("Could not read metadata for s3://%s/%s",
-                              self.bucket, self.filename)
+            self.log.warning("Could not read metadata for s3://%s/%s", self.bucket, self.filename)
 
-    def __total_from_headers (self, http_headers):
+    def __total_from_headers(self, http_headers):
         """Returns the total object size from 'content-range', else 'content-length'."""
-        content_range = value_or (http_headers, "content-range", None)
+        content_range = value_or(http_headers, "content-range", None)
         if content_range is not None and "/" in content_range:
-            total = content_range.rsplit ("/", 1)[1].strip ()
-            if total.isdigit ():
-                return int (total)
+            total = content_range.rsplit("/", 1)[1].strip()
+            if total.isdigit():
+                return int(total)
         return self.content_length
 
-    def body (self):
+    def body(self):
         """Returns the request body to directly read from."""
         if self.file_contents is None:
-            self.connect ()
+            self.connect()
 
         return self.file_contents
 
-    def iterator (self):
+    def iterator(self):
         """Returns an iterator to read the request body."""
         if self.file_contents is None:
-            self.connect ()
+            self.connect()
 
-        return self.file_contents.iter_chunks (chunk_size=self.chunk_size)
+        return self.file_contents.iter_chunks(chunk_size=self.chunk_size)
 
-    def close (self):
+    def close(self):
         """Closes the file stream and resets the internal state."""
         if self.file_contents is not None:
             self.file_contents.close()
@@ -164,69 +189,74 @@ class S3DownloadStreamer:
         self.etag = None
         self.client = None
 
-    def reset (self, offset=DEFAULT_OFFSET):
+    def reset(self, offset=DEFAULT_OFFSET):
         """Resets the S3 connection and attempt to continue reading at OFFSET.
 
         The previously seen ETag is kept so the reconnect is guarded with
         'IfMatch': serving bytes from a changed object corrupts the download.
         """
         etag = self.etag
-        self.close ()
+        self.close()
         self.etag = etag
         self.offset = offset
-        self.connect ()
+        self.connect()
 
-    def reset_range (self, offset=DEFAULT_OFFSET, end=None):
+    def reset_range(self, offset=DEFAULT_OFFSET, end=None):
         """Resets the connection to read the inclusive byte range [OFFSET, END].
 
         The previously seen ETag is kept so the reconnect is guarded with
         'IfMatch': serving bytes from a changed object corrupts the download.
         """
         etag = self.etag
-        self.close ()
+        self.close()
         self.etag = etag
         self.offset = offset
         self.end = end
-        self.connect ()
+        self.connect()
 
-def s3_file_exists (endpoint, bucket, access_key, secret_key, filename):
+
+def s3_file_exists(endpoint, bucket, access_key, secret_key, filename):
     """Returns True when FILENAME exists in BUCKET, False otherwise."""
     try:
         client = S3ClientFactory.get_client(
-            endpoint=endpoint,
-            access_key=access_key,
-            secret_key=secret_key
+            endpoint=endpoint, access_key=access_key, secret_key=secret_key
         )
-        client.head_object (Bucket=bucket, Key=filename)
+        client.head_object(Bucket=bucket, Key=filename)
         return True
     except PartialCredentialsError:
         logger = logging.getLogger(__name__)
-        logger.warning ("Potential misconfiguration of S3 bucket '%s'.", bucket)
+        logger.warning("Potential misconfiguration of S3 bucket '%s'.", bucket)
         return False
     except ClientError:
         return False
 
-def s3_temporary_file (reader):
+
+def s3_temporary_file(reader):
     """Downloads the S3 file from READER and returns the local filesystem path."""
-    cached_filename = os.path.join (config.s3_cache_storage, str(uuid.uuid4()))
-    with open (cached_filename, "wb") as output_stream:
+    cached_filename = os.path.join(config.s3_cache_storage, str(uuid.uuid4()))
+    with open(cached_filename, "wb") as output_stream:
         retries = 3
         while retries > 0:
             try:
                 for chunk in reader.iterator():
-                    output_stream.write (chunk)
+                    output_stream.write(chunk)
                 retries = 0
             except (ResponseStreamingError, ReadTimeoutError, IncompleteRead):
-                logger = logging.getLogger (__name__)
+                logger = logging.getLogger(__name__)
                 current_offset = reader.body().tell()
-                reader.reset (offset = current_offset)
+                reader.reset(offset=current_offset)
                 retries -= 1
                 if retries > 0:
-                    logger.warning ("Retrying to fetch after %s bytes of %s.",
-                                    current_offset, reader.original_filename)
+                    logger.warning(
+                        "Retrying to fetch after %s bytes of %s.",
+                        current_offset,
+                        reader.original_filename,
+                    )
                     continue
-                logger.error ("Failed to fetch S3 object %s (%s) for ZIP.",
-                              reader.original_filename,
-                              reader.content_length)
+                logger.error(
+                    "Failed to fetch S3 object %s (%s) for ZIP.",
+                    reader.original_filename,
+                    reader.content_length,
+                )
     reader.close()
     return cached_filename

--- a/src/djehuty/web/zipfly.py
+++ b/src/djehuty/web/zipfly.py
@@ -45,7 +45,7 @@ except (ImportError, ModuleNotFoundError):
     S3_ENABLED = False
 
 
-class LargePredictionSize(Exception):
+class LargePredictionSizeError(Exception):
     """Raised when Buffer is larger than ZIP64."""
 
 
@@ -115,7 +115,7 @@ class ZipFly:
 
         zs = sum([end_of_central_directory, file_offset, size_paths])
         if zs > 2147483649:  # (1 << 31) + 1
-            raise LargePredictionSize("File predicted to be larger than the ZIP64 limit.")
+            raise LargePredictionSizeError("File predicted to be larger than the ZIP64 limit.")
 
         return zs
 
@@ -171,10 +171,10 @@ class ZipFly:
                     if self.reproducible_timestamps:
                         z_info.date_time = (1980, 1, 1, 0, 0, 0)
                     """
-                    Zip files on prevalent *nix supports InfoZIP external attributes to encode file mode
-                    including symbolic links with ((attr >> 16) & S_IFMT) == S_IFLNK, i.e. 0120755 << 16,
-                    using u+rwx,g+rx,o+rx conventions. Content of file is symlink destination. Ignored
-                    on platforms that do not support symbolic links.
+                    Zip files on prevalent *nix supports InfoZIP external attributes to encode
+                    file mode including symbolic links with ((attr >> 16) & S_IFMT) == S_IFLNK,
+                    i.e. 0120755 << 16, using u+rwx,g+rx,o+rx conventions. Content of file is
+                    symlink destination. Ignored on platforms that do not support symbolic links.
                     """
                     if os.path.islink(path[self.filesystem]):
                         z_info.external_attr = 0o120755 << 16

--- a/src/djehuty/web/zipfly.py
+++ b/src/djehuty/web/zipfly.py
@@ -30,57 +30,62 @@ conditions of 'zipfly'.
 # -----------------------------------------------------------------------------
 
 import io
-import zipfile
 import logging
 import os
 import stat
-from zipfile import ZipFile, ZipInfo, ZIP_STORED
+import zipfile
+from zipfile import ZIP_STORED, ZipFile, ZipInfo
 
 try:
-    from botocore.exceptions import ResponseStreamingError, ReadTimeoutError
+    from botocore.exceptions import ReadTimeoutError, ResponseStreamingError
     from urllib3.exceptions import IncompleteRead
+
     S3_ENABLED = True
 except (ImportError, ModuleNotFoundError):
     S3_ENABLED = False
 
-class LargePredictionSize (Exception):
+
+class LargePredictionSize(Exception):
     """Raised when Buffer is larger than ZIP64."""
 
-class ZipflyStream (io.RawIOBase):
+
+class ZipflyStream(io.RawIOBase):
     """
     The RawIOBase ABC extends IOBase. It deals with
     the reading and writing of bytes to a stream. FileIO subclasses
     RawIOBase to provide an interface to files in the machine’s file system.
     """
-    def __init__ (self):
+
+    def __init__(self):
         self._buffer = b""
         self._size = 0
 
-    def writable (self):
+    def writable(self):
         """Returns True to signify the stream is writable."""
         return True
 
-    def write (self, b):
+    def write(self, b):
         """Procedure to write a chunk to the opened stream."""
         if self.closed:  # pylint: disable=using-constant-test
             raise RuntimeError("ZipFly stream was closed!")
         self._buffer += b
         return len(b)
 
-    def get (self):
+    def get(self):
         """Procedure to read a chunk from the opened stream."""
         chunk = self._buffer
         self._buffer = b""
         self._size += len(chunk)
         return chunk
 
-    def size (self):
+    def size(self):
         """Returns the current size of the stored stream."""
         return self._size
 
 
 class ZipFly:
     """The core ZipFly class."""
+
     def __init__(self, paths=None, reproducible_timestamps=False):
         """This class implements the main ZipFly functionality."""
         self.log = logging.getLogger(__name__)
@@ -92,68 +97,75 @@ class ZipFly:
         self._buffer_size = None
         self.reproducible_timestamps = reproducible_timestamps
 
-    def buffer_prediction_size (self):
+    def buffer_prediction_size(self):
         """Returns the predicted size for the Zip buffer."""
         end_of_central_directory = int("0x16", 16)
         file_offset = int("0x5e", 16) * len(self.paths)
         size_paths = 0
         for path in self.paths:
             name = self.arcname
-            if not self.arcname in path:
+            if self.arcname not in path:
                 name = self.filesystem
 
             tmp_name = path[name]
-            if tmp_name.startswith ("/"):
-                tmp_name = tmp_name[1:len(tmp_name)]
+            if tmp_name.startswith("/"):
+                tmp_name = tmp_name[1 : len(tmp_name)]
 
             size_paths += (len(tmp_name.encode("utf-8")) - 1) * 2
 
-        zs = sum([end_of_central_directory,file_offset,size_paths])
-        if zs > 2147483649: # (1 << 31) + 1
+        zs = sum([end_of_central_directory, file_offset, size_paths])
+        if zs > 2147483649:  # (1 << 31) + 1
             raise LargePredictionSize("File predicted to be larger than the ZIP64 limit.")
 
         return zs
 
-    def generator (self):
+    def generator(self):
         """Returns a generator to stream-on-the-fly."""
         stream = ZipflyStream()
         with ZipFile(stream, mode="w", compression=ZIP_STORED, allowZip64=True) as zip_stream:
             for path in self.paths:
                 if self.s3_stream in path:
                     if not S3_ENABLED:
-                        self.log.warning ("Unable to process S3 object because 'boto3' is not installed.")
+                        self.log.warning(
+                            "Unable to process S3 object because 'boto3' is not installed."
+                        )
                         continue
                     s3_object = path[self.s3_stream]
                     s3_object.connect()
-                    z_info = ZipInfo.from_file (__file__, s3_object.original_filename)
+                    z_info = ZipInfo.from_file(__file__, s3_object.original_filename)
                     z_info.file_size = s3_object.content_length
                     if not self.reproducible_timestamps:
                         z_info.date_time = s3_object.last_modified
                     else:
                         z_info.date_time = (1980, 1, 1, 0, 0, 0)
                     z_info.external_attr = 33188 << 16  # Unix attributes
-                    with zip_stream.open (z_info, mode="w") as zip_writer:
+                    with zip_stream.open(z_info, mode="w") as zip_writer:
                         retries = 3
                         while retries > 0:
                             try:
                                 for chunk in s3_object.iterator():
-                                    zip_writer.write (chunk)
+                                    zip_writer.write(chunk)
                                     yield stream.get()
                                 retries = 0
                             except (ResponseStreamingError, ReadTimeoutError, IncompleteRead):
                                 current_offset = s3_object.body().tell()
-                                s3_object.reset (offset = current_offset)
+                                s3_object.reset(offset=current_offset)
                                 retries -= 1
                                 if retries > 0:
-                                    self.log.warning ("Retrying to fetch after %s bytes of %s.",
-                                                      current_offset, s3_object.original_filename)
+                                    self.log.warning(
+                                        "Retrying to fetch after %s bytes of %s.",
+                                        current_offset,
+                                        s3_object.original_filename,
+                                    )
                                     continue
-                                self.log.error ("Failed to fetch S3 object %s (%s) for ZIP.",
-                                                s3_object.original_filename,
-                                                s3_object.content_length)
+                                self.log.error(
+                                    "Failed to fetch S3 object %s (%s) for ZIP.",
+                                    s3_object.original_filename,
+                                    s3_object.content_length,
+                                )
                         s3_object.close()
                 elif self.filesystem in path:
-                    if not self.arcname in path:
+                    if self.arcname not in path:
                         path[self.arcname] = path[self.filesystem]
                     z_info = zipfile.ZipInfo.from_file(path[self.filesystem], path[self.arcname])
                     if self.reproducible_timestamps:
@@ -164,16 +176,16 @@ class ZipFly:
                     using u+rwx,g+rx,o+rx conventions. Content of file is symlink destination. Ignored
                     on platforms that do not support symbolic links.
                     """
-                    if os.path.islink( path[self.filesystem] ):
-                        z_info.external_attr = ( 0o120755 << 16 )
+                    if os.path.islink(path[self.filesystem]):
+                        z_info.external_attr = 0o120755 << 16
                         z_info.create_system = 3
-                        zip_stream.writestr(z_info,os.readlink(path[self.filesystem]))
+                        zip_stream.writestr(z_info, os.readlink(path[self.filesystem]))
                     else:
-                        with open (path[self.filesystem], "rb") as e:
+                        with open(path[self.filesystem], "rb") as e:
                             """never include dereferenced content from symbolic links in stream"""
-                            if stat.S_ISLNK( os.fstat(e.fileno()).st_mode ):
+                            if stat.S_ISLNK(os.fstat(e.fileno()).st_mode):
                                 continue
-                            with zip_stream.open (z_info, mode="w") as d:
+                            with zip_stream.open(z_info, mode="w") as d:
                                 for chunk in iter(lambda: e.read(self.chunksize), b""):  # pylint: disable=cell-var-from-loop
                                     d.write(chunk)
                                     yield stream.get()
@@ -184,6 +196,6 @@ class ZipFly:
         self._buffer_size = stream.size()
         stream.close()
 
-    def get_size (self):
+    def get_size(self):
         """Returns the current size of the buffer."""
         return self._buffer_size


### PR DESCRIPTION
> **Note:** Stacked on #173; rebased onto main once #173 merged.

**Summary**

Next slice of the incremental Ruff rollout (#66): lints and formats the `src/djehuty/web/` caching and I/O helpers (`cache.py`, `s3.py`, `zipfly.py`) and adds them to the enforced scope. Split into a mechanical commit (pure `ruff check --fix` + `ruff format` output, safe to skim) and a manual commit (the violations ruff could not auto-fix, worth reviewing).

**Changes**
- `cache.py`, `s3.py`, `zipfly.py` (commit 1, mechanical): apply `ruff check --fix`and `ruff format`. No functional changes.
- `zipfly.py` (commit 2, manual): rewrap one over-long comment block; rename the `LargePredictionSize` exception to `LargePredictionSizeError` (N818).
- `justfile`: add the three files to `lint_paths` so `just lint` and CI enforce them.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Closes #143 (part of #66)

**Screenshots (optional)**

Green CI run on my fork with the Lint job covering the extended scope:
https://github.com/641e16/djehuty/actions/runs/29338189040

**Notes**

-  !! One rename, called out explicitly: `LargePredictionSize` -> `LargePredictionSizeError` (N818). Verified via grep that the
  exception is defined, raised, and referenced only inside `zipfly.py` - nothing else in src/ or tests/ touches it. We could also instead drop the rename in favour of a `# noqa: N818` if you prefer zero renames in lint PRs.
- `zipfly.py` is a diverged simplification of the zipfly library (embedded in 0fe0904a and modified since), doesn't seem to be a tracked vendor copy, so reformatting it doesn't complicate future syncs.  Its original MIT license header is untouched.
- Verified: `just lint` green on the full scope; modules import cleanly; unit tests 157/157. These three files have thin direct test coverage i think.
