### PR TITLE
Feature #41 |  Support date ranges for physical samples.

### DIFF
--- a/src/djehuty/utils/convenience.py
+++ b/src/djehuty/utils/convenience.py
@@ -213,11 +213,31 @@ def deduplicate_list(alist):
     except TypeError:
         logging.error("Wrong type of %s in deduplicate_list", alist)
         return None
+def day_first_date (date_value):
+    """
+    Return the partial date DATE_VALUE with its parts in day-first order, so
+    2010 stays 2010, while 2010-05 becomes 05-2010 and 2010-05-17 becomes
+    17-05-2010.
+    """
+    if not date_value:
+        return ""
 
+    return "-".join (reversed (str(date_value).split("-")))
 
-def make_citation(
-    authors, year, title, version, item_type, doi, publisher="4TU.ResearchData", max_cited_authors=5
-):
+def date_or_range (date_value, date_end=None, separator=" – "):
+    """
+    Return the day-first notation of DATE_VALUE, or of the range that starts at
+    DATE_VALUE and ends at DATE_END when the latter is set.
+    """
+    start = day_first_date (date_value)
+    end   = day_first_date (date_end)
+    if not end:
+        return start
+
+    return f"{start}{separator}{end}"
+
+def make_citation (authors, year, title, version, item_type, doi,
+                   publisher='4TU.ResearchData', max_cited_authors=5):
     """Return citation in standard Datacite format."""
     try:
         auths = [

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -154,6 +154,15 @@ class SparqlInterface:
 
         return template.render ({ **args, **parameters })
 
+    def __date_datatype (self, date):
+        """Returns the datatype matching the precision of the partial date DATE."""
+
+        if date is None:
+            return None
+
+        ## A year (YYYY), a year and month (YYYY-MM) or a full date (YYYY-MM-DD).
+        return {4: XSD.gYear, 7: XSD.gYearMonth}.get (len (date), XSD.date)
+
     def __run_logged_query (self, query):
         """Passthrough for '__run_query' that handles the audit log feature."""
 
@@ -3534,7 +3543,8 @@ class SparqlInterface:
             if self.add_date_to_physical_sample (container_uuid,
                                                  conv.value_or (date, "date_type", "other"),
                                                  conv.value_or_none (date, "date"),
-                                                 account_uuid) is None:
+                                                 account_uuid,
+                                                 conv.value_or_none (date, "date_end")) is None:
                 self.log.error ("Failed to copy date %s into draft %s.",
                                 conv.value_or_none (date, "uuid"), draft_uuid)
 
@@ -3617,8 +3627,13 @@ class SparqlInterface:
         })
         return self.__run_query (query)
 
-    def add_date_to_physical_sample (self, container_uuid, date_type, date, account_uuid):
-        """Adds a date to a physical sample."""
+    def add_date_to_physical_sample (self, container_uuid, date_type, date,
+                                     account_uuid, date_end=None):
+        """Adds a date or a range of dates to a physical sample.
+
+        Set DATE_END for a range, where DATE is the start.  The two are stored
+        apart so that both stay real dates.
+        """
 
         graph          = Graph()
         uri            = rdf.unique_node ("physical-sample-date")
@@ -3626,13 +3641,10 @@ class SparqlInterface:
         current_time   = datetime.strftime (datetime.now(), "%Y-%m-%dT%H:%M:%SZ")
         date_uuid      = rdf.uri_to_uuid (uri)
 
-        ## Pick a datatype that matches the depositor entered, so
-        ## year (YYYY), a year and month (YYYY-MM) or a full date (YYYY-MM-DD).
-        date_datatype = {4: XSD.gYear, 7: XSD.gYearMonth}.get (len (date), XSD.date)
-
         rdf.add (graph, uri, rdf.DJHT["created_date"], current_time, XSD.dateTime)
         rdf.add (graph, uri, rdf.DJHT["date_type"],    date_type_uri, "uri")
-        rdf.add (graph, uri, rdf.DJHT["date"],         date, date_datatype)
+        rdf.add (graph, uri, rdf.DJHT["date"],         date, self.__date_datatype (date))
+        rdf.add (graph, uri, rdf.DJHT["date_end"],     date_end, self.__date_datatype (date_end))
         rdf.add (graph, uri, RDF.type,                 rdf.DJHT["PhysicalSampleDate"], "uri")
 
         if not self.add_triples_from_graph (graph):

--- a/src/djehuty/web/formatter.py
+++ b/src/djehuty/web/formatter.py
@@ -692,6 +692,7 @@ def format_physical_sample_date_record (record):
         "uuid":          conv.value_or_none (record, "uuid"),
         "type":          conv.value_or_none (record, "date_type"),
         "date":          conv.value_or_none (record, "date"),
+        "date_end":      conv.value_or_none (record, "date_end"),
         "created_date":  conv.value_or_none (record, "created_date")
     }
 

--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -52,13 +52,11 @@ jQuery(document).ready(function (){
 #related-resources tbody tr:first-child td { padding-bottom: .75em; }
 #related-resources tbody tr:nth-child(2) td { padding-top: 4px; }
 #related-resources tbody tr { border: none; }
-#physical-sample-dates tbody tr:first-child td { padding-bottom: .75em; }
-#physical-sample-dates tbody tr:nth-child(2) td { padding-top: 4px; }
-#physical-sample-dates tbody tr { border: none; }
+#physical-sample-dates tbody tr { border: none; border-bottom: solid 1pt #f0f0f0; }
 #related-resource { width: 512pt !important; border-radius: .5em !important; }
 #identifierType, #relationType { width: 125pt !important; border-radius: .5em !important; }
 #related-resources input[type="text"], #related-resources select { margin-bottom: 0; }
-/* Dates — Licence & Access style tabbed panel. */
+/* Dates — the format of the value, then the value, then what it marks. */
 #physical-sample-dates-wrapper {
     border: solid 1pt #aaa;
     border-radius: 0em .5em .5em .5em;
@@ -67,6 +65,20 @@ jQuery(document).ready(function (){
     margin-bottom: 1em;
 }
 #date-format-intro { margin: .1em 0em .7em 0em; color: #333; }
+#date-hint { margin: .2em 0em .8em 0em; color: #555; }
+#physical-sample-dates-wrapper .date-cap {
+    display: block;
+    background: none;
+    border: 0pt;
+    border-radius: 0pt;
+    padding: 0em;
+    margin: 0em 0em .35em 0em;
+    font-size: .7em;
+    font-weight: bold;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+    color: #5a5a5a;
+}
 #physical-sample-dates-wrapper #date-format-tabs {
     border: none;
     border-bottom: solid 2pt #333;
@@ -81,41 +93,54 @@ jQuery(document).ready(function (){
     padding: .5em .9em;
     margin-right: .15em;
 }
-#date-hint { margin: .2em 0em .8em 0em; color: #555; }
 .date-field-grid {
     display: grid;
-    grid-template-columns: 1fr 180pt auto;
+    grid-template-columns: 1fr 175pt auto;
     gap: .8em;
     align-items: end;
 }
-#date-entry-panel label.inner-head { display: block; margin-bottom: .15em; }
+/* A range keeps its format, start and end on one line, so the type and the
+   button stay level with them instead of dropping to the bottom of the panel. */
+#date-range-fields { display: none; }
+#date-entry-panel.is-range #date-range-fields {
+    display: grid;
+    grid-template-columns: 110pt 1fr 1fr;
+    gap: .8em;
+    align-items: end;
+}
+#date-entry-panel.is-range #date-single,
+#date-entry-panel.is-range #date-single-cap { display: none; }
+#date-range-fields select.date-range-format,
 #date-entry-panel input[type="text"].date-input,
 #date-entry-panel select#dateType {
     width: 100%;
     box-sizing: border-box;
     margin-bottom: 0;
 }
+/* A select is taller than an input, which would stagger the captions above them. */
+#date-range-fields select.date-range-format,
+#date-entry-panel input[type="text"].date-input,
+#date-entry-panel select#dateType { height: 2.5em; }
+#date-entry-panel input[type="text"].date-input { font-family: monospace; }
+#date-entry-panel select#dateType { max-width: 175pt; }
 #date-entry-panel .add-date-button { align-self: end; }
-/* Dates -> the format of the range, then its start and its end. */
-#date-range-fields { display: none; }
-#date-range-fields .date-range-row {
-    display: grid;
-    grid-template-columns: 4.5em 1fr;
-    gap: .5em;
-    align-items: center;
-    margin-bottom: .4em;
+#physical-sample-dates { width: 100%; border-collapse: collapse; margin-top: 1.2em; }
+#physical-sample-dates thead th {
+    font-size: .7em;
+    font-weight: bold;
+    letter-spacing: .09em;
+    text-transform: uppercase;
+    color: #5a5a5a;
+    border-bottom: solid 1pt #e4e4e4;
+    padding: 0em .5em .3em .5em;
 }
-#date-range-fields .date-range-row:last-child { margin-bottom: 0em; }
-#date-range-fields label.inner-head { margin-bottom: 0em; }
-#date-entry-panel select.date-range-format {
-    width: 100%;
-    max-width: 110pt;
-    box-sizing: border-box;
-    margin-bottom: 0;
-}
-#physical-sample-dates { width: 100%; border-collapse: collapse; margin-top: .3em; }
 #physical-sample-dates td { vertical-align: middle; padding: .4em .5em; }
 #physical-sample-dates td:last-child { text-align: right; width: 2em; }
+@media (max-width: 900px) {
+    .date-field-grid { grid-template-columns: 1fr; }
+    #date-entry-panel.is-range #date-range-fields { grid-template-columns: 1fr; }
+    #date-entry-panel select#dateType { max-width: none; }
+}
 #categories-wrapper .subitem-checkbox { margin-left: 3em; }
 #expanded-categories { display: none; }
 #groups-wrapper h4 {
@@ -265,7 +290,7 @@ jQuery(document).ready(function (){
 
 <label>Dates</label><div class="fas fa-question-circle help-icon"><span class="help-text">This property may be used to log events relevant to the physical sample. Enter the date, and select the date type. A period is entered as a range, of which the start and the end are entered in the same format.</span></div>
 <div id="physical-sample-dates-wrapper">
-  <p id="date-format-intro">Choose the format matches the date you want to enter (full date, month, year, or a range), enter the value, and select the date type:</p>
+  <p id="date-format-intro">Choose the format that matches the date you want to enter, enter the value, and select the date type:</p>
   <div id="date-format-tabs" class="options-wrapper">
     <input type="radio" name="dateFormat" id="format-day" value="day" checked="checked" />
     <label class="no-head" for="format-day">Full date</label>
@@ -280,33 +305,31 @@ jQuery(document).ready(function (){
     <p class="date-hint" id="date-hint"></p>
     <div class="date-field-grid">
       <div class="date-field">
-        <label class="inner-head">Date</label>
-        <input type="text" id="date-year" class="date-input" placeholder="yyyy" inputmode="numeric" autocomplete="off" />
-        <input type="text" id="date-month" class="date-input" placeholder="mm/yyyy" inputmode="numeric" autocomplete="off" />
-        <input type="text" id="date-day" class="date-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
+        <label class="date-cap" id="date-single-cap" for="date-single">Date</label>
+        <input type="text" id="date-single" class="date-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
         <div id="date-range-fields">
-          <div class="date-range-row">
-            <label class="inner-head" for="date-range-format">Format</label>
+          <div class="date-range-field">
+            <label class="date-cap" for="date-range-format">Format</label>
             <select id="date-range-format" class="date-range-format">
               <option value="day">Full date</option>
               <option value="month">Month</option>
               <option value="year">Year</option>
             </select>
           </div>
-          <div class="date-range-row">
-            <label class="inner-head" for="date-range-start">From</label>
+          <div class="date-range-field">
+            <label class="date-cap" for="date-range-start">From</label>
             <input type="text" id="date-range-start" class="date-input date-range-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
           </div>
-          <div class="date-range-row">
-            <label class="inner-head" for="date-range-end">To</label>
+          <div class="date-range-field">
+            <label class="date-cap" for="date-range-end">To</label>
             <input type="text" id="date-range-end" class="date-input date-range-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
           </div>
         </div>
       </div>
       <div class="date-field">
-        <label class="inner-head">Type</label>
+        <label class="date-cap" for="dateType">Date type</label>
         <select name="dateType" id="dateType">
-          <option value="" disabled="disabled" selected="selected">Date type</option>
+          <option value="" disabled="disabled" selected="selected">Choose a type</option>
           <option value="collected">Collected</option>
           <option value="created">Created</option>
           <option value="destroyed">Destroyed</option>
@@ -317,7 +340,10 @@ jQuery(document).ready(function (){
       <a class="form-button corporate-identity-standard-button add-date-button" href="#">Add</a>
     </div>
   </div>
-  <table id="physical-sample-dates"><tbody></tbody></table>
+  <table id="physical-sample-dates">
+    <thead><tr><th>Date</th><th>Type</th><th></th></tr></thead>
+    <tbody></tbody>
+  </table>
 </div>
 
 <h3 class="corporate-identity-h3">Linked resource &amp; references</h3>

--- a/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
+++ b/src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html
@@ -96,6 +96,23 @@ jQuery(document).ready(function (){
     margin-bottom: 0;
 }
 #date-entry-panel .add-date-button { align-self: end; }
+/* Dates -> the format of the range, then its start and its end. */
+#date-range-fields { display: none; }
+#date-range-fields .date-range-row {
+    display: grid;
+    grid-template-columns: 4.5em 1fr;
+    gap: .5em;
+    align-items: center;
+    margin-bottom: .4em;
+}
+#date-range-fields .date-range-row:last-child { margin-bottom: 0em; }
+#date-range-fields label.inner-head { margin-bottom: 0em; }
+#date-entry-panel select.date-range-format {
+    width: 100%;
+    max-width: 110pt;
+    box-sizing: border-box;
+    margin-bottom: 0;
+}
 #physical-sample-dates { width: 100%; border-collapse: collapse; margin-top: .3em; }
 #physical-sample-dates td { vertical-align: middle; padding: .4em .5em; }
 #physical-sample-dates td:last-child { text-align: right; width: 2em; }
@@ -246,9 +263,9 @@ jQuery(document).ready(function (){
 </div>
 
 
-<label>Dates</label><div class="fas fa-question-circle help-icon"><span class="help-text">This property may be used to log events relevant to the physical sample. Enter the date, and select the date type.</span></div>
+<label>Dates</label><div class="fas fa-question-circle help-icon"><span class="help-text">This property may be used to log events relevant to the physical sample. Enter the date, and select the date type. A period is entered as a range, of which the start and the end are entered in the same format.</span></div>
 <div id="physical-sample-dates-wrapper">
-  <p id="date-format-intro">Choose the format matches the date you want to enter (full date, month, or year), enter the value, and select the date type:</p>
+  <p id="date-format-intro">Choose the format matches the date you want to enter (full date, month, year, or a range), enter the value, and select the date type:</p>
   <div id="date-format-tabs" class="options-wrapper">
     <input type="radio" name="dateFormat" id="format-day" value="day" checked="checked" />
     <label class="no-head" for="format-day">Full date</label>
@@ -256,6 +273,8 @@ jQuery(document).ready(function (){
     <label class="no-head" for="format-month">Month</label>
     <input type="radio" name="dateFormat" id="format-year" value="year" />
     <label class="no-head" for="format-year">Year</label>
+    <input type="radio" name="dateFormat" id="format-range" value="range" />
+    <label class="no-head" for="format-range">Range</label>
   </div>
   <div id="date-entry-panel">
     <p class="date-hint" id="date-hint"></p>
@@ -265,6 +284,24 @@ jQuery(document).ready(function (){
         <input type="text" id="date-year" class="date-input" placeholder="yyyy" inputmode="numeric" autocomplete="off" />
         <input type="text" id="date-month" class="date-input" placeholder="mm/yyyy" inputmode="numeric" autocomplete="off" />
         <input type="text" id="date-day" class="date-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
+        <div id="date-range-fields">
+          <div class="date-range-row">
+            <label class="inner-head" for="date-range-format">Format</label>
+            <select id="date-range-format" class="date-range-format">
+              <option value="day">Full date</option>
+              <option value="month">Month</option>
+              <option value="year">Year</option>
+            </select>
+          </div>
+          <div class="date-range-row">
+            <label class="inner-head" for="date-range-start">From</label>
+            <input type="text" id="date-range-start" class="date-input date-range-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
+          </div>
+          <div class="date-range-row">
+            <label class="inner-head" for="date-range-end">To</label>
+            <input type="text" id="date-range-end" class="date-input date-range-input" placeholder="dd/mm/yyyy" inputmode="numeric" autocomplete="off" />
+          </div>
+        </div>
       </div>
       <div class="date-field">
         <label class="inner-head">Type</label>

--- a/src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql
+++ b/src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql
@@ -1,6 +1,7 @@
 {% extends "prefixes.sparql" %}
 {% block query %}
-SELECT DISTINCT ?uuid (STR(?date_raw) AS ?date) ?date_type ?created_date
+SELECT DISTINCT ?uuid (STR(?date_raw) AS ?date) (STR(?date_end_raw) AS ?date_end)
+                ?date_type ?created_date
                 (?rest AS ?originating_blank_node) ?order_index
 WHERE {
   GRAPH <{{state_graph}}> {
@@ -19,6 +20,10 @@ WHERE {
     ?date_type_uri     rdfs:label               ?date_type .
     ?date_entry        djht:date                ?date_raw .
     ?date_entry        djht:created_date        ?created_date .
+
+    # Only a range has an end date. It is kept apart from the start so that
+    # both stay real dates instead of one piece of text.
+    OPTIONAL { ?date_entry djht:date_end        ?date_end_raw . }
 
     {%- if account_uuid is not none %}
     ?container         djht:account             ?account .

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -440,21 +440,24 @@ function date_placeholder (format) {
     return "dd/mm/yyyy";
 }
 
+function date_format () {
+    return jQuery("input[name='dateFormat']:checked").val();
+}
+
 function set_date_format (format) {
-    // Show only the picker for the chosen format and clear the others and update the tip.
+    // The single field serves every format; only its placeholder differs.
+    // A range swaps it for the format, start and end fields on the same line.
     let hints = {
         "year":  "Enter the year only.",
         "month": "Enter the month and year.",
         "day":   "Enter the full calendar date.",
-        "range": "Choose the format, then enter the start and the end of the period."
+        "range": "Choose the format the period is written in, then enter its start and its end."
     };
-    jQuery("#date-year, #date-month, #date-day").hide().val("");
-    jQuery("#date-range-fields").hide();
-    set_date_range_format (jQuery("#date-range-format"));
-    if (format === "year") { jQuery("#date-year").show(); }
-    else if (format === "month") { jQuery("#date-month").show(); }
-    else if (format === "range") { jQuery("#date-range-fields").show(); }
-    else { jQuery("#date-day").show(); }
+    let is_range = (format === "range");
+    jQuery("#date-entry-panel").toggleClass ("is-range", is_range);
+    jQuery("#date-single").val("").attr("placeholder", date_placeholder (format));
+    if (is_range) { set_date_range_format (jQuery("#date-range-format")); }
+    else { jQuery("#date-range-start, #date-range-end").val(""); }
     jQuery("#date-hint").text (hints[format] || "");
 }
 
@@ -466,15 +469,10 @@ function set_date_range_format (select) {
 }
 
 function get_new_date_value () {
-    let format = jQuery("input[name='dateFormat']:checked").val();
-    if (format === "year") { return or_null(jQuery("#date-year").val()); }
-    if (format === "month") { return or_null(jQuery("#date-month").val()); }
-    if (format === "range") {
-        let start = or_null(jQuery("#date-range-start").val());
-        let end   = or_null(jQuery("#date-range-end").val());
-        return (start === null || end === null) ? null : [start, end];
-    }
-    return or_null(jQuery("#date-day").val());
+    if (date_format () !== "range") { return or_null(jQuery("#date-single").val()); }
+    let start = or_null(jQuery("#date-range-start").val());
+    let end   = or_null(jQuery("#date-range-end").val());
+    return (start === null || end === null) ? null : [start, end];
 }
 
 function auto_format_date (input, format) {
@@ -546,7 +544,8 @@ function format_display_range (iso, iso_end) {
 }
 
 function add_date (container_uuid) {
-    let format  = jQuery("input[name='dateFormat']:checked").val();
+    let format     = date_format ();
+    let is_period  = (format === "range");
     let raw_value  = get_new_date_value ();
     let type_value = or_null(jQuery("#dateType").val());
     let hints = {
@@ -556,14 +555,14 @@ function add_date (container_uuid) {
     };
 
     if (raw_value === null) {
-        show_message ("failure", (format === "range")
+        show_message ("failure", is_period
                       ? "<p>Enter both the start and the end of the period before adding it.</p>"
                       : "<p>Enter a date before adding it.</p>");
         return;
     }
 
     let iso_value = null;
-    if (format === "range") {
+    if (is_period) {
         // The start and the end use the format chosen for the range.
         let range_format = jQuery("#date-range-format").val();
         let ends = [];
@@ -605,7 +604,7 @@ function add_date (container_uuid) {
         data:        JSON.stringify([data]),
     }).done(function () {
         // Reset the entry fields and refresh the list below.
-        jQuery("#date-year, #date-month, #date-day").val("");
+        jQuery("#date-single").val("");
         jQuery("#date-range-start, #date-range-end").val("");
         jQuery("#dateType").val("");
         render_dates (container_uuid);
@@ -883,7 +882,7 @@ function activate (container_uuid, callback=jQuery.noop) {
         // A range follows its own format, not the one from the tabs.
         let format = jQuery(this).hasClass("date-range-input")
             ? jQuery("#date-range-format").val()
-            : jQuery("input[name='dateFormat']:checked").val();
+            : date_format ();
         auto_format_date (this, format);
     });
     jQuery("#physical-sample-dates-wrapper").on("click", ".add-date-button", function (event) {
@@ -895,7 +894,7 @@ function activate (container_uuid, callback=jQuery.noop) {
         remove_date (jQuery(this).data("uuid"), container_uuid);
     });
     // Set the initial format date (Full date) once the static markup exists.
-    set_date_format (jQuery("input[name='dateFormat']:checked").val());
+    set_date_format (date_format ());
     render_tags (container_uuid);
     render_categories_for_physical_sample (container_uuid);
     jQuery("#expand-categories-button").on("click", toggle_categories);

--- a/src/djehuty/web/resources/static/js/edit-physical-sample.js
+++ b/src/djehuty/web/resources/static/js/edit-physical-sample.js
@@ -434,24 +434,46 @@ function remove_date (date_uuid, container_uuid) {
       .fail(function () { show_message ("failure", "<p>Failed to remove date.</p>"); });
 }
 
+function date_placeholder (format) {
+    if (format === "year") { return "yyyy"; }
+    if (format === "month") { return "mm/yyyy"; }
+    return "dd/mm/yyyy";
+}
+
 function set_date_format (format) {
     // Show only the picker for the chosen format and clear the others and update the tip.
     let hints = {
         "year":  "Enter the year only.",
         "month": "Enter the month and year.",
-        "day":   "Enter the full calendar date."
+        "day":   "Enter the full calendar date.",
+        "range": "Choose the format, then enter the start and the end of the period."
     };
     jQuery("#date-year, #date-month, #date-day").hide().val("");
+    jQuery("#date-range-fields").hide();
+    set_date_range_format (jQuery("#date-range-format"));
     if (format === "year") { jQuery("#date-year").show(); }
     else if (format === "month") { jQuery("#date-month").show(); }
+    else if (format === "range") { jQuery("#date-range-fields").show(); }
     else { jQuery("#date-day").show(); }
     jQuery("#date-hint").text (hints[format] || "");
+}
+
+function set_date_range_format (select) {
+    // A range has one format, so both inputs are cleared together.
+    let format = jQuery(select).val();
+    jQuery("#date-range-start, #date-range-end")
+        .val("").attr("placeholder", date_placeholder (format));
 }
 
 function get_new_date_value () {
     let format = jQuery("input[name='dateFormat']:checked").val();
     if (format === "year") { return or_null(jQuery("#date-year").val()); }
     if (format === "month") { return or_null(jQuery("#date-month").val()); }
+    if (format === "range") {
+        let start = or_null(jQuery("#date-range-start").val());
+        let end   = or_null(jQuery("#date-range-end").val());
+        return (start === null || end === null) ? null : [start, end];
+    }
     return or_null(jQuery("#date-day").val());
 }
 
@@ -517,22 +539,54 @@ function format_display_date (iso) {
     return `${parseInt(parts[2], 10)} ${month_name} ${year}`;
 }
 
+function format_display_range (iso, iso_end) {
+    let start = format_display_date (iso);
+    if (iso_end === null || iso_end === undefined || iso_end === "") { return start; }
+    return `${start} – ${format_display_date (iso_end)}`;
+}
+
 function add_date (container_uuid) {
     let format  = jQuery("input[name='dateFormat']:checked").val();
     let raw_value  = get_new_date_value ();
     let type_value = or_null(jQuery("#dateType").val());
+    let hints = {
+        "year":  "yyyy, for example 2024",
+        "month": "mm/yyyy, for example 05/2024",
+        "day":   "dd/mm/yyyy, for example 17/05/2024"
+    };
 
     if (raw_value === null) {
-        show_message ("failure", "<p>Enter a date before adding it.</p>");
+        show_message ("failure", (format === "range")
+                      ? "<p>Enter both the start and the end of the period before adding it.</p>"
+                      : "<p>Enter a date before adding it.</p>");
         return;
     }
-    let iso_value = to_iso_date (format, raw_value);
+
+    let iso_value = null;
+    if (format === "range") {
+        // The start and the end use the format chosen for the range.
+        let range_format = jQuery("#date-range-format").val();
+        let ends = [];
+        for (let index = 0; index < 2; index++) {
+            let converted = to_iso_date (range_format, raw_value[index]);
+            if (converted === false) {
+                show_message ("failure", `<p>Enter the ${index === 0 ? "start" : "end"} ` +
+                              `of the period as ${hints[range_format]}.</p>`);
+                return;
+            }
+            ends.push (converted);
+        }
+        // Comparing if date start > date end
+        if (ends[0] > ends[1]) {
+            show_message ("failure", "<p>The end of the period precedes its start.</p>");
+            return;
+        }
+        iso_value = `${ends[0]}/${ends[1]}`;
+    } else {
+        iso_value = to_iso_date (format, raw_value);
+    }
+
     if (iso_value === false) {
-        let hints = {
-            "year":  "yyyy, for example 2024",
-            "month": "mm/yyyy, for example 05/2024",
-            "day":   "dd/mm/yyyy, for example 17/05/2024"
-        };
         show_message ("failure", `<p>Enter the date as ${hints[format]}.</p>`);
         return;
     }
@@ -552,6 +606,7 @@ function add_date (container_uuid) {
     }).done(function () {
         // Reset the entry fields and refresh the list below.
         jQuery("#date-year, #date-month, #date-day").val("");
+        jQuery("#date-range-start, #date-range-end").val("");
         jQuery("#dateType").val("");
         render_dates (container_uuid);
     }).fail(function () {
@@ -577,8 +632,9 @@ function render_dates (container_uuid) {
         });
 
         for (let date_entry of dates) {
-            // Show dates with the month spelled e.g. "2010", "May 2010" or "17 May 2010".
-            let display_date = format_display_date (date_entry.date);
+            // Show dates with the month spelled e.g. "2010", "May 2010", "17 May 2010"
+            // or, for a range, "May 2010 – 2012".
+            let display_date = format_display_range (date_entry.date, date_entry.date_end);
             let row = `<tr><td>${display_date}</td>`;
             row += `<td><span class="resource-badge date-type">${date_entry.type}</span></td>`;
             row += `<td><a href="#" data-uuid="${date_entry.uuid}" `;
@@ -820,8 +876,15 @@ function activate (container_uuid, callback=jQuery.noop) {
     jQuery("#physical-sample-dates-wrapper").on("change", "input[name='dateFormat']", function () {
         set_date_format (jQuery(this).val());
     });
+    jQuery("#physical-sample-dates-wrapper").on("change", ".date-range-format", function () {
+        set_date_range_format (this);
+    });
     jQuery("#physical-sample-dates-wrapper").on("input", ".date-input", function () {
-        auto_format_date (this, jQuery("input[name='dateFormat']:checked").val());
+        // A range follows its own format, not the one from the tabs.
+        let format = jQuery(this).hasClass("date-range-input")
+            ? jQuery("#date-range-format").val()
+            : jQuery("input[name='dateFormat']:checked").val();
+        auto_format_date (this, format);
     });
     jQuery("#physical-sample-dates-wrapper").on("click", ".add-date-button", function (event) {
         event.preventDefault();

--- a/src/djehuty/web/validator.py
+++ b/src/djehuty/web/validator.py
@@ -2,6 +2,7 @@
 This module contains procedures to validate user input.
 """
 
+import datetime
 import re
 from djehuty.utils import convenience as conv
 
@@ -378,39 +379,100 @@ def date_value (record, field_name, required=False, error_list=None):
 
     return value
 
-def partial_date_value (record, field_name, required=False, error_list=None):
+def __is_partial_date (value):
     """
-    Validation procedure for dates of partial values.  Accepts a full date
-    (YYYY-MM-DD), a year and month (YYYY-MM), or only a year (YYYY).
+    Returns True when VALUE is a year (YYYY), a year and month (YYYY-MM) or a
+    day that exists on the calendar (YYYY-MM-DD), False otherwise.
+    """
+
+    if re.match ("^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$", value) is None:
+        return False
+
+    parts = list (map (int, value.split("-")))
+    if len(parts) > 1 and not 1 <= parts[1] <= 12:
+        return False
+
+    if len(parts) > 2:
+        try:
+            datetime.date (*parts)
+        except ValueError:
+            return False
+
+    return True
+
+def partial_date_range_value (record, field_name, required=False, error_list=None):
+    """
+    Validation procedure for a date like "2023-06", or a range like
+    "2023-06/2026-06".  Both dates of a range are written in the same form.
+    Returns the start and the end, where the end is None for a single date
+    (not range).
     """
 
     value = record if field_name is None else conv.value_or_none (record, field_name)
     if value is None:
         if required:
-            return raise_or_return_error (error_list,
+            raise_or_return_error (error_list,
                         MissingRequiredField(
                             field_name = field_name,
                             message = f"Missing required value for '{field_name}'.",
                             code    = "MissingRequiredField"))
-        return None
+        return None, None
 
     if not isinstance (value, str):
-        return raise_or_return_error (error_list,
+        raise_or_return_error (error_list,
                     InvalidValueType(
                         field_name = field_name,
-                        message = f"Expected '{field_name}' in the form YYYY, YYYY-MM or YYYY-MM-DD.",
+                        message = f"Expected '{field_name}' to be a date or a range of two dates.",
                         code    = "WrongValueType"))
+        return None, None
 
-    ## Check its form: YYYY, YYYY-MM or YYYY-MM-DD.
-    pattern = "^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$"
-    if re.match(pattern, value) is None:
-        return raise_or_return_error (error_list,
+    parts = value.split("/")
+    if len(parts) > 2:
+        raise_or_return_error (error_list,
                     InvalidValueType(
                         field_name = field_name,
-                        message = f"Expected '{field_name}' in the form YYYY, YYYY-MM or YYYY-MM-DD.",
+                        message = (f"Expected '{field_name}' to hold at most two dates "
+                                   "separated by a slash."),
                         code    = "WrongValueFormat"))
+        return None, None
 
-    return value
+    for part in parts:
+        if not __is_partial_date (part):
+            raise_or_return_error (error_list,
+                        InvalidValueType(
+                            field_name = field_name,
+                            message = (f"Expected '{field_name}' in the form YYYY, "
+                                       "YYYY-MM or YYYY-MM-DD."),
+                            code    = "WrongValueFormat"))
+            return None, None
+
+    start = parts[0]
+    if len(parts) == 1:
+        return start, None
+
+    end = parts[1]
+
+    ## For now: a range runs from a year to a year, or from a month to a month, but
+    ## never from one to the other.
+    if start.count("-") != end.count("-"):
+        raise_or_return_error (error_list,
+                    InvalidValueType(
+                        field_name = field_name,
+                        message = (f"Expected both dates of '{field_name}' in the "
+                                   "same form."),
+                        code    = "WrongValueFormat"))
+        return None, None
+
+    ## Comparing if date start > date end
+    if start > end:
+        raise_or_return_error (error_list,
+                    InvalidValueType(
+                        field_name = field_name,
+                        message = f"The end of '{field_name}' precedes its start.",
+                        code    = "WrongValueFormat"))
+        return None, None
+
+    return start, end
 
 def boolean_value (record, field_name, required=False, when_none=None, error_list=None):
     """

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -38,6 +38,7 @@ from djehuty.utils.constants import (
     member_url_names,
 )
 from djehuty.utils.convenience import (
+    date_or_range,
     decimal_coords,
     deduplicate_list,
     html_to_plaintext,
@@ -3611,12 +3612,14 @@ class WebServer:
 
             for date_record in record:
                 date_type = validator.options_value (date_record, "type", types, True, errors)
-                date      = validator.partial_date_value (date_record, "date", True, errors)
+                date, date_end = validator.partial_date_range_value (date_record, "date",
+                                                                     True, errors)
                 if date_type is not None and date is not None:
                     if self.db.add_date_to_physical_sample (container_uuid,
                                                             date_type,
                                                             date,
-                                                            account_uuid) is None:
+                                                            account_uuid,
+                                                            date_end) is None:
                         self.log.error ("Failed to add date (%s, %s) to physical sample %s.",
                                         date_type, date, container_uuid)
                         errors.append ({
@@ -5549,7 +5552,8 @@ class WebServer:
                          image_factory = qrcode.image.svg.SvgPathImage).save (qr_buf)
             qr_code_svg = qr_buf.getvalue().decode("utf-8")
 
-        dates = [("-".join(reversed(str(d.get("date", ""))[:10].split("-"))), str(d.get("date_type", "")))
+        dates = [(date_or_range (d.get("date"), d.get("date_end")),
+                  str(d.get("date_type", "")))
                  for d in raw_dates if d.get("date")]
 
         lat = self_or_value_or_none (physical_sample, "latitude")

--- a/src/djehuty/web/xml_formatter.py
+++ b/src/djehuty/web/xml_formatter.py
@@ -452,7 +452,11 @@ def datacite_physical_sample_tree (parameters, debug=False):
         ## persisted copy so it is not written twice.
         if date_type == 'Issued':
             continue
-        maker.child (dates_element, 'date', {'dateType': date_type}, str (date_value)[:10])
+        ## DataCite writes a range as the two dates with a slash between them.
+        date_end = value_or_none (entry, 'date_end')
+        if date_end:
+            date_value = f"{date_value}/{date_end}"
+        maker.child (dates_element, 'date', {'dateType': date_type}, str (date_value))
 
     #10 alternateIdentifiers
     if 'alternate_identifier' in item:


### PR DESCRIPTION
**Summary**

Add the options of Date range in the "Dates" of physical sample. 
Now only ranges carry an extra triple `date_end`. It is read as  OPTIONAL 
because only ranges dates carry one. This is written like in this way to 
keep `datetype` for dates.

**Changes**
* src/djehuty/web/validator.py: Add partial_date_range_value, which returns
  the start and  the end of a range.
* src/djehuty/web/database.py: Store the end as a separate date_end, so each end
  keeps the datatype.
* src/djehuty/web/resources/sparql_templates/physical_sample_dates.sparql:
  Read date_end with OPTIONAL, because only ranges carry one.
* src/djehuty/web/xml_formatter.py: Join dates range with a slash for DataCite.
* src/djehuty/utils/convenience.py: Add convenience for day_first_date and date_or_range
  to render a date.
* src/djehuty/web/wsgi.py: Render date range for physical_sample.
* src/djehuty/web/resources/html_templates/depositor/edit-physical-sample.html:
  Add a Range tab to the date form.
* src/djehuty/web/resources/static/js/edit-physical-sample.js: Handle range tab.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Part of #41 

**Screenshots**

After
<img width="700" alt="image" src="https://github.com/user-attachments/assets/3639c4c2-fb08-444a-b816-856f6f17c6e6" />

**Notes**
 Forked from wip-feat-41-igsn-related-resources