### PR TITLE
feat: soft delete dataset draft

### DIFF
--- a/doc/knowledge-graph.tex
+++ b/doc/knowledge-graph.tex
@@ -96,6 +96,20 @@
   the \i{view}, \i{download}, \i{share} and \i{citation} counts are stored
   in a version-unspecific way.
 
+\subsection{Soft-deleted drafts}
+
+  Deleting a draft dataset does not remove its triples.  Instead, the draft
+  is marked with \code{djht:is\_deleted} set to \code{true} and a
+  \code{djht:deleted\_date} timestamp, while its link to the
+  \code{djht:DatasetContainer} is kept.  A soft-deleted draft is hidden from
+  the depositor's \i{Drafts}, \i{Under review}, and \i{Published} lists and
+  appears under a separate \i{Deleted} list, from where it can be restored
+  (clearing \code{djht:is\_deleted}) or permanently deleted (removing the
+  triples as before).  The absence of \code{djht:is\_deleted} is treated as
+  ``not deleted'', so drafts created before this property existed need no
+  migration.  File contents on the filesystem are not affected by soft
+  delete, restore, or permanent delete.
+
 \section{Collections}
 
   Collections provide a way to group \code{djht:Dataset} objects.

--- a/docs/knowledge-graph.md
+++ b/docs/knowledge-graph.md
@@ -81,6 +81,18 @@ The data model follows a natural expression of published versions as a linked
 list. The figure above further reveals that the *view*, *download*, *share* and
 *citation* counts are stored in a version-unspecific way.
 
+### Soft-deleted drafts
+
+Deleting a draft dataset does not remove its triples. Instead, the draft is
+marked with `djht:is_deleted` set to `true` and a `djht:deleted_date`
+timestamp, while its link to the `djht:DatasetContainer` is kept. A soft-deleted
+draft is hidden from the depositor's *Drafts*, *Under review*, and *Published*
+lists and appears under a separate *Deleted* list, from where it can be restored
+(clearing `djht:is_deleted`) or permanently deleted (removing the triples as
+before). The absence of `djht:is_deleted` is treated as "not deleted", so drafts
+created before this property existed need no migration. File contents on the
+filesystem are not affected by soft delete, restore, or permanent delete.
+
 ## Collections
 
 Collections provide a way to group `djht:Dataset` objects.

--- a/src/djehuty/schema/migrations/0002_add_dataset_is_deleted.ttl
+++ b/src/djehuty/schema/migrations/0002_add_dataset_is_deleted.ttl
@@ -1,0 +1,22 @@
+@prefix djht: <https://ontologies.data.4tu.nl/djehuty/0.0.1/> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+# Soft delete for draft datasets. A draft carrying djht:is_deleted "true"
+# is hidden from the depositor's draft/review/published views but keeps all
+# of its triples and files, so it can be restored. Absence of the predicate
+# means "not deleted"; existing drafts need no back-fill.
+
+djht:is_deleted a owl:DatatypeProperty ;
+    rdfs:label "is deleted"^^xsd:string ;
+    rdfs:comment "True when a draft dataset has been soft-deleted by its owner or a reviewer."^^xsd:string ;
+    rdfs:domain djht:Dataset ;
+    rdfs:range xsd:boolean .
+
+djht:deleted_date a owl:DatatypeProperty ;
+    rdfs:label "deleted date"^^xsd:string ;
+    rdfs:comment "Timestamp at which a draft dataset was soft-deleted."^^xsd:string ;
+    rdfs:domain djht:Dataset ;
+    rdfs:range xsd:dateTime .

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -409,7 +409,7 @@ class SparqlInterface:
                   is_published=True, is_under_review=None, git_uuid=None,
                   private_link_id_string=None, use_cache=True, is_restricted=None,
                   is_embargoed=None, is_software=None, organizations=None,
-                  codecheck_certificate_doi=None):
+                  codecheck_certificate_doi=None, is_deleted=False):
         """Procedure to retrieve version(s) of datasets."""
 
         filters  = rdf.sparql_filter ("container_uri",  rdf.uuid_to_uri (container_uuid, "container"), is_uri=True)
@@ -464,6 +464,7 @@ class SparqlInterface:
             "is_latest":      is_latest,
             "is_published":   is_published,
             "is_under_review": is_under_review,
+            "is_deleted":     is_deleted,
             "private_link_id_string": private_link_id_string,
             "search_for_raw": rdf.escape_string_value (search_for_raw),
             "filters":        filters,
@@ -2160,6 +2161,51 @@ class SparqlInterface:
         if is_under_review:
             self.cache.invalidate_by_prefix ("reviews")
 
+        return result
+
+    def __invalidate_dataset_draft_caches (self, dataset_uuid, account_uuid,
+                                           owner_account_uuid, collaborators):
+        """Invalidate the caches touched by a draft delete/soft-delete/restore."""
+
+        self.cache.invalidate_by_prefix (f"{account_uuid}_storage")
+        self.cache.invalidate_by_prefix (f"{dataset_uuid}_dataset_storage")
+        self.cache.invalidate_by_prefix (f"datasets_{owner_account_uuid}")
+
+        for collaborator in collaborators:
+            self.cache.invalidate_by_prefix (f"datasets_{collaborator['account_uuid']}")
+
+        if self.dataset_is_under_review (dataset_uuid):
+            self.cache.invalidate_by_prefix ("reviews")
+
+    def soft_delete_dataset_draft (self, container_uuid, dataset_uuid, account_uuid, owner_account_uuid):
+        """Mark the draft dataset as deleted without removing its triples."""
+
+        # Only explicit collaborators are needed for cache invalidation; skip
+        # the costly inferred institution-group members.
+        collaborators = self.collaborators (dataset_uuid, include_inferred=False)
+        current_time  = datetime.strftime (datetime.now(), datetime_format)
+        query   = self.__query_from_template ("soft_delete_dataset_draft", {
+            "dataset_uuid":        dataset_uuid,
+            "deleted_date":        current_time
+        })
+
+        result = self.__run_logged_query (query)
+        self.__invalidate_dataset_draft_caches (dataset_uuid, account_uuid,
+                                                owner_account_uuid, collaborators)
+        return result
+
+    def restore_dataset_draft (self, container_uuid, dataset_uuid, account_uuid, owner_account_uuid):
+        """Clear the deleted mark on a soft-deleted draft dataset."""
+
+        # See soft_delete_dataset_draft: inferred members are not needed here.
+        collaborators = self.collaborators (dataset_uuid, include_inferred=False)
+        query   = self.__query_from_template ("restore_dataset_draft", {
+            "dataset_uuid":        dataset_uuid
+        })
+
+        result = self.__run_logged_query (query)
+        self.__invalidate_dataset_draft_caches (dataset_uuid, account_uuid,
+                                                owner_account_uuid, collaborators)
         return result
 
     def publish_collection (self, container_uuid, account_uuid):

--- a/src/djehuty/web/resources/html_templates/depositor/delete-dataset-permanently.html
+++ b/src/djehuty/web/resources/html_templates/depositor/delete-dataset-permanently.html
@@ -1,0 +1,22 @@
+{% extends "layout.html" %}
+{% block body %}
+<h1>Delete dataset permanently</h1>
+{%- if error %}
+<p class="message-box failure">{{error}}</p>
+{%- endif %}
+<p>You are about to permanently delete the draft
+  <strong>{{dataset.title}}</strong>.</p>
+<p><strong>This cannot be undone.</strong> The metadata will be removed and
+  cannot be recovered. If you only want to hide this draft, go back and leave
+  it in the Deleted list instead, where it can still be restored.</p>
+<form method="POST" action="/my/datasets/{{dataset.container_uuid}}/delete-permanently">
+  <p>
+    <input type="checkbox" id="confirm" name="confirm" value="yes" />
+    <label for="confirm">I understand this permanently deletes the draft and cannot be undone.</label>
+  </p>
+  <div class="center">
+    <a href="/my/datasets" class="button corporate-identity-standard-button">Cancel</a>
+    <button type="submit" class="button corporate-identity-alert-button">Delete permanently</button>
+  </div>
+</form>
+{% endblock %}

--- a/src/djehuty/web/resources/html_templates/depositor/my-data.html
+++ b/src/djehuty/web/resources/html_templates/depositor/my-data.html
@@ -8,6 +8,8 @@
 #table-unpublished { display: none; }
 #table-published { display: none; }
 #table-review { display: none; }
+#table-deleted { display: none; }
+#table-deleted a.delete-permanently { color: #cc0000; }
 #add-new-dataset { margin: auto; }
 </style>
 <script nonce="{{nonce}}">
@@ -34,6 +36,15 @@ jQuery(document).ready(function () {
     });
     jQuery("#table-review").show();
     jQuery("#table-review-loader").remove();
+
+    if (jQuery("#table-deleted").length) {
+        jQuery("#table-deleted").DataTable({
+            columnDefs: [{ orderable: false, targets: 3 }],
+            order: [[2, 'desc']]
+        });
+        jQuery("#table-deleted").show();
+        jQuery("#table-deleted-loader").remove();
+    }
 });
 </script>
 {% endblock %}
@@ -129,6 +140,29 @@ jQuery(document).ready(function () {
         {%- if not article.has_draft %}<a href="/my/datasets/{{article.container_uuid}}/new-version-draft" class="fas fa-plus" title="Add new version"></a>{% endif %}
         <a href="/my/datasets/{{article.uuid}}/private_links" class="fas fa-link" title="Private links"></a>
       </td>
+    </tr>
+  {% endfor %}</tbody>
+</table>
+{%- endif %}
+{%- if deleted_datasets: %}
+<h2>Deleted</h2>
+<p>These drafts were deleted and are hidden from your other lists. Restore one to keep working on it, or delete it permanently.</p>
+<div id="table-deleted-loader" class="loader"></div>
+<table id="table-deleted" class="corporate-identity-table">
+  <thead>
+    <tr>
+      <th>Dataset</th>
+      <th>Type</th>
+      <th>Deleted&nbsp;at</th>
+      <th>Actions</th>
+    </tr>
+  </thead>
+  <tbody>{% for article in deleted_datasets: %}
+    <tr>
+      <td>{{article.title}}</td>
+      <td>{{article.defined_type_name | default("undefined", False)}}</td>
+      <td>{{article.deleted_date | truncate(10,False,'')}}</td>
+      <td>{% if not article.is_shared_with_me or (article.is_shared_with_me and article.is_supervisor) %}<a href="/my/datasets/{{article.container_uuid}}/restore" class="fas fa-sync" title="Restore this draft"></a>&nbsp;<a href="/my/datasets/{{article.container_uuid}}/delete-permanently" class="fas fa-trash-can delete-permanently" title="Delete permanently (cannot be undone)"></a>{% endif %}</td>
     </tr>
   {% endfor %}</tbody>
 </table>

--- a/src/djehuty/web/resources/sparql_templates/datasets.sparql
+++ b/src/djehuty/web/resources/sparql_templates/datasets.sparql
@@ -13,7 +13,7 @@ SELECT DISTINCT ?account_uuid ?citation ?confidential_reason ?container_uuid
                 ?institution_id ?is_active ?is_confidential ?is_embargoed ?is_restricted
                 ?is_metadata_record ?license_id ?license_name ?license_url ?license_spdx
                 ?metadata_reason ?modified_date ?published_date ?container_doi
-                ?resource_doi ?resource_title ?size ?status ?thumb ?declined_date
+                ?resource_doi ?resource_title ?size ?status ?thumb ?declined_date ?deleted_date ?is_deleted
                 ?timeline_posted ?has_draft (STR(?publisher_ut) AS ?publisher)
                 ?timeline_publisher_publication ?timeline_first_online
                 ?timeline_revision ?timeline_submission ?title ?url
@@ -123,6 +123,7 @@ WHERE {
     OPTIONAL { ?dataset djht:modified_date         ?modified_date . }
     OPTIONAL { ?dataset djht:published_date        ?published_date . }
     OPTIONAL { ?dataset djht:declined_date         ?declined_date . }
+    OPTIONAL { ?dataset djht:deleted_date          ?deleted_date . }
     OPTIONAL { ?dataset djht:resource_doi          ?resource_doi . }
     OPTIONAL { ?dataset djht:resource_title        ?resource_title . }
     OPTIONAL { ?dataset djht:size                  ?size . }
@@ -190,6 +191,9 @@ WHERE {
     OPTIONAL { ?dataset djht:is_under_review       ?is_under_review_tmp . }
     BIND(COALESCE(?is_under_review_tmp, "false"^^xsd:boolean) AS ?is_under_review)
 
+    OPTIONAL { ?dataset djht:is_deleted            ?is_deleted_tmp . }
+    BIND(COALESCE(?is_deleted_tmp, "false"^^xsd:boolean) AS ?is_deleted)
+
     BIND(STRAFTER(STR(?container_uri), "container:") AS ?container_uuid)
     BIND(STRAFTER(STR(?dataset), "dataset:")         AS ?uuid)
     BIND(STRAFTER(STR(?account), "account:")         AS ?account_uuid)
@@ -221,6 +225,13 @@ WHERE {
 FILTER (?is_under_review = "true"^^xsd:boolean)
 {%- else %}
 FILTER (?is_under_review = "false"^^xsd:boolean)
+{%- endif %}
+{%- endif %}
+{%- if is_deleted is not none: %}
+{%- if is_deleted: %}
+FILTER (?is_deleted = "true"^^xsd:boolean)
+{%- else %}
+FILTER (?is_deleted = "false"^^xsd:boolean)
 {%- endif %}
 {%- endif %}
 {%- if collection_uri is not none %}

--- a/src/djehuty/web/resources/sparql_templates/restore_dataset_draft.sparql
+++ b/src/djehuty/web/resources/sparql_templates/restore_dataset_draft.sparql
@@ -1,0 +1,17 @@
+{% extends "prefixes.sparql" %}
+{% block query %}
+DELETE {
+  GRAPH <{{state_graph}}> {
+    ?dataset   djht:is_deleted            ?is_deleted .
+    ?dataset   djht:deleted_date          ?deleted_date .
+  }
+}
+WHERE {
+  GRAPH <{{state_graph}}> {
+    ?dataset   rdf:type              djht:Dataset ;
+               djht:is_deleted       ?is_deleted .
+    OPTIONAL { ?dataset djht:deleted_date ?deleted_date . }
+  }
+  FILTER (?dataset = <dataset:{{dataset_uuid}}>)
+}
+{% endblock %}

--- a/src/djehuty/web/resources/sparql_templates/soft_delete_dataset_draft.sparql
+++ b/src/djehuty/web/resources/sparql_templates/soft_delete_dataset_draft.sparql
@@ -1,0 +1,23 @@
+{% extends "prefixes.sparql" %}
+{% block query %}
+DELETE {
+  GRAPH <{{state_graph}}> {
+    ?dataset   djht:is_deleted            ?is_deleted .
+    ?dataset   djht:deleted_date          ?deleted_date .
+  }
+}
+INSERT {
+  GRAPH <{{state_graph}}> {
+    ?dataset   djht:is_deleted            "true"^^xsd:boolean .
+    ?dataset   djht:deleted_date          "{{deleted_date}}"^^xsd:dateTime .
+  }
+}
+WHERE {
+  GRAPH <{{state_graph}}> {
+    ?dataset   rdf:type              djht:Dataset .
+    OPTIONAL { ?dataset djht:is_deleted   ?is_deleted . }
+    OPTIONAL { ?dataset djht:deleted_date ?deleted_date . }
+  }
+  FILTER (?dataset = <dataset:{{dataset_uuid}}>)
+}
+{% endblock %}

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -122,6 +122,8 @@ class WebServer:
             R("/my/datasets",                                                    self.ui_my_data),
             R("/my/datasets/<dataset_id>/edit",                                  self.ui_edit_dataset),
             R("/my/datasets/<dataset_id>/delete",                                self.ui_delete_dataset),
+            R("/my/datasets/<dataset_id>/restore",                               self.ui_restore_dataset),
+            R("/my/datasets/<dataset_id>/delete-permanently",                    self.ui_delete_dataset_permanently),
             R("/my/datasets/<dataset_uuid>/private_links",                       self.ui_dataset_private_links),
             R("/my/datasets/<dataset_uuid>/private_link/<link_id>/delete",       self.ui_dataset_delete_private_link),
             R("/my/datasets/<dataset_uuid>/private_link/new",                    self.ui_dataset_new_private_link),
@@ -1056,7 +1058,7 @@ class WebServer:
     def __dataset_by_id_or_uri (self, identifier, account_uuid=None,
                                 is_published=True, is_latest=False,
                                 is_under_review=None, version=None,
-                                use_cache=True):
+                                use_cache=True, is_deleted=False):
         try:
             if version is not None and not parses_to_int (version):
                 return None
@@ -1065,6 +1067,7 @@ class WebServer:
                 "is_published": is_published,
                 "is_latest": is_latest,
                 "is_under_review": is_under_review,
+                "is_deleted": is_deleted,
                 "version": version,
                 "account_uuid": account_uuid,
                 "use_cache": use_cache,
@@ -2216,6 +2219,11 @@ class WebServer:
                                                limit           = 10000,
                                                is_latest       = True,
                                                is_under_review = False)
+        deleted_datasets   = self.db.datasets (account_uuid    = account_uuid,
+                                               limit           = 10000,
+                                               is_published    = False,
+                                               is_under_review = None,
+                                               is_deleted      = True)
 
         draft_datasets     = self.__datasets_with_storage_usage (draft_datasets)
         review_datasets    = self.__datasets_with_storage_usage (review_datasets)
@@ -2224,7 +2232,8 @@ class WebServer:
         return self.__render_template (request, "depositor/my-data.html",
                                        draft_datasets     = draft_datasets,
                                        review_datasets    = review_datasets,
-                                       published_datasets = published_datasets)
+                                       published_datasets = published_datasets,
+                                       deleted_datasets   = deleted_datasets)
 
     def ui_collection_published (self, request, collection_id):
         """Implements /my/collections/published/<id>."""
@@ -2294,11 +2303,16 @@ class WebServer:
             return self.error_403 (request, (f"account:{account_uuid} attempted to create "
                                              f"new version of dataset:{dataset_id}."))
 
+        # is_deleted=None so a soft-deleted draft also blocks a second one.
         existing_draft = self.__dataset_by_id_or_uri (container_uuid,
                                                       is_published = False,
                                                       account_uuid = account_uuid,
+                                                      is_deleted   = None,
                                                       use_cache    = False)
         if existing_draft is not None:
+            if value_or (existing_draft, "is_deleted", False):
+                self.log.info ("Refusing to create a draft while a deleted one exists.")
+                return redirect ("/my/datasets", code=302)
             self.log.info ("Refusing to create two drafts for one dataset.")
             return redirect (f"/my/datasets/{container_uuid}/edit", code=302)
 
@@ -2394,10 +2408,80 @@ class WebServer:
                                                  f"to delete dataset:{dataset_id}."))
 
             container_uuid = dataset["container_uuid"]
-            if self.db.delete_dataset_draft (container_uuid, dataset["uuid"], account_uuid, dataset["account_uuid"]):
+            if self.db.soft_delete_dataset_draft (container_uuid, dataset["uuid"], account_uuid, dataset["account_uuid"]):
                 return redirect ("/my/datasets", code=303)
 
             return self.error_404 (request)
+        except (IndexError, KeyError):
+            pass
+
+        return self.error_500 ()
+
+    def ui_restore_dataset (self, request, dataset_id):
+        """Implements /my/datasets/<id>/restore."""
+        if not self.accepts_html (request):
+            return self.error_406 ("text/html")
+
+        account_uuid, error_response = self.__depositor_account_uuid (request)
+        if error_response is not None:
+            return error_response
+
+        try:
+            dataset = self.__dataset_by_id_or_uri (dataset_id,
+                                                   account_uuid=account_uuid,
+                                                   is_published=False,
+                                                   is_deleted=True)
+
+            if dataset is None:
+                return self.error_403 (request, (f"account:{account_uuid} attempted "
+                                                 f"to restore dataset:{dataset_id}."))
+
+            # Existence confirmed above; a falsy result is a failed update.
+            container_uuid = dataset["container_uuid"]
+            if self.db.restore_dataset_draft (container_uuid, dataset["uuid"], account_uuid, dataset["account_uuid"]):
+                return redirect ("/my/datasets", code=303)
+
+            return self.error_500 ()
+        except (IndexError, KeyError):
+            pass
+
+        return self.error_500 ()
+
+    def ui_delete_dataset_permanently (self, request, dataset_id):
+        """Implements /my/datasets/<id>/delete-permanently."""
+        if not self.accepts_html (request):
+            return self.error_406 ("text/html")
+
+        account_uuid, error_response = self.__depositor_account_uuid (request)
+        if error_response is not None:
+            return error_response
+
+        try:
+            dataset = self.__dataset_by_id_or_uri (dataset_id,
+                                                   account_uuid=account_uuid,
+                                                   is_published=False,
+                                                   is_deleted=True)
+
+            if dataset is None:
+                return self.error_403 (request, (f"account:{account_uuid} attempted "
+                                                 f"to permanently delete dataset:{dataset_id}."))
+
+            if request.method != "POST":
+                return self.__render_template (
+                    request, "depositor/delete-dataset-permanently.html",
+                    dataset = dataset)
+
+            if request.form.get ("confirm") != "yes":
+                return self.__render_template (
+                    request, "depositor/delete-dataset-permanently.html",
+                    dataset = dataset,
+                    error   = "Please tick the confirmation box. Nothing was deleted.")
+
+            container_uuid = dataset["container_uuid"]
+            if self.db.delete_dataset_draft (container_uuid, dataset["uuid"], account_uuid, dataset["account_uuid"]):
+                return redirect ("/my/datasets", code=303)
+
+            return self.error_500 ()
         except (IndexError, KeyError):
             pass
 
@@ -5503,7 +5587,7 @@ class WebServer:
                                                            is_published=False)
 
                 container_uuid = dataset["container_uuid"]
-                if self.db.delete_dataset_draft (container_uuid, dataset["uuid"], account_uuid, dataset["account_uuid"]):
+                if self.db.soft_delete_dataset_draft (container_uuid, dataset["uuid"], account_uuid, dataset["account_uuid"]):
                     return self.respond_204()
             except (IndexError, KeyError):
                 pass

--- a/tests/e2e/tests/test_dataset.py
+++ b/tests/e2e/tests/test_dataset.py
@@ -200,8 +200,10 @@ class TestDeleteDataset:
         authenticated_page.wait_for_load_state("domcontentloaded")
         screenshot(authenticated_page, "after-delete-from-list")
 
-        # The unique title should not appear anymore
-        expect(authenticated_page.locator("body")).not_to_contain_text(unique_title)
+        expect(authenticated_page.locator("#table-deleted")).to_contain_text(unique_title)
+        drafts_table = authenticated_page.locator("#table-unpublished")
+        if drafts_table.count() > 0:
+            expect(drafts_table).not_to_contain_text(unique_title)
 
 
 @pytest.mark.dataset

--- a/tests/e2e/tests/test_soft_delete.py
+++ b/tests/e2e/tests/test_soft_delete.py
@@ -1,0 +1,105 @@
+"""
+Soft-delete lifecycle tests for draft datasets.
+
+Covers:
+    - Deleting a draft moves it out of Drafts and into the Deleted list
+      (it is soft-deleted, not purged).
+    - Restoring a soft-deleted draft returns it to Drafts.
+    - Permanent deletion is title-gated and removes the draft for good.
+
+Run with:
+    cd tests/e2e && python -m pytest tests/test_soft_delete.py -v
+"""
+
+import uuid
+
+import pytest
+from playwright.sync_api import Page, expect
+
+from config import BASE_URL
+from helpers.dataset import create_draft_dataset, get_container_uuid_from_url
+from pages.dataset_editor_page import DatasetEditorPage
+
+
+def _named_draft(page: Page) -> tuple[str, str, str]:
+    """Create a draft with a unique title. Returns (edit_url, container_uuid, title)."""
+    url = create_draft_dataset(page)
+    editor = DatasetEditorPage(page)
+    title = f"SoftDelete-{uuid.uuid4().hex[:8]}"
+    editor.set_title(title)
+    editor.save()
+    return url, get_container_uuid_from_url(url), title
+
+
+@pytest.mark.dataset
+class TestSoftDelete:
+    def test_deleted_draft_moves_to_deleted_list(self, authenticated_page: Page, screenshot):
+        """A deleted draft leaves Drafts and appears under Deleted."""
+        url, _container, title = _named_draft(authenticated_page)
+
+        authenticated_page.goto(url)
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        DatasetEditorPage(authenticated_page).delete()
+
+        authenticated_page.goto("/my/datasets")
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        screenshot(authenticated_page, "after-soft-delete")
+
+        expect(authenticated_page.locator("#table-deleted")).to_contain_text(title)
+        drafts_table = authenticated_page.locator("#table-unpublished")
+        if drafts_table.count() > 0:
+            expect(drafts_table).not_to_contain_text(title)
+
+    def test_restore_returns_draft_to_drafts(self, authenticated_page: Page, screenshot):
+        """Restoring a soft-deleted draft puts it back in Drafts."""
+        url, container, title = _named_draft(authenticated_page)
+
+        authenticated_page.goto(url)
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        DatasetEditorPage(authenticated_page).delete()
+
+        # Restore via the endpoint the Deleted-list button targets.
+        authenticated_page.goto(f"/my/datasets/{container}/restore")
+        authenticated_page.wait_for_url("**/my/datasets", wait_until="domcontentloaded")
+        screenshot(authenticated_page, "after-restore")
+
+        expect(authenticated_page.locator("#table-unpublished")).to_contain_text(title)
+        deleted_table = authenticated_page.locator("#table-deleted")
+        if deleted_table.count() > 0:
+            expect(deleted_table).not_to_contain_text(title)
+
+    def test_permanent_delete_requires_confirmation(self, authenticated_page: Page, screenshot):
+        """Without ticking the box nothing is deleted; ticking it purges the draft."""
+        url, container, title = _named_draft(authenticated_page)
+
+        authenticated_page.goto(url)
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        DatasetEditorPage(authenticated_page).delete()
+
+        # Submitting without ticking the box keeps the record.
+        authenticated_page.goto(f"/my/datasets/{container}/delete-permanently")
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        authenticated_page.get_by_role("button", name="Delete permanently").click()
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        authenticated_page.goto("/my/datasets")
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        expect(authenticated_page.locator("#table-deleted")).to_contain_text(title)
+
+        # Ticking the box purges it.
+        authenticated_page.goto(f"/my/datasets/{container}/delete-permanently")
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        authenticated_page.locator("#confirm").check()
+        authenticated_page.get_by_role("button", name="Delete permanently").click()
+        authenticated_page.wait_for_url("**/my/datasets", wait_until="domcontentloaded")
+        screenshot(authenticated_page, "after-permanent-delete")
+
+        expect(authenticated_page.locator("body")).not_to_contain_text(title)
+
+
+@pytest.mark.dataset
+class TestSoftDeleteAccessControl:
+    def test_restore_unknown_dataset_is_forbidden(self, authenticated_page: Page):
+        """Restoring a dataset the account does not own returns 403."""
+        response = authenticated_page.goto(f"/my/datasets/{uuid.uuid4()}/restore")
+        assert response is not None
+        assert response.status == 403

--- a/tests/e2e/tests/test_versioning.py
+++ b/tests/e2e/tests/test_versioning.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 from playwright.sync_api import Page, expect
 
+from config import BASE_URL
 from helpers.dataset import (
     create_draft_dataset,
     get_container_uuid_from_url,
@@ -475,3 +476,41 @@ class TestVersionAccess:
 
         assert len(versions) >= 1
         assert any(v["version"] == 1 for v in versions)
+
+
+@pytest.mark.versioning
+@pytest.mark.dataset
+class TestNewVersionWithDeletedDraft:
+    """A soft-deleted draft still occupies the container's single draft slot."""
+
+    def test_soft_deleted_draft_blocks_second_new_version(
+        self, authenticated_page: Page, published_dataset: str, screenshot
+    ):
+        """Creating a new-version draft, soft-deleting it, then requesting
+        another must not create a second draft on the same container."""
+        container_uuid = published_dataset
+
+        # First new-version draft.
+        authenticated_page.goto(f"/my/datasets/{container_uuid}/new-version-draft")
+        authenticated_page.wait_for_url("**/my/datasets/*/edit")
+        authenticated_page.wait_for_load_state("domcontentloaded")
+
+        # Soft-delete it.
+        DatasetEditorPage(authenticated_page).delete()
+
+        # Requesting another new version must be refused, not create a second draft.
+        authenticated_page.goto(f"/my/datasets/{container_uuid}/new-version-draft")
+        authenticated_page.wait_for_load_state("domcontentloaded")
+        screenshot(authenticated_page, "new-version-blocked-by-deleted-draft")
+        expect(authenticated_page).to_have_url(f"{BASE_URL}/my/datasets")
+
+        # The container's deleted draft is listed exactly once, and it has
+        # no active draft.
+        deleted_table = authenticated_page.locator("#table-deleted")
+        expect(deleted_table).to_be_visible()
+        restore_link = f'a[href="/my/datasets/{container_uuid}/restore"]'
+        expect(deleted_table.locator(f"tbody tr:has({restore_link})")).to_have_count(1)
+        drafts_table = authenticated_page.locator("#table-unpublished")
+        if drafts_table.count() > 0:
+            edit_link = f'a[href="/my/datasets/{container_uuid}/edit"]'
+            expect(drafts_table.locator(edit_link)).to_have_count(0)

--- a/tests/unit/test_migrate.py
+++ b/tests/unit/test_migrate.py
@@ -50,10 +50,25 @@ def in_memory_dataset():
 
 
 @pytest.fixture
-def runner_real(in_memory_dataset, real_migrations_dir):
+def initial_only_migrations_dir(real_migrations_dir, tmp_path):
+    """Copy of the production dir holding only 0001_initial.ttl.
+
+    These tests assert on the initial seed specifically (head == 0001,
+    a single applied migration); isolating it keeps them stable as real
+    migrations accumulate in the production directory.
+    """
+    dest = tmp_path / "initial_only"
+    dest.mkdir()
+    src = real_migrations_dir / "0001_initial.ttl"
+    (dest / src.name).write_text(src.read_text())
+    return dest
+
+
+@pytest.fixture
+def runner_real(in_memory_dataset, initial_only_migrations_dir):
     return MigrationRunner(
         sparql_graph=in_memory_dataset,
-        migrations_dir=real_migrations_dir,
+        migrations_dir=initial_only_migrations_dir,
         target_graph=STATE_GRAPH,
         migrations_graph=MIG_GRAPH,
         djehuty_version="test",


### PR DESCRIPTION
## Summary

Draft deletion is currently a hard delete: the depositor's "delete" removes every triple of the draft, and it cannot be undone.  This change makes draft deletion a soft delete, so the draft is flagged and hidden instead of removed, listed in a new "Deleted" section on /my/datasets, from where the depositor can restore it or permanently delete it behind a typed-title confirmation. The existing hard-delete query is reused unchanged for the permanent path. Uploaded files on S3 are not touched by either path.

## Changes
- src/djehuty/schema/migrations/0002_add_dataset_is_deleted.ttl: new migration declaring the djht:is_deleted and djht:deleted_date predicates. Absence means "not deleted", so existing drafts need no back-fill.
- src/djehuty/web/resources/sparql_templates/soft_delete_dataset_draft.sparql: new — sets the deleted flag and timestamp, keeps all triples and the container→draft link. Same owner/supervisor authorization filter as the hard delete.
- src/djehuty/web/resources/sparql_templates/restore_dataset_draft.sparql: new — clears the deleted flag.
- src/djehuty/web/resources/sparql_templates/datasets.sparql: select/bind is_deleted + deleted_date; add an is_deleted filter (True/False/None → only-deleted / exclude-deleted / no-filter).
- src/djehuty/web/database.py: datasets() gains an is_deleted param (defaults to False, so every existing caller excludes soft-deleted drafts). New soft_delete_dataset_draft / restore_dataset_draft methods plus a shared cache-invalidation helper. The hard delete_dataset_draft is unchanged.
- src/djehuty/web/wsgi.py: new /restore and /delete-permanently routes and handlers; the two everyday delete callers now soft-delete; ui_my_data renders a "Deleted" bucket; the new-version-draft guard queries with is_deleted=None so a soft-deleted draft still blocks a second draft on the container.
- src/djehuty/web/resources/html_templates/depositor/my-data.html: "Deleted" section with Restore / Delete-permanently actions.
- src/djehuty/web/resources/html_templates/depositor/delete-dataset-permanently.html: new — typed-title confirmation page for permanent deletion.
- tests/e2e/tests/test_soft_delete.py: new — soft-delete moves a draft to Deleted, restore returns it to Drafts, permanent delete is title-gated, and restore access-control.
- tests/e2e/tests/test_versioning.py: regression test — a soft-deleted draft blocks creating a second new-version draft.
- tests/unit/test_migrate.py: isolate runner_real to a copy containing only 0001_initial.ttl, so the initial-seed assertions stay stable as real migrations accumulate.
- docs/knowledge-graph.md: new Soft-deleted drafts subsection under Datasets.
- doc/knowledge-graph.tex: new Soft-deleted drafts subsection under Datasets.

## Approval Checklist
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

## Issue Reference (optional - PRs may not be associated with an issue)


## Screenshots (optional)

<img width="1512" height="864" alt="Screenshot 2026-08-03 at 08 52 02" src="https://github.com/user-attachments/assets/8c998099-cf9a-45c4-955f-b4ec138dc984" />

<img width="1512" height="864" alt="Screenshot 2026-08-03 at 08 52 29" src="https://github.com/user-attachments/assets/538a2371-f596-4f4b-8b91-44ee9d59e4ef" />

<img width="1512" height="864" alt="Screenshot 2026-08-03 at 08 52 57" src="https://github.com/user-attachments/assets/77e918f4-7bd9-4b23-8e3a-b8d902698f86" />


## Notes (optional)

Additional context, caveats, or follow-up tasks.