### PR TITLE
Feature #41 | Allow register date for physical sample when only the year or the year and month is known and  accept Created and Updated as a date type

### DIFF
--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -3626,9 +3626,13 @@ class SparqlInterface:
         current_time   = datetime.strftime (datetime.now(), "%Y-%m-%dT%H:%M:%SZ")
         date_uuid      = rdf.uri_to_uuid (uri)
 
+        ## Pick a datatype that matches the depositor entered, so
+        ## year (YYYY), a year and month (YYYY-MM) or a full date (YYYY-MM-DD).
+        date_datatype = {4: XSD.gYear, 7: XSD.gYearMonth}.get (len (date), XSD.date)
+
         rdf.add (graph, uri, rdf.DJHT["created_date"], current_time, XSD.dateTime)
         rdf.add (graph, uri, rdf.DJHT["date_type"],    date_type_uri, "uri")
-        rdf.add (graph, uri, rdf.DJHT["date"],         date, XSD.date)
+        rdf.add (graph, uri, rdf.DJHT["date"],         date, date_datatype)
         rdf.add (graph, uri, RDF.type,                 rdf.DJHT["PhysicalSampleDate"], "uri")
 
         if not self.add_triples_from_graph (graph):

--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -55,11 +55,50 @@ jQuery(document).ready(function (){
 #physical-sample-dates tbody tr:first-child td { padding-bottom: .75em; }
 #physical-sample-dates tbody tr:nth-child(2) td { padding-top: 4px; }
 #physical-sample-dates tbody tr { border: none; }
-#date { width: 637pt !important; border-radius: .5em !important; }
 #related-resource { width: 512pt !important; border-radius: .5em !important; }
-#dateType, #identifierType, #relationType { width: 125pt !important; border-radius: .5em !important; }
+#identifierType, #relationType { width: 125pt !important; border-radius: .5em !important; }
 #related-resources input[type="text"], #related-resources select { margin-bottom: 0; }
-#physical-sample-dates input[type="date"], #physical-sample-dates select { margin-bottom: 0; }
+/* Dates — Licence & Access style tabbed panel. */
+#physical-sample-dates-wrapper {
+    border: solid 1pt #aaa;
+    border-radius: 0em .5em .5em .5em;
+    background: #fff;
+    padding: .9em;
+    margin-bottom: 1em;
+}
+#date-format-intro { margin: .1em 0em .7em 0em; color: #333; }
+#physical-sample-dates-wrapper #date-format-tabs {
+    border: none;
+    border-bottom: solid 2pt #333;
+    border-radius: 0em;
+    padding: 0em;
+    margin: 0em 0em 1em 0em;
+    background: none;
+    width: auto;
+}
+#physical-sample-dates-wrapper #date-format-tabs label.no-head {
+    border-radius: .5em .5em 0em 0em;
+    padding: .5em .9em;
+    margin-right: .15em;
+}
+#date-hint { margin: .2em 0em .8em 0em; color: #555; }
+.date-field-grid {
+    display: grid;
+    grid-template-columns: 1fr 180pt auto;
+    gap: .8em;
+    align-items: end;
+}
+#date-entry-panel label.inner-head { display: block; margin-bottom: .15em; }
+#date-entry-panel input[type="text"].date-input,
+#date-entry-panel select#dateType {
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 0;
+}
+#date-entry-panel .add-date-button { align-self: end; }
+#physical-sample-dates { width: 100%; border-collapse: collapse; margin-top: .3em; }
+#physical-sample-dates td { vertical-align: middle; padding: .4em .5em; }
+#physical-sample-dates td:last-child { text-align: right; width: 2em; }
 #categories-wrapper .subitem-checkbox { margin-left: 3em; }
 #expanded-categories { display: none; }
 #groups-wrapper h4 {
@@ -206,14 +245,42 @@ jQuery(document).ready(function (){
   <input type="text" id="latitude" name="latitude" placeholder="Example: 52.893" value="{{object["latitude"] | default("", True)}}" />
 </div>
 
-<label>Dates</label><div class="fas fa-question-circle help-icon"><span class="help-text">Different dates relevant to the physical sample. Enter the date, and select the date type. For depicting date ranges, use the slash mark (/) between the starting date and ending date, e.g. 2010/2012.</span></div>
-<div class="options-wrapper">
-  <table id="physical-sample-dates">
-    <thead>
-      <tr><th>Date</th><th>Type</th><th></th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
+
+<label>Dates</label><div class="fas fa-question-circle help-icon"><span class="help-text">This property may be used to log events relevant to the physical sample. Enter the date, and select the date type.</span></div>
+<div id="physical-sample-dates-wrapper">
+  <p id="date-format-intro">Choose the format matches the date you want to enter (full date, month, or year), enter the value, and select the date type:</p>
+  <div id="date-format-tabs" class="options-wrapper">
+    <input type="radio" name="dateFormat" id="format-day" value="day" checked="checked" />
+    <label class="no-head" for="format-day">Full date</label>
+    <input type="radio" name="dateFormat" id="format-month" value="month" />
+    <label class="no-head" for="format-month">Month</label>
+    <input type="radio" name="dateFormat" id="format-year" value="year" />
+    <label class="no-head" for="format-year">Year</label>
+  </div>
+  <div id="date-entry-panel">
+    <p class="date-hint" id="date-hint"></p>
+    <div class="date-field-grid">
+      <div class="date-field">
+        <label class="inner-head">Date</label>
+        <input type="text" id="date-year" class="date-input" placeholder="yyyy" inputmode="numeric" autocomplete="off" />
+        <input type="text" id="date-month" class="date-input" placeholder="mm/yyyy" inputmode="numeric" autocomplete="off" />
+        <input type="text" id="date-day" class="date-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
+      </div>
+      <div class="date-field">
+        <label class="inner-head">Type</label>
+        <select name="dateType" id="dateType">
+          <option value="" disabled="disabled" selected="selected">Date type</option>
+          <option value="collected">Collected</option>
+          <option value="created">Created</option>
+          <option value="destroyed">Destroyed</option>
+          <option value="updated">Updated</option>
+          <option value="other">Other</option>
+        </select>
+      </div>
+      <a class="form-button corporate-identity-standard-button add-date-button" href="#">Add</a>
+    </div>
+  </div>
+  <table id="physical-sample-dates"><tbody></tbody></table>
 </div>
 
 <h3 class="corporate-identity-h3">Linked resource &amp; references</h3>

--- a/src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql
@@ -1,6 +1,6 @@
 {% extends "prefixes.sparql" %}
 {% block query %}
-SELECT DISTINCT ?uuid ?date ?date_type ?created_date
+SELECT DISTINCT ?uuid (STR(?date_raw) AS ?date) ?date_type ?created_date
                 (?rest AS ?originating_blank_node) ?order_index
 WHERE {
   GRAPH <{{state_graph}}> {
@@ -17,7 +17,7 @@ WHERE {
 
     ?date_entry        djht:date_type           ?date_type_uri .
     ?date_type_uri     rdfs:label               ?date_type .
-    ?date_entry        djht:date                ?date .
+    ?date_entry        djht:date                ?date_raw .
     ?date_entry        djht:created_date        ?created_date .
 
     {%- if account_uuid is not none %}

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -438,11 +438,114 @@ function remove_date (date_uuid, container_uuid) {
       .fail(function () { show_message ("failure", "<p>Failed to remove date.</p>"); });
 }
 
-function add_date (container_uuid) {
-    let data = {
-        "date": or_null(jQuery("#date").val()),
-        "type": or_null(jQuery("#dateType").val())
+function set_date_format (format) {
+    // Show only the picker for the chosen format and clear the others and update the tip.
+    let hints = {
+        "year":  "Enter the year only.",
+        "month": "Enter the month and year.",
+        "day":   "Enter the full calendar date."
     };
+    jQuery("#date-year, #date-month, #date-day").hide().val("");
+    if (format === "year") { jQuery("#date-year").show(); }
+    else if (format === "month") { jQuery("#date-month").show(); }
+    else { jQuery("#date-day").show(); }
+    jQuery("#date-hint").text (hints[format] || "");
+}
+
+function get_new_date_value () {
+    let format = jQuery("input[name='dateFormat']:checked").val();
+    if (format === "year") { return or_null(jQuery("#date-year").val()); }
+    if (format === "month") { return or_null(jQuery("#date-month").val()); }
+    return or_null(jQuery("#date-day").val());
+}
+
+function auto_format_date (input, format) {
+    // Keep only digits and re-insert the "/" separators as the user types
+    let digits = input.value.replace(/\D/g, "");
+    let out = "";
+    if (format === "year") {
+        out = digits.slice(0, 4);
+    } else if (format === "month") {
+        digits = digits.slice(0, 6);
+        out = digits.slice(0, 2);
+        if (digits.length > 2) { out += "/" + digits.slice(2); }
+    } else {
+        digits = digits.slice(0, 8);
+        out = digits.slice(0, 2);
+        if (digits.length > 2) { out += "/" + digits.slice(2, 4); }
+        if (digits.length > 4) { out += "/" + digits.slice(4); }
+    }
+    input.value = out;
+}
+
+function to_iso_date (format, raw) {
+    // Convert the "user friendly" day first input to ISO (year-first).
+    // Returns the ISO string, or false when the value is not a valid date.
+    let value = raw.trim();
+    if (format === "year") {
+        return (/^\d{4}$/.test(value)) ? value : false;
+    }
+
+    let parts = value.split("/");
+    if (format === "month") {
+        if (parts.length !== 2) { return false; }
+        let [mm, yyyy] = parts;
+        let month = parseInt(mm, 10);
+        if (!(/^\d{4}$/.test(yyyy)) || month < 1 || month > 12) { return false; }
+        return `${yyyy}-${String(month).padStart(2, "0")}`;
+    }
+
+    if (parts.length !== 3) { return false; }
+    let [dd, mm, yyyy] = parts;
+    let day = parseInt(dd, 10);
+    let month = parseInt(mm, 10);
+    if (!(/^\d{4}$/.test(yyyy)) || month < 1 || month > 12 || day < 1 || day > 31) {
+        return false;
+    }
+    let iso = `${yyyy}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+    // Reject impossible calendar dates such as 31/02/2024.
+    let check = new Date(`${iso}T00:00:00Z`);
+    if (check.getUTCMonth() + 1 !== month || check.getUTCDate() !== day) { return false; }
+    return iso;
+}
+
+function format_display_date (iso) {
+    if (iso === null || iso === undefined || iso === "") { return ""; }
+    let months = ["January", "February", "March", "April", "May", "June",
+                  "July", "August", "September", "October", "November", "December"];
+    let parts = String(iso).split("-");
+    let year = parts[0];
+    if (parts.length < 2) { return year; }
+    let month_name = months[parseInt(parts[1], 10) - 1] || parts[1];
+    if (parts.length < 3) { return `${month_name} ${year}`; }
+    return `${parseInt(parts[2], 10)} ${month_name} ${year}`;
+}
+
+function add_date (container_uuid) {
+    let format  = jQuery("input[name='dateFormat']:checked").val();
+    let raw_value  = get_new_date_value ();
+    let type_value = or_null(jQuery("#dateType").val());
+
+    if (raw_value === null) {
+        show_message ("failure", "<p>Enter a date before adding it.</p>");
+        return;
+    }
+    let iso_value = to_iso_date (format, raw_value);
+    if (iso_value === false) {
+        let hints = {
+            "year":  "yyyy, for example 2024",
+            "month": "mm/yyyy, for example 05/2024",
+            "day":   "dd/mm/yyyy, for example 17/05/2024"
+        };
+        show_message ("failure", `<p>Enter the date as ${hints[format]}.</p>`);
+        return;
+    }
+    if (type_value === null) {
+        show_message ("failure", "<p>Select a date type before adding it.</p>");
+        return;
+    }
+
+    let data = { "date": iso_value, "type": type_value };
 
     jQuery.ajax({
         url:         `/v3/physical-samples/${container_uuid}/dates`,
@@ -451,6 +554,9 @@ function add_date (container_uuid) {
         accept:      "application/json",
         data:        JSON.stringify([data]),
     }).done(function () {
+        // Reset the entry fields and refresh the list below.
+        jQuery("#date-year, #date-month, #date-day").val("");
+        jQuery("#dateType").val("");
         render_dates (container_uuid);
     }).fail(function () {
         show_message ("failure", `<p>Failed to add date. Try again later.</p>`);
@@ -464,26 +570,19 @@ function render_dates (container_uuid) {
         type:        "GET",
         accept:      "application/json",
     }).done(function (dates) {
+        // Render the list of dates already added to the data.
         jQuery("#physical-sample-dates tbody").empty();
 
-        let row = '<tr><td><input type="text" name="date" id="date" ';
-        row += 'placeholder="YYYY-MM-DD, YYYY-MM or YYYY" ';
-        row += 'pattern="\\d{4}(-\\d{2}(-\\d{2})?)?" ';
-        row += 'title="Enter a full date (YYYY-MM-DD), a year and month (YYYY-MM), or only a year (YYYY)." /></td>';
-        row += '<td><select name="dateType" id="dateType">';
-        row += '<option value="" disabled="disabled" selected="selected">Date type</option>';
-        row += '<option value="collected">Collected</option>';
-        row += '<option value="created">Created</option>';
-        row += '<option value="destroyed">Destroyed</option>';
-        row += '<option value="updated">Updated</option>';
-        row += '<option value="other">Other</option>';
-        row += '</select></td>';
-        row += '<td><a class="form-button corporate-identity-standard-button add-date-button" href="#">Add</a></td></tr>';
-        jQuery("#physical-sample-dates tbody").append(row);
+        // Sort by the date value chronologically.
+        dates.sort (function (a, b) {
+            if (a.date < b.date) { return 1; }
+            if (a.date > b.date) { return -1; }
+            return 0;
+        });
 
         for (let date_entry of dates) {
-            // Reverse the ISO parts to day-first: 2010, 05-2010 or 17-05-2010.
-            let display_date = date_entry.date.split("-").reverse().join("-");
+            // Show dates with the month spelled e.g. "2010", "May 2010" or "17 May 2010".
+            let display_date = format_display_date (date_entry.date);
             let row = `<tr><td>${display_date}</td>`;
             row += `<td><span class="resource-badge date-type">${date_entry.type}</span></td>`;
             row += `<td><a href="#" data-uuid="${date_entry.uuid}" `;
@@ -716,14 +815,22 @@ function activate (container_uuid, callback=jQuery.noop) {
         event.preventDefault();
         remove_related_resource (jQuery(this).data("uuid"), container_uuid);
     });
-    jQuery("#physical-sample-dates").on("click", ".add-date-button", function (event) {
+    jQuery("#physical-sample-dates-wrapper").on("change", "input[name='dateFormat']", function () {
+        set_date_format (jQuery(this).val());
+    });
+    jQuery("#physical-sample-dates-wrapper").on("input", ".date-input", function () {
+        auto_format_date (this, jQuery("input[name='dateFormat']:checked").val());
+    });
+    jQuery("#physical-sample-dates-wrapper").on("click", ".add-date-button", function (event) {
         event.preventDefault();
         add_date (container_uuid);
     });
-    jQuery("#physical-sample-dates").on("click", ".remove-date", function (event) {
+    jQuery("#physical-sample-dates-wrapper").on("click", ".remove-date", function (event) {
         event.preventDefault();
         remove_date (jQuery(this).data("uuid"), container_uuid);
     });
+    // Set the initial format date (Full date) once the static markup exists.
+    set_date_format (jQuery("input[name='dateFormat']:checked").val());
     render_tags (container_uuid);
     render_categories_for_physical_sample (container_uuid);
     jQuery("#expand-categories-button").on("click", toggle_categories);

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -470,7 +470,9 @@ function render_dates (container_uuid) {
         row += '<td><select name="dateType" id="dateType">';
         row += '<option value="" disabled="disabled" selected="selected">Date type</option>';
         row += '<option value="collected">Collected</option>';
+        row += '<option value="created">Created</option>';
         row += '<option value="destroyed">Destroyed</option>';
+        row += '<option value="updated">Updated</option>';
         row += '<option value="other">Other</option>';
         row += '</select></td>';
         row += '<td><a class="form-button corporate-identity-standard-button add-date-button" href="#">Add</a></td></tr>';

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -466,7 +466,10 @@ function render_dates (container_uuid) {
     }).done(function (dates) {
         jQuery("#physical-sample-dates tbody").empty();
 
-        let row = '<tr><td><input type="date" name="date" id="date" /></td>';
+        let row = '<tr><td><input type="text" name="date" id="date" ';
+        row += 'placeholder="YYYY-MM-DD, YYYY-MM or YYYY" ';
+        row += 'pattern="\\d{4}(-\\d{2}(-\\d{2})?)?" ';
+        row += 'title="Enter a full date (YYYY-MM-DD), a year and month (YYYY-MM), or only a year (YYYY)." /></td>';
         row += '<td><select name="dateType" id="dateType">';
         row += '<option value="" disabled="disabled" selected="selected">Date type</option>';
         row += '<option value="collected">Collected</option>';
@@ -479,8 +482,9 @@ function render_dates (container_uuid) {
         jQuery("#physical-sample-dates tbody").append(row);
 
         for (let date_entry of dates) {
-            let [y, m, d] = date_entry.date.split("-");
-            let row = `<tr><td>${d}-${m}-${y}</td>`;
+            // Reverse the ISO parts to day-first: 2010, 05-2010 or 17-05-2010.
+            let display_date = date_entry.date.split("-").reverse().join("-");
+            let row = `<tr><td>${display_date}</td>`;
             row += `<td><span class="resource-badge date-type">${date_entry.type}</span></td>`;
             row += `<td><a href="#" data-uuid="${date_entry.uuid}" `;
             row += `class="remove-date fas fa-trash-can" title="Remove"></a></td></tr>`;

--- a/src/djehuty/web/validator.py
+++ b/src/djehuty/web/validator.py
@@ -378,6 +378,40 @@ def date_value (record, field_name, required=False, error_list=None):
 
     return value
 
+def partial_date_value (record, field_name, required=False, error_list=None):
+    """
+    Validation procedure for dates of partial values.  Accepts a full date
+    (YYYY-MM-DD), a year and month (YYYY-MM), or only a year (YYYY).
+    """
+
+    value = record if field_name is None else conv.value_or_none (record, field_name)
+    if value is None:
+        if required:
+            return raise_or_return_error (error_list,
+                        MissingRequiredField(
+                            field_name = field_name,
+                            message = f"Missing required value for '{field_name}'.",
+                            code    = "MissingRequiredField"))
+        return None
+
+    if not isinstance (value, str):
+        return raise_or_return_error (error_list,
+                    InvalidValueType(
+                        field_name = field_name,
+                        message = f"Expected '{field_name}' in the form YYYY, YYYY-MM or YYYY-MM-DD.",
+                        code    = "WrongValueType"))
+
+    ## Check its form: YYYY, YYYY-MM or YYYY-MM-DD.
+    pattern = "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$"
+    if re.match(pattern, value) is None:
+        return raise_or_return_error (error_list,
+                    InvalidValueType(
+                        field_name = field_name,
+                        message = f"Expected '{field_name}' in the form YYYY, YYYY-MM or YYYY-MM-DD.",
+                        code    = "WrongValueFormat"))
+
+    return value
+
 def boolean_value (record, field_name, required=False, when_none=None, error_list=None):
     """
     Validation procedure for boolean values.  If FIELD_NAME is None, it expects

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3602,7 +3602,7 @@ class WebServer:
             record = request.get_json()
             ## "issued" is intentionally omitted: the Issued date is set
             ## automatically to the publication date and cannot be entered by hand.
-            types  = ["collected", "destroyed", "other"]
+            types  = ["collected", "created", "destroyed", "updated", "other"]
             errors = []
 
             if not isinstance (record, list):

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -3611,7 +3611,7 @@ class WebServer:
 
             for date_record in record:
                 date_type = validator.options_value (date_record, "type", types, True, errors)
-                date      = validator.date_value (date_record, "date", True, errors)
+                date      = validator.partial_date_value (date_record, "date", True, errors)
                 if date_type is not None and date is not None:
                     if self.db.add_date_to_physical_sample (container_uuid,
                                                             date_type,

--- a/src/djehuty/web/xml_formatter.py
+++ b/src/djehuty/web/xml_formatter.py
@@ -363,7 +363,9 @@ def datacite (parameters, indent=True):
 ## mapped to "Other".
 DATACITE_SAMPLE_DATE_TYPES = {
     "Collected": "Collected",
+    "Created":   "Created",
     "Issued":    "Issued",
+    "Updated":   "Updated",
     "Other":     "Other",
     "Destroyed": "Other",
 }


### PR DESCRIPTION
**Summary**

We would like to let depositors register a date for physical sample when only the year or the
year and month is known and also accept Created and Updated as a date type.

**Changes**
- src/djehuty/web/validator.py: Accept dates in the form YYYY, YYYY-MM or
  YYYY-MM-DD.
- src/djehuty/web/wsgi.py: Validate physical sample dates with the variable
  format rule.
- src/djehuty/web/database.py: Store each date with the datatype matching
  its format.
- src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql:
  Return the date as a string value regardless of datatype.
- src/djehuty/web/resources/static/js/edit-physical-sample.js:
  Accept and display dates of any format.
- src/djehuty/web/resources/static/js/edit-physical-sample.js: Add Created
  and Updated in the date type dropdown.
- src/djehuty/web/xml_formatter.py: Map the new date types to DataCite.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue**

Part of #41 

**Screenshots**

After
<img width="700"  alt="image" src="https://github.com/user-attachments/assets/c2ab3523-50bc-4611-a2c6-a3541aa280ab" />

**Notes**

Forked fom wip-feat-41-igsn-fix-draft