### PR TITLE
fix: strip username from saml common name

### DIFF
--- a/src/djehuty/utils/convenience.py
+++ b/src/djehuty/utils/convenience.py
@@ -376,6 +376,17 @@ def strip_string(input_string):
     return input_string
 
 
+def strip_parenthesized_suffix(value):
+    """Removes a trailing parenthesized token from VALUE.
+
+    'Surname, N. (nsurname)' -> 'Surname, N.'
+    """
+    if not isinstance(value, str):
+        return value
+    stripped = re.sub(r"\s*\([^()]*\)\s*$", "", value).strip()
+    return stripped if stripped else value.strip()
+
+
 def normalize_identifier(value, prefix_url):
     """Procedure to rewrite URLs to URIs."""
     # Don't process invalid entries

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -51,6 +51,7 @@ from djehuty.utils.convenience import (
     self_or_value_or_none,
     split_author_name,
     split_string,
+    strip_parenthesized_suffix,
     value_or,
     value_or_none,
 )
@@ -1502,7 +1503,7 @@ class WebServer:
             record["email"]      = attributes[config.saml_attribute_email][0]
             record["first_name"] = attributes[config.saml_attribute_first_name][0]
             record["last_name"]  = attributes[config.saml_attribute_last_name][0]
-            record["common_name"] = attributes[config.saml_attribute_common_name][0]
+            record["common_name"] = strip_parenthesized_suffix (attributes[config.saml_attribute_common_name][0])
             record["domain"] = None
             record["group_uuid"] = None
 

--- a/tests/unit/test_convenience.py
+++ b/tests/unit/test_convenience.py
@@ -1,0 +1,27 @@
+"""Unit tests for convenience helpers."""
+
+import pytest
+
+from djehuty.utils.convenience import strip_parenthesized_suffix
+
+
+class TestStripParenthesizedSuffix:
+    """Login names appended by identity providers must be stripped."""
+
+    @pytest.mark.parametrize("value, expected", [
+        ("Surname, N. (namesurname)", "Surname, N."),
+        ("Doe, J.(jdoe)", "Doe, J."),
+        ("Doe, J. (jdoe) ", "Doe, J."),
+        ("van Doe, J. (jvandoedoe) ", "van Doe, J."),
+        ("Jansen, P.", "Jansen, P."),
+        ("Robert (Bob) Smith", "Robert (Bob) Smith"),
+        ("(jdoe)", "(jdoe)"),
+        (" Jansen, P. ", "Jansen, P."),
+        ("", ""),
+    ])
+    def test_strips_only_trailing_parenthesized_token(self, value, expected):
+        assert strip_parenthesized_suffix(value) == expected
+
+    @pytest.mark.parametrize("value", [None, 42])
+    def test_non_string_values_pass_through(self, value):
+        assert strip_parenthesized_suffix(value) is value


### PR DESCRIPTION
**Summary**

Some identity providers append the login name to the display name
attribute, e.g. 'Surname, N. (namesurname)'.  The common name is
Strip the trailing parenthesized token when reading the SAML
attributes


**Changes**
- src/djehuty/utils/convenience.py: add the strip functionality utility 
- src/djehuty/web/wsgi.py: add the use of the `strip_parenthesized_suffix`
- tests/unit/test_convenience.py: add tests for avoid regression (unit)

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #229

**Screenshots (optional)**


**Notes (optional)**

Additional context, caveats, or follow-up tasks.