### PR TITLE
Release version v26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ news section (`doc/news.tex`) is regenerated at release time by `just news`.
 
 Commit links point to <https://github.com/4TUResearchData/djehuty>.
 
+
+## [v26.4]
+
+The fourth release of 2026 consists of 12 commits made by 3 authors.
+
+This release gives administrators two new tools for correcting the record after
+publication.
+
+### New features
+
+- Add an administrative dashboard action to retract a published dataset. ([a358518](https://github.com/4TUResearchData/djehuty/commit/a35851850e24c72fa48c76711125977c86b9f7a4))
+- Add an administrative action to merge user accounts and transfer their ownership. ([83cbe0d](https://github.com/4TUResearchData/djehuty/commit/83cbe0d3799ae74ec6331d7143b92ecb66cd643d))
+- Show the djehuty version in the page footer. ([ed9f9c8](https://github.com/4TUResearchData/djehuty/commit/ed9f9c89719abea0d96931b1d050fc2c32b5ef7e))
+
+### Incremental improvements
+
+- Set up Ruff linting and formatting. ([45805c2](https://github.com/4TUResearchData/djehuty/commit/45805c2e50501b98d92cbb39966b00040d548c69))
+- Update Python, GitHub Actions and Docker dependencies for security and performance. ([7c5ca35](https://github.com/4TUResearchData/djehuty/commit/7c5ca352da3fe83e2ba09a0e1f6136f997d364f8),
+[02a4ad1](https://github.com/4TUResearchData/djehuty/commit/02a4ad1f7d4e0c2be556056c497680fa24b4854e),
+[dc35b9a](https://github.com/4TUResearchData/djehuty/commit/dc35b9a7006489076fce710e65921dd4452b3e1f),
+[36d0698](https://github.com/4TUResearchData/djehuty/commit/36d0698aa56e14d017fc74a28b14973eee643ee2),
+[ac3967f](https://github.com/4TUResearchData/djehuty/commit/ac3967ff7f7511121fbb7c26d991f52fc717820d))
+
+### Documentation
+
+- Migrate the documentation to Markdown and publish it with MkDocs. ([3f28684](https://github.com/4TUResearchData/djehuty/commit/3f28684da8fb51fed2b69b418de2bd84d756b48a))
+- Remove the documentation section from README.md now that it lives in the docs site. ([dd8f54b](https://github.com/4TUResearchData/djehuty/commit/dd8f54bf95b0836a2f5b4611b32bccc52601ae22))
+- Add a documentation issue template. ([5a2e2b5](https://github.com/4TUResearchData/djehuty/commit/5a2e2b5aed0babd005c903e10b1df706a6cb9078))
+
+
 ## [v26.3.3]
 
 This patch release fixes the Djehuty container image, which failed to start

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT(djehuty, 26.3.3)
+AC_INIT(djehuty, 26.4)
 AM_INIT_AUTOMAKE([foreign tar-ustar])
 AM_PATH_PYTHON([3.10])
 AC_CONFIG_FILES([

--- a/doc/news.tex
+++ b/doc/news.tex
@@ -5,6 +5,46 @@
 \fi
 \chapter*{News}
 
+\labelWithConsistentHTMLTag{release-26-4}
+\section*{Release notes for \texttt{v26.4}.}
+
+  The fourth release of 2026 consists of 12 commits made by 3 authors.
+
+  This release gives administrators two new tools for correcting the record after
+publication.
+
+\subsection*{New features}
+\begin{itemize}
+\item{Add an administrative dashboard action to retract a published dataset.
+    (\commitLink{a35851850e24c72fa48c76711125977c86b9f7a4}).}
+\item{Add an administrative action to merge user accounts and transfer their ownership.
+    (\commitLink{83cbe0d3799ae74ec6331d7143b92ecb66cd643d}).}
+\item{Show the djehuty version in the page footer.
+    (\commitLink{ed9f9c89719abea0d96931b1d050fc2c32b5ef7e}).}
+\end{itemize}
+
+\subsection*{Incremental improvements}
+\begin{itemize}
+\item{Set up Ruff linting and formatting.
+    (\commitLink{45805c2e50501b98d92cbb39966b00040d548c69}).}
+\item{Update Python, GitHub Actions and Docker dependencies for security and performance.
+    (\commitLink{7c5ca352da3fe83e2ba09a0e1f6136f997d364f8},
+    \commitLink{02a4ad1f7d4e0c2be556056c497680fa24b4854e},
+    \commitLink{dc35b9a7006489076fce710e65921dd4452b3e1f},
+    \commitLink{36d0698aa56e14d017fc74a28b14973eee643ee2},
+    \commitLink{ac3967ff7f7511121fbb7c26d991f52fc717820d}).}
+\end{itemize}
+
+\subsection*{Documentation}
+\begin{itemize}
+\item{Migrate the documentation to Markdown and publish it with MkDocs.
+    (\commitLink{3f28684da8fb51fed2b69b418de2bd84d756b48a}).}
+\item{Remove the documentation section from README.md now that it lives in the docs site.
+    (\commitLink{dd8f54bf95b0836a2f5b4611b32bccc52601ae22}).}
+\item{Add a documentation issue template.
+    (\commitLink{5a2e2b5aed0babd005c903e10b1df706a6cb9078}).}
+\end{itemize}
+
 \labelWithConsistentHTMLTag{release-26-3-3}
 \section*{Release notes for \texttt{v26.3.3}.}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend   = "setuptools.build_meta"
 
 [project]
 name            = "djehuty"
-version         = "26.3.3"
+version         = "26.4"
 authors         = [{ name="Roel Janssen", email="r.r.e.janssen@tudelft.nl" }]
 description     = "The 4TU.ResearchData and Nikhef data repository system"
 readme          = "README.md"


### PR DESCRIPTION
**Summary**

The fourth release of 2026 consists of 12 commits made by 3 authors.

This release gives administrators two new tools for correcting the record after
publication.

**Changes**

* pyproject.toml: Bump version to v26.4
* configure.ac: Bump version to v26.4
* CHANGELOG.md: Add release notes for v26.4
* doc/news.tex: Add release notes for v26.4

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Notes**

`just docs-html` for build the documentation