### PR TITLE
web: Add djehuty version to the footer.

### DIFF
--- a/src/djehuty/web/config/runtime.py
+++ b/src/djehuty/web/config/runtime.py
@@ -82,6 +82,7 @@ class RuntimeConfiguration:  # pylint: disable=too-few-public-methods
             "</p></div>"
         )
         self.large_footer = self.small_footer
+        self.djehuty_version = ""
         self.orcid_client_id = None
         self.orcid_client_secret = None
         self.orcid_endpoint = None

--- a/src/djehuty/web/resources/html_templates/layout.html
+++ b/src/djehuty/web/resources/html_templates/layout.html
@@ -127,6 +127,9 @@
       {%- else %}
       {{small_footer | safe}}
       {%- endif %}
+      {%- if djehuty_version %}
+      <p style="text-align: right;">Djehuty v<strong>{{djehuty_version}}</strong></p>
+      {%- endif %}
     </div>
   </body>
 </html>

--- a/src/djehuty/web/resources/html_templates/layout.html
+++ b/src/djehuty/web/resources/html_templates/layout.html
@@ -128,7 +128,7 @@
       {{small_footer | safe}}
       {%- endif %}
       {%- if djehuty_version %}
-      <p style="text-align: right;">Djehuty v<strong>{{djehuty_version}}</strong></p>
+      <p class="djehuty-version">Djehuty v{{djehuty_version}}</p>
       {%- endif %}
     </div>
   </body>

--- a/src/djehuty/web/resources/static/css/main.css
+++ b/src/djehuty/web/resources/static/css/main.css
@@ -355,6 +355,11 @@ pre {
     padding: 0mm 0mm 0mm 5mm;
     text-align: left;
 }
+#footer .djehuty-version {
+    padding-bottom: 0.5em;
+    font-size: 10pt;
+}
+
 p.cts { text-align: right; }
 img.cts { width: 120px; }
 

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -1,5 +1,6 @@
 """This module contains the command-line interface for the 'web' subcommand."""
 
+import importlib.metadata
 import json
 import logging
 import os
@@ -1259,6 +1260,8 @@ def main (config_file=None, run_internal_server=True, initialize=True,
 
         if perform_export:
             return perform_rdf_export (logger, server, full_rdf_export)
+
+        config.djehuty_version = importlib.metadata.version("djehuty")
 
         if not run_internal_server:
             config.using_uwsgi = True

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -535,6 +535,7 @@ class WebServer:
             "is_logged_in":        account is not None,
             "may_deposit":         self.db.is_depositor (token, account),
             "large_footer":        config.large_footer,
+            "djehuty_version":     config.djehuty_version,
             "maintenance_mode":    config.maintenance_mode,
             "menu":                config.menu,
             "orcid_client_id":     config.orcid_client_id,

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -5,6 +5,8 @@ Run with:
     cd tests/e2e && python -m pytest tests/test_smoke.py -v
 """
 
+import importlib.metadata
+
 import pytest
 from playwright.sync_api import Page, expect
 
@@ -41,6 +43,12 @@ class TestSmoke:
         screenshot(page, "portal-with-title")
         expect(page).not_to_have_title("")
 
+    def test_footer_version(self, page: Page, screenshot):
+        """The footer should show the installed djehuty version."""
+        true_version = importlib.metadata.version("djehuty")
+        page.goto("/portal")
+        screenshot(page, "portal-footer-version")
+        expect(page.locator("#footer")).to_contain_text(f"Djehuty v{true_version}")
 
 @pytest.mark.smoke
 class TestPageObjects:


### PR DESCRIPTION
**Summary**
Displays the currently installed djehuty version in the site footer, so it remains visible even when an instance injects some custom large/small footer HTML via configs. Version is derived from the installed package version at startup, ensuring that the value is always reflective of the true version. 

**Changes**
- src/djehuty/web/config/runtime.py: Add new `djehuty_version` to runtime config.
- src/djehuty/web/ui.py: Assign `djehuty_version` a value in main() along with other startup parameters.
- src/djehuty/web/wsgi.py: Add `djehuty_version` to `__render_template` parameters.
- src/djehuty/web/resources/html_templates/layout.html: Render `djehuty_version` in an html paragraph block bottommost in the `footer` div.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**
Closes #192

**Screenshots (optional)**
<img width="982" height="136" alt="image" src="https://github.com/user-attachments/assets/135ea018-4928-4fd5-9772-6811ac22ba23" />


**Notes (optional)**
- Ground truth version value is derived from `importlib.metadata.version`, which is what is used by other version collecting helper functions. 
- The regression test uses this value to check that the installed djehuty version matches what's rendered in the footer. The version is assigned once at startup in `web/ui.py`'s `main()` and passed alongside all other render parameters on every request. This should make a stale value unlikely. The only case I can think of is in the instance's hosting uses an explicit caching layer (e.g. Content Delivery Network), which Playwright wouldn't catch.