### PR TITLE
Feature #41 | Add physical sample schema migration

### DIFF
--- a/src/djehuty/schema/migrations/0002_add_physical_sample.ttl
+++ b/src/djehuty/schema/migrations/0002_add_physical_sample.ttl
@@ -1,0 +1,31 @@
+@prefix djht: <https://ontologies.data.4tu.nl/djehuty/0.0.1/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+## Container hierarchy
+djht:PhysicalSampleContainer rdfs:subClassOf djht:Container .
+
+## Physical-sample date types
+djht:PhysicalSampleDateCollected rdfs:label "Collected"^^xsd:string .
+djht:PhysicalSampleDateCreated rdfs:label "Created"^^xsd:string .
+djht:PhysicalSampleDateDestroyed rdfs:label "Destroyed"^^xsd:string .
+djht:PhysicalSampleDateIssued rdfs:label "Issued"^^xsd:string .
+djht:PhysicalSampleDateUpdated rdfs:label "Updated"^^xsd:string .
+djht:PhysicalSampleDateOther rdfs:label "Other"^^xsd:string .
+
+## Physical-sample related-resource identifier types
+djht:PhysicalSampleRelatedResourceIGSNDOI rdfs:label "IGSN"^^xsd:string .
+djht:PhysicalSampleRelatedResourceOtherDOI rdfs:label "DOI"^^xsd:string .
+djht:PhysicalSampleRelatedResourceURL rdfs:label "URL"^^xsd:string .
+
+## Physical-sample related-resource relation types
+djht:PhysicalSampleRelatedResourceIsPartOf rdfs:label "Is part of"^^xsd:string .
+djht:PhysicalSampleRelatedResourceHasPart rdfs:label "Has part"^^xsd:string .
+djht:PhysicalSampleRelatedResourceIsDerivedFrom rdfs:label "Is derived from"^^xsd:string .
+djht:PhysicalSampleRelatedResourceIsSourceOf rdfs:label "Is source of"^^xsd:string .
+djht:PhysicalSampleRelatedResourceIsReferencedBy rdfs:label "Is referenced by"^^xsd:string .
+djht:PhysicalSampleRelatedResourceReferences rdfs:label "References"^^xsd:string .
+djht:PhysicalSampleRelatedResourceIsCitedBy rdfs:label "Is cited by"^^xsd:string .
+djht:PhysicalSampleRelatedResourceCites rdfs:label "Cites"^^xsd:string .
+djht:PhysicalSampleRelatedResourceIsDescribedBy rdfs:label "Is described by"^^xsd:string .
+djht:PhysicalSampleRelatedResourceDescribes rdfs:label "Describes"^^xsd:string .

--- a/src/djehuty/utils/convenience.py
+++ b/src/djehuty/utils/convenience.py
@@ -213,7 +213,9 @@ def deduplicate_list(alist):
     except TypeError:
         logging.error("Wrong type of %s in deduplicate_list", alist)
         return None
-def day_first_date (date_value):
+
+
+def day_first_date(date_value):
     """
     Return the partial date DATE_VALUE with its parts in day-first order, so
     2010 stays 2010, while 2010-05 becomes 05-2010 and 2010-05-17 becomes
@@ -222,22 +224,25 @@ def day_first_date (date_value):
     if not date_value:
         return ""
 
-    return "-".join (reversed (str(date_value).split("-")))
+    return "-".join(reversed(str(date_value).split("-")))
 
-def date_or_range (date_value, date_end=None, separator=" – "):
+
+def date_or_range(date_value, date_end=None, separator=" – "):
     """
     Return the day-first notation of DATE_VALUE, or of the range that starts at
     DATE_VALUE and ends at DATE_END when the latter is set.
     """
-    start = day_first_date (date_value)
-    end   = day_first_date (date_end)
+    start = day_first_date(date_value)
+    end = day_first_date(date_end)
     if not end:
         return start
 
     return f"{start}{separator}{end}"
 
-def make_citation (authors, year, title, version, item_type, doi,
-                   publisher='4TU.ResearchData', max_cited_authors=5):
+
+def make_citation(
+    authors, year, title, version, item_type, doi, publisher="4TU.ResearchData", max_cited_authors=5
+):
     """Return citation in standard Datacite format."""
     try:
         auths = [

--- a/tests/unit/test_migrate.py
+++ b/tests/unit/test_migrate.py
@@ -37,6 +37,19 @@ def real_migrations_dir():
 
 
 @pytest.fixture
+def real_migration_ids(real_migrations_dir):
+    """Production migration identifiers, in application order.
+
+    Derived from disk so that adding a migration does not break these tests.
+    """
+    return [
+        path.stem
+        for path in sorted(real_migrations_dir.iterdir())
+        if path.suffix in (".ttl", ".sparql")
+    ]
+
+
+@pytest.fixture
 def tmp_migrations_dir():
     """Fresh empty migrations directory; tests populate it as needed."""
     with tempfile.TemporaryDirectory() as tmp:
@@ -82,32 +95,34 @@ def _write_migration(migrations_dir, identifier, kind, body):
 
 
 class TestFresh:
-    def test_apply_initial(self, runner_real, in_memory_dataset):
-        """Fresh upgrade seeds 0001_initial, writes a log row and the marker."""
+    def test_apply_initial(self, runner_real, in_memory_dataset, real_migration_ids):
+        """Fresh upgrade seeds every migration, writes log rows and the marker."""
         assert runner_real.current() is None
-        assert runner_real.head() == "0001_initial"
+        assert runner_real.head() == real_migration_ids[-1]
 
-        assert runner_real.upgrade() == 1
-        assert runner_real.current() == "0001_initial"
+        assert runner_real.upgrade() == len(real_migration_ids)
+        assert runner_real.current() == real_migration_ids[-1]
 
         state = in_memory_dataset.graph(URIRef(STATE_GRAPH))
         log = in_memory_dataset.graph(URIRef(MIG_GRAPH))
         assert len(state) > 1000, "0001_initial should produce >1000 triples"
         assert INIT_MARKER in state
         log_subjects = {s for s, _, _ in log.triples((None, None, MU_MIGR.Migration))}
-        assert len(log_subjects) == 1
+        assert len(log_subjects) == len(real_migration_ids)
 
 
 class TestIdempotency:
-    def test_second_upgrade_is_noop(self, runner_real):
-        assert runner_real.upgrade() == 1
+    def test_second_upgrade_is_noop(self, runner_real, real_migration_ids):
+        assert runner_real.upgrade() == len(real_migration_ids)
         assert runner_real.upgrade() == 0
         assert runner_real.verify() is True
 
 
 class TestStamp:
-    def test_stamp_head_writes_log_without_body(self, runner_real, in_memory_dataset):
-        assert runner_real.stamp("head") == 1
+    def test_stamp_head_writes_log_without_body(
+        self, runner_real, in_memory_dataset, real_migration_ids
+    ):
+        assert runner_real.stamp("head") == len(real_migration_ids)
         state = in_memory_dataset.graph(URIRef(STATE_GRAPH))
         log = in_memory_dataset.graph(URIRef(MIG_GRAPH))
         assert len(state) == 0  # body not run
@@ -120,14 +135,16 @@ class TestStamp:
 
 
 class TestDrift:
-    def test_drift_detected_after_log_tampering(self, runner_real, in_memory_dataset):
+    def test_drift_detected_after_log_tampering(
+        self, runner_real, in_memory_dataset, real_migration_ids
+    ):
         runner_real.upgrade()
         assert runner_real.verify() is True
 
-        # Tamper: replace the stored checksum with a bogus value.
+        # Tamper: replace one stored checksum with a bogus value.
         log = in_memory_dataset.graph(URIRef(MIG_GRAPH))
         cs_triples = list(log.triples((None, DJH_MIG.checksum, None)))
-        assert len(cs_triples) == 1
+        assert len(cs_triples) == len(real_migration_ids)
         subject, predicate, _ = cs_triples[0]
         log.remove((subject, predicate, None))
         log.add((subject, predicate, Literal("sha256:tampered")))
@@ -151,7 +168,7 @@ class TestAutoStamp:
         ],
     )
     def test_auto_stamps_when_already_seeded(
-        self, seed_triple, runner_real, in_memory_dataset
+        self, seed_triple, runner_real, in_memory_dataset, real_migration_ids
     ):
         # Marker present, or seeded without one (Figshare import): stamp 0001,
         # don't re-run its body, or the static data doubles up.
@@ -159,9 +176,11 @@ class TestAutoStamp:
         state.add(seed_triple)
         before = len(state)
 
-        assert runner_real.upgrade() == 1
-        assert len(state) == before  # stamped, not run
-        assert runner_real.current() == "0001_initial"
+        assert runner_real.upgrade() == len(real_migration_ids)
+        # 0001_initial was stamped rather than re-run, so its >1000 triples are
+        # absent; only the later, far smaller migrations actually ran.
+        assert len(state) - before < 1000
+        assert runner_real.current() == real_migration_ids[-1]
         assert runner_real.upgrade() == 0
 
     def test_seed_probe_never_fatal(self, runner_real, monkeypatch):


### PR DESCRIPTION
**Summary**

Seed the physical sample container hierarchy, the date types and the related-resource identifier and relation types and adapt the migration tests.

**Changes**
* src/djehuty/schema/migrations/0002_add_physical_sample.ttl: Seed the physical
  sample container hierarchy, the date types and the related-resource identifier 
  and relation types
* tests/unit/test_migrate.py: Read the expected migrations from the
  migrations directory instead of assuming a single one.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Part of #41 

**Notes**

Forked from wip-feat-41-igsn-date-range