### PR TITLE
doc: Migrate contact e-mail addresses to the djehuty.4tu.nl domain.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -25,7 +25,7 @@ With these considerations in mind, we agree to behave mindfully toward each othe
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, contact Core Maintainers via email at [djehuty@4tu.nl](mailto:djehuty@4tu.nl).
+When an incident does occur, it is important to report it promptly. To report a possible violation, contact Core Maintainers via email at [security@djehuty.4tu.nl](mailto:security@djehuty.4tu.nl).
 
 Core Maintainers take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Core Maintainers will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ We welcome contributions in the form of bug reports and feature suggestions. Her
 
 1. **Contact us!**
 
-    Before starting any work, please **contact repository maintainers at [djehuty@4tu.nl](mailto:djehuty@4tu.nl)** to discuss how your idea fits with our strategic goals.
+    Before starting any work, please **contact repository maintainers at [info@djehuty.4tu.nl](mailto:info@djehuty.4tu.nl)** to discuss how your idea fits with our strategic goals.
 
 2. **Check or open an issue**
 
@@ -77,7 +77,7 @@ We welcome contributions in the form of bug reports and feature suggestions. Her
 
     After review and approval, your PR must be squashed into a single commit using the project’s [commit message template](#commit-message-template). Once the checklist is complete, a maintainer will rebase-merge it into the main branch to keep the history clean.
 
-If you want to make a very small contribution, such as one or a few lines of code for which following the code contributions workflow is not convenient, please contact the [core maintainers](mailto:djehuty@4tu.nl).
+If you want to make a very small contribution, such as one or a few lines of code for which following the code contributions workflow is not convenient, please contact the [core maintainers](mailto:info@djehuty.4tu.nl).
 
 ---
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -141,8 +141,8 @@ to maintain a welcoming and inclusive environment.
 
 ## Contact information
 - Core maintainer: g.kuhn@tudelft.nl
-- Governance questions: djehuty@4tu.nl
-- Security issues: djehuty@4tu.nl
+- Governance questions: info@djehuty.4tu.nl
+- Security issues: security@djehuty.4tu.nl
 
 Djehuty governance is reviewed periodically and will be improved with the involvement of our community members.
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ This runs `ruff check` (bugs, style errors, import sorting) and `ruff format --c
 
 ---
 ### Contact information
+- **General**: info@djehuty.4tu.nl
 - **Maintainers**: a.e.wilczynska@tudelft.nl, g.kuhn@tudelft.nl, k.f.deAraujo@tudelft.nl
-- **Security issues**: djehuty@4tu.nl
+- **Security issues**: security@djehuty.4tu.nl
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Reporting a Vulnerability
 
 If you discover a security vulnerability in djehuty, please report it
-**privately** by emailing [djehuty@4tu.nl](mailto:djehuty@4tu.nl).
+**privately** by emailing [security@djehuty.4tu.nl](mailto:security@djehuty.4tu.nl).
 
 **Please do not open a public issue for security vulnerabilities.**
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -8,13 +8,13 @@ for news, events, opportunities and announcements regarding `djehuty` and 4TU.Re
 ## General inquiries
 
 For questions about the project or requests, e-mail us at
-[djehuty@4tu.nl](mailto:djehuty@4tu.nl).
+[info@djehuty.4tu.nl](mailto:info@djehuty.4tu.nl).
 
 ## Reporting security vulnerabilities
 
 For security-related matters, please take a look at the
 [security policy](https://github.com/4TUResearchData/djehuty?tab=security-ov-file#readme)
-document and e-mail us at [djehuty@4tu.nl](mailto:djehuty@4tu.nl).
+document and e-mail us at [security@djehuty.4tu.nl](mailto:security@djehuty.4tu.nl).
 
 ## Contact the team
 
@@ -31,4 +31,4 @@ Software Engineer @ TU Delft
 Senior Software Engineer @ TU Delft
 
 **For general questions about 4TU.ResearchData** :
-[researchdata@4tu.nl](mailto:researchdata@4tu.nl)
+[info@djehuty.4tu.nl](mailto:info@djehuty.4tu.nl)


### PR DESCRIPTION
**Summary**

Migrates the project's contact addresses from `djehuty@4tu.nl` and `researchdata@4tu.nl` to the two new mailboxes on the `djehuty.4tu.nl` domain: `info@djehuty.4tu.nl` for general inquiries and `security@djehuty.4tu.nl` for security and confidential reports.

Both new mailboxes have been created, with credentials held by @mdesmaele and @kairoaraujo (also in Bitwarden).

**Changes**
- `README.md`: add a **General** contact line; route security issues to `security@djehuty.4tu.nl`.
- `SECURITY.md`: report vulnerabilities to `security@djehuty.4tu.nl`.
- `CODE_OF_CONDUCT.md`: report conduct violations to `security@djehuty.4tu.nl`.
- `CONTRIBUTING.md`: contact maintainers at `info@djehuty.4tu.nl` (pre-work discussion and small contributions).
- `GOVERNANCE.md`: split governance questions to `info@djehuty.4tu.nl` and security issues to `security@djehuty.4tu.nl`.
- `docs/contact.md`: replace both old addresses with the new ones.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference**

Mentioned in #36

**Notes**

- `LICENSE` is deliberately excluded. The `researchdata@4tu.nl` address there is  part of a registered copyright record rather than contact routing, and per the team lead it stays as-is; any future change to it is theirs to make.
- Two files still reference `djehuty@4tu.nl` and are intentionally left out as we move onto markdown documentation:
  `.github/ISSUE_TEMPLATE/config.yml` and `doc/contact.tex`.