### PR TITLE
docs: remove documentation section in README.md

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,15 @@
 name: Docs
 
+
 # Builds the MkDocs documentation and publishes it to the gh-pages
 # branch, which GitHub Pages serves.
-#
+
 # Only the Markdown docs are built here for now! When the API docs
 # (Swagger/OpenAPI) and ontology docs exist, add their build steps
 # here too, writing into their own subfolder of `site/` (e.g.
 # site/api/, site/ontology/) before the publish step runs, so the
 # whole site is assembled and published atomically in one go.
+
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -141,23 +141,6 @@ stack used locally, so a green `just test` on your laptop reproduces
 what CI sees. Screenshots are captured on failure and uploaded as
 artifacts; coverage from each shard is combined into a single report.
 
-## Documentation
-
-The documentation source lives in `docs/`. It is built with
-[MkDocs](https://www.mkdocs.org/) using the Material theme.
-
-To preview the docs locally with live reload:
-
-```bash
-just docs-md-serve
-```
-
-To build a static site into `site/`:
-
-```bash
-just docs-md
-```
-
 ---
 ### Contact information
 - **Maintainers**: a.e.wilczynska@tudelft.nl, g.kuhn@tudelft.nl, k.f.deAraujo@tudelft.nl


### PR DESCRIPTION
**Summary**

Removed the documentation section in README.md as it was prematurely added. 

**Changes**
- README.md: documentation section removed.
- docs.yml: fixed indentation.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Not associated with any issue in particular. Revisted after PR #169 .

**Notes (optional)**

- Cleaner to leave it out of the README until there's a real hosted URL to point people to, which at that point will need changes to display the URL to documentation.