### PR TITLE
Feat/new http foundation

### DIFF
--- a/docs/http-migration.md
+++ b/docs/http-migration.md
@@ -1,0 +1,253 @@
+# HTTP stack migration: Werkzeug to FastAPI
+
+## The goal
+
+Replace the ~10k line `src/djehuty/web/wsgi.py` with a FastAPI stack.
+
+We ship it one route group at a time. Every group can be switched between the new
+implementation and the legacy one in
+production, independently. So if `/api/v3` (new) misbehaves in your deployment, we do
+not scramble on a hotfix and a redeploy. We flip that one group back to legacy,
+restart, and we are back to known-good in seconds. Then we fix the new code calmly,
+test it, deploy, and flip it on again.
+
+## Principles
+
+1. **AS-IS.** Users notice nothing. The new handlers reproduce the legacy behaviour
+   faithfully, including quirks, so switching new/legacy is invisible to clients.
+2. **Reversible per group.** Any group can be flipped new to legacy (or back) with a
+   config change and a restart. No code change, no rebuild, no new image.
+3. **Detached.** The new code lives in its own package tree (`djehuty.api`,
+   `djehuty.auth`, `djehuty.views`, `djehuty.services`). The legacy `wsgi.py` stays
+   untouched until we delete it. It is always clear what will be removed.
+4. **Incremental in and out.** Groups arrive one PR at a time, and legacy is removed
+   one group at a time. No step is large enough to be scary.
+
+## What we do not touch: the database and business logic
+
+This is the part that matters most for keeping the risk low, so it is worth
+being explicit for anyone worried about the change.
+
+The migration replaces the HTTP layer: the code that parses a request and builds a
+response. It does not rewrite what the application actually does. Two categories:
+
+**Shared, never copied, never modified.** The database interface
+(`djehuty.web.database`, the SparqlInterface) and the neutral core (`validator`,
+`formatter`, `config`, `s3`, `locks`, `email_handler`, `convenience`, `constants`)
+stay exactly where they are. The new handlers receive the same `db` object the legacy
+server uses and call the same methods (`db.datasets(...)`,
+`db.account_by_session_token(...)`, and so on). Same code, same queries, same results.
+There is no second copy to drift, so there is no way for these to behave differently
+between new and legacy. This is where most of the business logic actually lives, and
+we do not go near it.
+
+**Copied AS-IS, legacy left intact.** Some logic used to live inside the `wsgi.py`
+handler methods: the SAML attribute mapping, the account-creation side effects on
+login, git repository resolution, and so on. To use it from the new stack without
+importing `wsgi.py`, we copy it verbatim into `djehuty.services`, preserving behaviour
+line for line. We do NOT edit the legacy copy. That is deliberate: legacy stays
+self-contained and fully working, which is exactly what makes a toggle-back safe. So
+during the migration this logic lives in two places on purpose. The copies are pinned
+by the AS-IS test suite, and the duplication disappears when a group's legacy handlers
+are removed (see "Removing legacy later").
+
+What guarantees we did not change behaviour:
+
+- An isolation test asserts no new-stack module imports `djehuty.web.wsgi`.
+- The AS-IS contract tests pin the exact status codes and payloads, including known
+  legacy quirks, so new and legacy respond identically.
+- `wsgi.py` is not edited when a group is added. It is only touched when that group's
+  legacy handlers are finally deleted.
+
+## How it works
+
+The new stack is one umbrella FastAPI app (`djehuty.application:create_app`) that
+mounts every new router. In front of it sits a small WSGI dispatcher that decides,
+per request, whether the new stack or the legacy `wsgi.py` handles it. Both entry
+points serve the dispatcher — the internal development server and the uWSGI
+`application` entry point (which builds it once and reuses it across requests) — so
+deployments behave the same either way.
+
+```mermaid
+flowchart TD
+    request([incoming request]) --> dispatcher["WebServiceDispatcher<br/>(matches path &rarr; group)"]
+    dispatcher -->|group toggle = new| new["umbrella FastAPI app<br/>(djehuty.application)"]
+    dispatcher -->|group toggle = legacy| legacy["legacy wsgi.py<br/>(djehuty.web.wsgi)"]
+```
+
+Three pieces:
+
+- **Route-group registry.** One module maps each group to its path matchers, for
+  example `api-v3` owns everything under `/v3/`, `admin` owns `/admin/`. This is the
+  single source of truth for "which group does this path belong to".
+- **Umbrella app.** Always mounts all the new routers. Mounting a router does not
+  make it live; the dispatcher decides that.
+- **Per-group dispatcher.** For each request: find the group for the path, read that
+  group's toggle, send the request to the new app or to legacy.
+
+## Configuration
+
+The `web-service` section lives at the top level of the config file. `default` is the
+global posture (`new` or `legacy`); `groups` pins individual groups. JSON, since the
+XML config is deprecated:
+
+```json
+"web-service": {
+  "default": "new",
+  "groups": {
+    "api-v2": "new",
+    "admin": "legacy"
+  }
+}
+```
+
+Read this as: everything runs on the new stack, except `admin`, which runs on legacy.
+The old flat `"web-service": "new"` / `"legacy"` value still works as a global default,
+and `api-service` is accepted as a back-compat alias for the key.
+
+**The config is optional.** With no `web-service` block, `default` is `new`, so every
+group runs new. The config is there for visibility and control, not because the code
+needs it.
+
+**Every group lists itself.** Each group's PR adds its own line under `groups`, set to
+`"new"` (foundation registers none; api-v2 adds `api-v2`, api-v3 adds `api-v3`, ...).
+A group set to `"new"` is a no-op functionally (that is the default), but the config
+becomes a dashboard: operators see every surface and its state, and rolling one back is
+changing one word to `"legacy"`. A group missing from the config still falls back to
+`default`, so a forgotten line never breaks anything.
+
+**The docs are always on.** The `api-docs` group (`/api/docs`, `/api/redoc`,
+`/api/openapi.json`) is `always_new`: it is served by the new stack regardless of the
+toggle, so the API reference stays available even with `{"default": "legacy",
+"groups": {}}`. It is not listed under `groups` because it is not toggleable. Legacy
+has no `/api/` routes, so this is always safe.
+
+Per environment matters. Production can pin a group to `legacy` while it is still being
+validated, even though the default is `new`. Staging can run everything `new`.
+
+**Flipping in production:** change the one value, restart the service. That is the whole
+procedure. Restart is fast and needs no rebuild. Live reload without a restart is
+possible later, but a restart is good enough and simpler to reason about.
+
+## Route groups
+
+Each group is one PR and one toggle. Approximate route counts from the legacy URL map:
+
+| Group            | Owns (paths)                                                        | Routes | Legacy handlers |
+|------------------|---------------------------------------------------------------------|-------:|-----------------|
+| `api-v2`         | `/v2/`                                                               |   ~56  | `api_*` v2       |
+| `api-v3`         | `/v3/`                                                               |   ~60  | `api_v3_*`       |
+| `auth`           | `/login`, `/logout`, `/saml/`                                        |     4  | `ui_login`, `ui_logout`, `saml_metadata` |
+| `public-ui`      | `/`, `/portal`, `/browse`, `/robots.txt`, `/sitemap.xml`, `/theme/`, `/categories/`, `/category`, `/institutions/`, `/authors/`, `/search`, `/opendap_to_doi`, `/feedback`, `/data_access_request` | ~15 | `ui_home`, `ui_categories`, ... |
+| `datasets-ui`    | `/datasets/`, `/articles/`, `/private_datasets/`                     |    ~9  | `ui_dataset`, `ui_private_dataset` |
+| `collections-ui` | `/collections/`, `/private_collections/`                            |    ~5  | `ui_collection`, `ui_private_collection` |
+| `my`             | `/my/`                                                               |   ~25  | `ui_my_*`        |
+| `admin`          | `/admin/`                                                            |   ~23  | `ui_admin_*`     |
+| `review`         | `/review/`                                                           |     5  | `ui_review_*`    |
+| `exports`        | `/export`, `/ndownloader`, `/file`                                  |    ~4  | export/download handlers |
+| `iiif`           | `/iiif/`                                                             |     5  | `iiif_v3_*`      |
+| `misc`           | `/account`, leftovers                                                |    ~2  | misc            |
+
+The API and public-ui groups are largely done on `refact/fastapi`. The heavy remaining
+work is `my` and `admin`.
+
+## Branch and PR structure
+
+Every migration branch is prefixed `feat/new-http-` so the work is recognizable at a
+glance. Each branch is one PR into the `new-http` integration branch.
+
+```
+main
+ +-- new-http                    integration branch, forked from main
+      +-- feat/new-http-foundation      registry + per-group dispatcher + toggle config + umbrella skeleton + test harness (+ this doc)
+      +-- feat/new-http-api-v2
+      +-- feat/new-http-api-v3
+      +-- feat/new-http-auth
+      +-- feat/new-http-public-ui       also brings the templating foundation (djehuty.views)
+      +-- feat/new-http-datasets-ui
+      +-- feat/new-http-collections-ui
+      +-- feat/new-http-my
+      +-- feat/new-http-admin
+      +-- feat/new-http-review
+      +-- feat/new-http-exports
+      +-- feat/new-http-iiif
+      +-- feat/new-http-misc
+```
+
+Rules of the road:
+
+- **`feat/new-http-foundation` lands first** and adds no user-facing behaviour. Every
+  group defaults to a no-op until its PR registers it. Easy, low-anxiety review. It also
+  carries this design doc.
+- Each group PR = the new router(s) + register the group in the dispatcher + tests.
+- Commits inside a PR are organized, not one blob. A typical shape:
+  1. extract framework-neutral logic into `djehuty.services`
+  2. add the FastAPI router
+  3. register the group + wire the dispatcher
+  4. tests (unit + e2e)
+- The groups depend on each other (for example `api-v3` reuses shared code from
+  `api-v2`), so the branches form a chain. Two equivalent ways to manage it:
+  - **Merge-as-you-go:** merge each `feat/new-http-*` into `new-http` (a
+    regular `--no-ff` merge, not squash, to keep the organized commits) as it is
+    ready, then branch the next group off the updated `new-http`. One
+    integration point, no deep rebases. This is the default.
+  - **Stacked branches:** base each group branch on the previous one and keep them
+    open as a stack (each PR's base is the branch below). Cleaner incremental diffs
+    and nothing merges until the end, at the cost of restacking (use
+    `git rebase --update-refs`) whenever a lower branch changes. Merge bottom-up.
+- `new-http` stays mergeable to `main` at any time, because merged groups can
+  default `new` or be pinned `legacy` per environment.
+
+## Rollback runbook
+
+The scenario this whole design exists for. Say `/api/v3` on the new stack shows a bug
+in production:
+
+1. Edit the production config: set `web-service.groups.api-v3 = "legacy"`.
+2. Restart the service. `/v3/` is now served by legacy `wsgi.py` again. Users are back
+   to known-good behaviour. No code change was needed.
+3. Reproduce and fix the bug on a branch off `new-http`. Add a test that covers
+   it. Get it reviewed and merged.
+4. Deploy the new image.
+5. Set `web-service.groups.api-v3` back to `"new"` (or remove the override), restart.
+
+Time-to-mitigation is a config edit and a restart, not a code-fix-build-deploy cycle.
+
+## Removing legacy later
+
+Same safety story on the way out. Once a group has run happily on `new` in production
+for long enough, a small follow-up PR:
+
+- deletes that group's legacy handlers from `wsgi.py`,
+- drops the group's toggle (it is always new now).
+
+`wsgi.py` shrinks group by group. When the last group is removed, `wsgi.py` and the
+`legacy` branch of the dispatcher are deleted together. No big-bang deletion.
+
+## Reusing the existing work
+
+We do not rewrite. The `refact/fastapi` spike already has the API, auth, templating
+foundation and public pages ported, with 225 unit tests and the e2e smoke/auth/search
+suites green. Those commits are the source material. Each group PR lifts the relevant
+code from `refact/fastapi`, adds the per-group toggle, and organizes the commits. This
+keeps the proven code and gives the team a reviewable, reversible package.
+
+## Testing
+
+- **Unit tests** per group, using FastAPI's `TestClient` with a fake db. Fast, run
+  locally, no container.
+- **e2e tests** (Playwright, in the container) per marker: `smoke`, `auth`, `search`,
+  `admin`, and so on. Each group PR must keep its marker green.
+- **Isolation guardrail:** an AST test asserts no new-stack module imports
+  `djehuty.web.wsgi`. This keeps the dependency direction one-way so the final
+  deletion stays fearless.
+- **AS-IS check:** where the legacy behaviour is a known bug, the e2e suite records it
+  as a warning rather than a failure, and the new handler reproduces it, so a
+  new/legacy flip is invisible.
+
+## Open questions and later work
+
+- Live config reload so a flip needs no restart. Nice to have, not required for v1.
+- Per-group request metrics, so we can watch a freshly-flipped group in production.
+- Whether `datasets-ui` and `collections-ui` should be one group or two (they share a
+  lot of metadata assembly).

--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -1,6 +1,10 @@
 {
   "djehuty": {
     "maintenance-mode": "0",
+    "web-service": {
+      "default": "new",
+      "groups": {}
+    },
     "site-name": "4TU.ResearchData",
     "site-shorttag": "dev",
     "site-description": "Djehuty development instance",

--- a/etc/djehuty/djehuty-example-config.json
+++ b/etc/djehuty/djehuty-example-config.json
@@ -1,6 +1,10 @@
 {
   "djehuty": {
     "maintenance-mode": "0",
+    "web-service": {
+      "default": "new",
+      "groups": {}
+    },
     "site-name": "Djehuty example instance",
     "site-shorttag": "example-shorttag",
     "site-description": "Djehuty example instance",

--- a/etc/djehuty/djehuty-example-config.xml
+++ b/etc/djehuty/djehuty-example-config.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <djehuty>
   <maintenance-mode>0</maintenance-mode>
+  <!-- New HTTP stack switch (see doc/http-migration.md). default is new|legacy;
+       list a functional group under <groups> to pin it, e.g.
+       <groups><api-v2>legacy</api-v2></groups>. The docs (/api/) are always new. -->
+  <web-service>
+    <default>new</default>
+    <groups/>
+  </web-service>
   <site-name>Djehuty example instance</site-name>
   <site-shorttag>example-shorttag</site-shorttag>
   <site-description>Djehuty example instance</site-description>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,8 +14,11 @@ nav:
   - Home: index.md
   - Introduction: introduction.md
   - Configuring & running djehuty: running-djehuty.md
-  - Knowledge graph: knowledge-graph.md
-  - Contributing: contributing.md
+  - Architecture & design:
+      - Knowledge graph: knowledge-graph.md
+      - HTTP stack migration: http-migration.md
+  - Contributing:
+      - Contributing guide: contributing.md
   - API: api.md
   - Contact: contact.md
   - News: news.md
@@ -28,6 +31,10 @@ markdown_extensions:
   - tables
   - fenced_code
   - admonition
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ dependencies    = [
     "Werkzeug>=2.0.2",
     "defusedxml>=0.7.1",
     "pillow>=9.4.0",
+    "fastapi>=0.115.0",
+    "pydantic>=2.0",
+    "a2wsgi>=1.10.0",
+    "python-multipart>=0.0.9",
 ]
 classifiers     = [
     "Programming Language :: Python :: 3",
@@ -51,6 +55,7 @@ docs = [
 dev = [
     "coverage[toml]>=7.0",
     "Faker>=37.12.0",
+    "httpx>=0.27.0",
     "playwright>=1.40.0",
     "pytest>=7.4.0",
     "pytest-playwright>=0.4.4",

--- a/src/djehuty/application.py
+++ b/src/djehuty/application.py
@@ -1,0 +1,22 @@
+"""Umbrella FastAPI app for the new HTTP stack.
+
+Each group PR mounts its router here and registers its RouteGroup. Mounting is
+not going live: the dispatcher in djehuty.web.ui picks new vs legacy per request.
+"""
+
+import importlib.metadata
+
+from fastapi import FastAPI
+
+
+def create_app(db) -> FastAPI:
+    app = FastAPI(
+        title="Djehuty",
+        summary="Research data repository for 4TU.ResearchData",
+        version=importlib.metadata.version("djehuty"),
+        docs_url="/api/docs",
+        redoc_url="/api/redoc",
+        openapi_url="/api/openapi.json",
+    )
+    app.state.db = db
+    return app

--- a/src/djehuty/dispatch.py
+++ b/src/djehuty/dispatch.py
@@ -1,0 +1,44 @@
+"""WSGI dispatcher: send each request to the new FastAPI app or to legacy.
+
+Never imports djehuty.web.wsgi; the legacy app is passed in.
+"""
+
+import logging
+
+from djehuty.route_groups import target_for_path
+
+_log = logging.getLogger(__name__)
+
+
+class WebServiceDispatcher:
+    def __init__(self, legacy, new, default="new", overrides=None):
+        self.legacy = legacy
+        self.new = new
+        self.default = default
+        self.overrides = overrides or {}
+
+    def __call__(self, environ, start_response):
+        path = environ.get("PATH_INFO", "")
+        if target_for_path(path, self.default, self.overrides) == "new":
+            return self.new(environ, start_response)
+        return self.legacy(environ, start_response)
+
+
+def build_wsgi_app(legacy_app, db, default="new", overrides=None):
+    """Wrap the umbrella app + legacy in the dispatcher; fall back to legacy if
+    the new stack cannot be imported."""
+    try:
+        from a2wsgi import ASGIMiddleware
+
+        from djehuty.application import create_app
+    except ImportError as error:
+        _log.warning("New HTTP stack unavailable (%s); serving legacy only.", error)
+        return legacy_app
+
+    new_app = ASGIMiddleware(create_app(db))
+    _log.info(
+        "Web service: FastAPI dispatcher active (default=%s, overrides=%s).",
+        default,
+        overrides or {},
+    )
+    return WebServiceDispatcher(legacy_app, new_app, default, overrides)

--- a/src/djehuty/route_groups.py
+++ b/src/djehuty/route_groups.py
@@ -1,0 +1,47 @@
+"""Which route group owns a path, and whether it resolves to new or legacy.
+
+Pure logic, no framework imports.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RouteGroup:
+    """A named set of paths that migrate and toggle together."""
+
+    name: str
+    prefixes: tuple = ()
+    exact: tuple = ()
+    # Always served by the new stack, ignoring the toggle (e.g. the docs).
+    always_new: bool = False
+
+    def matches(self, path: str) -> bool:
+        return path in self.exact or any(path.startswith(p) for p in self.prefixes)
+
+
+# One entry per group; each group's PR appends its own.
+ROUTE_GROUPS: tuple = (
+    # The umbrella OpenAPI docs (/api/docs, /api/redoc, /api/openapi.json).
+    # always_new: the docs stay available even when everything else is legacy.
+    RouteGroup("api-docs", prefixes=("/api/",), always_new=True),
+)
+
+
+def group_for_path(path: str, groups=None):
+    for group in ROUTE_GROUPS if groups is None else groups:
+        if group.matches(path):
+            return group
+    return None
+
+
+def target_for_path(path: str, default: str = "new", overrides=None, groups=None) -> str:
+    """Return "new" or "legacy" for path. Unregistered paths go to legacy."""
+    group = group_for_path(path, groups)
+    if group is None:
+        return "legacy"
+    if group.always_new:
+        return "new"
+    if overrides and group.name in overrides:
+        return overrides[group.name]
+    return default

--- a/src/djehuty/web/config/runtime.py
+++ b/src/djehuty/web/config/runtime.py
@@ -56,6 +56,11 @@ class RuntimeConfiguration:  # pylint: disable=too-few-public-methods
         self.in_preproduction = False
         self.using_uwsgi = False
         self.maintenance_mode = False
+        # New HTTP stack. "web_service" is the global
+        # default ("new"|"legacy") for registered route groups;
+        # "web_service_groups" pins individual groups, e.g. {"admin": "legacy"}.
+        self.web_service = "new"
+        self.web_service_groups = {}
         self.sandbox_message_css = ""
         self.sandbox_message = False
         self.notice_message = False

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -173,6 +173,53 @@ def read_storage_configuration (xml_root, logger):
             config.s3_buckets[bucket["name"]] = bucket
     return None
 
+def _read_web_service_targets (node):
+    """Collect {group_name: 'new'|'legacy'} from a config node.
+
+    Handles both formats: XML child elements (<admin>legacy</admin>) and JSON
+    scalar keys (which the JSON parser exposes via .attrib).
+    """
+    targets = {}
+    for child in node:
+        if child.text in ("new", "legacy"):
+            targets[child.tag] = child.text
+    for name, value in node.attrib.items():
+        if value in ("new", "legacy"):
+            targets[name] = value
+    return targets
+
+
+def read_web_service_configuration (xml_root):
+    """Read the per-group new/legacy switch.
+
+    Accepts a flat value (<web-service>new</web-service>) for the global default,
+    or an object with <default> and a <groups> map for per-group overrides. The
+    old key "api-service" is accepted as a back-compat alias.
+    """
+    node = xml_root.find ("web-service")
+    if node is None:
+        node = xml_root.find ("api-service")
+    if node is None:
+        return
+
+    # Flat form: sets the global default only.
+    if node.text in ("new", "legacy"):
+        config.web_service = node.text
+        return
+
+    # Object form: default + per-group overrides.
+    default = node.get ("default")
+    if default is None:
+        default_node = node.find ("default")
+        default = default_node.text if default_node is not None else None
+    if default in ("new", "legacy"):
+        config.web_service = default
+
+    groups_node = node.find ("groups")
+    if groups_node is not None:
+        config.web_service_groups.update (_read_web_service_targets (groups_node))
+
+
 def read_quotas_configuration (xml_root):
     """Read quota information from XML_ROOT."""
 
@@ -784,6 +831,8 @@ def read_configuration_file (server, config_file, logger, config_files):
         config.allow_crawlers = read_boolean_value (xml_root, "allow-crawlers",
                                                     config.allow_crawlers, logger)
 
+        read_web_service_configuration (xml_root)
+
         config.enable_iiif = read_boolean_value (xml_root, "enable-iiif",
                                                  config.enable_iiif, logger)
 
@@ -1389,7 +1438,14 @@ def main (config_file=None, run_internal_server=True, initialize=True,
             if config.static_cache_root is not None:
                 server.create_static_error_pages()
 
-        run_simple (config.address, config.port, server,
+        # Wrap the legacy server in the per-group new/legacy dispatcher. With no
+        # route groups registered this is a no-op (everything resolves to
+        # legacy); each group PR makes its prefix live.
+        from djehuty.dispatch import build_wsgi_app
+        wsgi_app = build_wsgi_app (server, server.db,
+                                   config.web_service, config.web_service_groups)
+
+        run_simple (config.address, config.port, wsgi_app,
                     threaded=(config.maximum_workers <= 1),
                     processes=config.maximum_workers,
                     extra_files=list(config_files),
@@ -1404,6 +1460,8 @@ def main (config_file=None, run_internal_server=True, initialize=True,
 ## ----------------------------------------------------------------------------
 ## Starting point for uWSGI
 ## ----------------------------------------------------------------------------
+
+_UWSGI_APP = None
 
 def application (env, start_response):
     """The main entry point for the WSGI."""
@@ -1424,5 +1482,10 @@ def application (env, start_response):
         start_response('200 OK', [('Content-Type','text/html')])
         return [b"<p>Please set the <code>DJEHUTY_CONFIG_FILE</code> environment variable.</p>"]
 
-    server = main (config_file=config_file, run_internal_server=False)
-    return server (env, start_response)
+    global _UWSGI_APP
+    if _UWSGI_APP is None:
+        server = main (config_file=config_file, run_internal_server=False)
+        from djehuty.dispatch import build_wsgi_app
+        _UWSGI_APP = build_wsgi_app (server, server.db,
+                                     config.web_service, config.web_service_groups)
+    return _UWSGI_APP (env, start_response)

--- a/tests/unit/test_application.py
+++ b/tests/unit/test_application.py
@@ -1,0 +1,16 @@
+"""The umbrella app serves its OpenAPI docs."""
+
+from fastapi.testclient import TestClient
+
+from djehuty.application import create_app
+
+
+class _DB:
+    def account_by_session_token(self, token):
+        return None
+
+
+def test_umbrella_serves_openapi_docs():
+    client = TestClient(create_app(_DB()))
+    assert client.get("/api/docs").status_code == 200
+    assert client.get("/api/openapi.json").status_code == 200

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -1,0 +1,45 @@
+"""Unit tests for the WSGI dispatcher (djehuty.dispatch).
+
+Confirms requests route to the new stack or legacy per their group toggle, and
+that a missing new stack degrades to legacy instead of failing.
+"""
+
+import djehuty.route_groups as rg
+from djehuty.route_groups import RouteGroup
+from djehuty.dispatch import WebServiceDispatcher, build_wsgi_app
+
+
+def _legacy(environ, start_response):
+    return [b"LEGACY"]
+
+
+def _new(environ, start_response):
+    return [b"NEW"]
+
+
+def _call(app, path):
+    return app({"PATH_INFO": path}, None)
+
+
+def test_unregistered_path_goes_to_legacy():
+    app = WebServiceDispatcher(_legacy, _new, default="new", overrides={})
+    assert _call(app, "/v3/x") == [b"LEGACY"]
+
+
+def test_registered_group_default_new_goes_to_new(monkeypatch):
+    monkeypatch.setattr(rg, "ROUTE_GROUPS", (RouteGroup("api-v3", prefixes=("/v3/",)),))
+    app = WebServiceDispatcher(_legacy, _new, default="new", overrides={})
+    assert _call(app, "/v3/x") == [b"NEW"]
+
+
+def test_group_pinned_to_legacy(monkeypatch):
+    monkeypatch.setattr(rg, "ROUTE_GROUPS", (RouteGroup("api-v3", prefixes=("/v3/",)),))
+    app = WebServiceDispatcher(_legacy, _new, default="new", overrides={"api-v3": "legacy"})
+    assert _call(app, "/v3/x") == [b"LEGACY"]
+
+
+def test_build_wsgi_app_returns_dispatcher_that_serves_legacy_by_default():
+    # No groups registered: the dispatcher forwards everything to legacy.
+    app = build_wsgi_app(_legacy, db=object(), default="new", overrides={})
+    assert isinstance(app, WebServiceDispatcher)
+    assert _call(app, "/anything") == [b"LEGACY"]

--- a/tests/unit/test_new_stack_isolation.py
+++ b/tests/unit/test_new_stack_isolation.py
@@ -1,0 +1,51 @@
+"""Architectural guardrail for the phased migration.
+
+The new HTTP stack must never import the legacy WSGI application. Keeping the
+dependency direction one-way is what makes the final removal fearless and each
+group independently switchable. The dispatcher composes new and legacy, but it
+receives the legacy app as a value; it does not import it.
+
+As each group PR adds packages (djehuty.api, djehuty.auth, djehuty.views,
+djehuty.services), extend NEW_STACK below.
+"""
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+LEGACY_WSGI_MODULE = "djehuty.web.wsgi"
+
+# New-stack modules/packages present so far. Grows with each group PR.
+NEW_STACK = ("djehuty.route_groups", "djehuty.application", "djehuty.dispatch")
+
+
+def _module_file(dotted: str) -> Path:
+    spec = importlib.util.find_spec(dotted)
+    assert spec and spec.origin, f"cannot locate module {dotted}"
+    return Path(spec.origin)
+
+
+def _imported_modules(tree: ast.AST) -> set:
+    modules = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            modules.add(node.module)
+    return modules
+
+
+@pytest.mark.parametrize("dotted", NEW_STACK)
+def test_new_stack_module_does_not_import_legacy_wsgi(dotted):
+    path = _module_file(dotted)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    imported = _imported_modules(tree)
+    offending = {
+        m for m in imported if m == LEGACY_WSGI_MODULE or m.startswith(LEGACY_WSGI_MODULE + ".")
+    }
+    assert not offending, (
+        f"{dotted} imports the legacy WSGI app ({sorted(offending)}). "
+        "The new stack must stay independent of djehuty.web.wsgi."
+    )

--- a/tests/unit/test_route_groups.py
+++ b/tests/unit/test_route_groups.py
@@ -1,0 +1,64 @@
+"""Tests for the route-group registry and new/legacy resolution."""
+
+from djehuty.route_groups import RouteGroup, group_for_path, target_for_path
+
+
+def test_route_group_matches_prefix_and_exact():
+    group = RouteGroup("api-v3", prefixes=("/v3/",), exact=("/robots.txt",))
+    assert group.matches("/v3/datasets") is True
+    assert group.matches("/robots.txt") is True
+    assert group.matches("/v2/articles") is False
+
+
+def test_group_for_path_returns_first_match():
+    groups = (
+        RouteGroup("api-v2", prefixes=("/v2/",)),
+        RouteGroup("api-v3", prefixes=("/v3/",)),
+    )
+    assert group_for_path("/v3/x", groups).name == "api-v3"
+    assert group_for_path("/nope", groups) is None
+
+
+def test_unregistered_path_resolves_to_legacy():
+    # New stack has no router for it.
+    assert target_for_path("/v3/x", default="new", overrides={}, groups=()) == "legacy"
+
+
+def test_registered_group_follows_default():
+    groups = (RouteGroup("api-v3", prefixes=("/v3/",)),)
+    assert target_for_path("/v3/x", "new", {}, groups) == "new"
+    assert target_for_path("/v3/x", "legacy", {}, groups) == "legacy"
+
+
+def test_override_pins_a_single_group():
+    groups = (
+        RouteGroup("api-v3", prefixes=("/v3/",)),
+        RouteGroup("admin", prefixes=("/admin/",)),
+    )
+    overrides = {"admin": "legacy"}
+    assert target_for_path("/v3/x", "new", overrides, groups) == "new"
+    assert target_for_path("/admin/users", "new", overrides, groups) == "legacy"
+
+
+def test_registry_entries_are_unique_route_groups():
+    import djehuty.route_groups as rg
+
+    names = [g.name for g in rg.ROUTE_GROUPS]
+    assert all(isinstance(g, RouteGroup) for g in rg.ROUTE_GROUPS)
+    assert len(names) == len(set(names))
+
+
+def test_api_docs_is_served_by_the_new_stack():
+    assert group_for_path("/api/docs").name == "api-docs"
+    assert target_for_path("/api/docs", "new", {}) == "new"
+
+
+def test_api_docs_stays_new_even_when_everything_is_disabled():
+    # always_new: docs must survive default=legacy and a legacy override.
+    assert target_for_path("/api/docs", "legacy", {}) == "new"
+    assert target_for_path("/api/docs", "legacy", {"api-docs": "legacy"}) == "new"
+
+
+def test_always_new_group_ignores_the_toggle():
+    groups = (RouteGroup("api-docs", prefixes=("/api/",), always_new=True),)
+    assert target_for_path("/api/x", "legacy", {"api-docs": "legacy"}, groups) == "new"

--- a/tests/unit/test_uwsgi_entry.py
+++ b/tests/unit/test_uwsgi_entry.py
@@ -1,0 +1,84 @@
+"""Unit tests for the uWSGI entry point (djehuty.web.ui.application).
+
+Covers the dependency and configuration error responses, and that the
+dispatcher-wrapped app is built once from the parsed config and reused
+across requests.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import djehuty.dispatch
+from djehuty.web import ui
+from djehuty.web.config import config
+
+
+@pytest.fixture(autouse=True)
+def fresh_entry_point(monkeypatch):
+    monkeypatch.setattr(ui, "_UWSGI_APP", None)
+    monkeypatch.setattr(ui, "UWSGI_DEPENDENCY_LOADED", True)
+
+
+def _call():
+    statuses = []
+    body = ui.application({}, lambda status, headers: statuses.append(status))
+    return statuses, body
+
+
+def _install_fake_stack(monkeypatch):
+    server = SimpleNamespace(db=object())
+    main_calls = []
+    build_calls = []
+
+    def fake_main(config_file=None, run_internal_server=True):
+        main_calls.append((config_file, run_internal_server))
+        return server
+
+    def fake_build(legacy, db, default, overrides):
+        build_calls.append((legacy, db, default, overrides))
+        return lambda env, start_response: [b"dispatched"]
+
+    monkeypatch.setattr(ui, "main", fake_main)
+    monkeypatch.setattr(djehuty.dispatch, "build_wsgi_app", fake_build)
+    return server, main_calls, build_calls
+
+
+def test_missing_uwsgi_dependency_returns_500(monkeypatch):
+    monkeypatch.setattr(ui, "UWSGI_DEPENDENCY_LOADED", False)
+    statuses, body = _call()
+    assert statuses == ["500 Internal Server Error"]
+    assert b"uwsgi" in body[0]
+
+
+def test_missing_config_file_asks_for_the_environment_variable(monkeypatch):
+    monkeypatch.delenv("DJEHUTY_CONFIG_FILE", raising=False)
+    statuses, body = _call()
+    assert statuses == ["200 OK"]
+    assert b"DJEHUTY_CONFIG_FILE" in body[0]
+
+
+def test_first_request_builds_the_dispatcher_from_the_config(monkeypatch):
+    monkeypatch.setenv("DJEHUTY_CONFIG_FILE", "/etc/djehuty/config.json")
+    monkeypatch.setattr(config, "web_service", "legacy")
+    monkeypatch.setattr(config, "web_service_groups", {"admin": "new"})
+    server, main_calls, build_calls = _install_fake_stack(monkeypatch)
+
+    _, body = _call()
+
+    assert body == [b"dispatched"]
+    assert main_calls == [("/etc/djehuty/config.json", False)]
+    assert build_calls == [(server, server.db, "legacy", {"admin": "new"})]
+
+
+def test_later_requests_reuse_the_cached_app(monkeypatch):
+    monkeypatch.setenv("DJEHUTY_CONFIG_FILE", "/etc/djehuty/config.json")
+    _, main_calls, build_calls = _install_fake_stack(monkeypatch)
+
+    _, first = _call()
+    _, second = _call()
+
+    assert first == [b"dispatched"]
+    assert second == [b"dispatched"]
+    assert len(main_calls) == 1
+    assert len(build_calls) == 1

--- a/tests/unit/test_web_service_config.py
+++ b/tests/unit/test_web_service_config.py
@@ -1,0 +1,71 @@
+"""Unit tests for parsing the per-group web-service switch (djehuty.web.ui).
+
+Covers both config formats (JSON and XML), both shapes (a flat default and the
+object form with per-group overrides), and the api-service back-compat alias.
+"""
+
+import pytest
+from defusedxml import ElementTree
+
+from djehuty.web.config import config
+from djehuty.web.config.json_parser import JsonConfigElement
+from djehuty.web.ui import read_web_service_configuration
+
+
+@pytest.fixture(autouse=True)
+def reset_config():
+    saved = (config.web_service, dict(config.web_service_groups))
+    config.web_service = "new"
+    config.web_service_groups = {}
+    yield
+    config.web_service, config.web_service_groups = saved[0], saved[1]
+
+
+def _json(data):
+    return JsonConfigElement("djehuty", data)
+
+
+def _xml(inner):
+    return ElementTree.fromstring(f"<djehuty>{inner}</djehuty>")
+
+
+def test_json_flat_sets_default_only():
+    read_web_service_configuration(_json({"web-service": "legacy"}))
+    assert config.web_service == "legacy"
+    assert config.web_service_groups == {}
+
+
+def test_json_object_sets_default_and_overrides():
+    read_web_service_configuration(
+        _json({"web-service": {"default": "new", "groups": {"admin": "legacy", "api-v3": "new"}}})
+    )
+    assert config.web_service == "new"
+    assert config.web_service_groups == {"admin": "legacy", "api-v3": "new"}
+
+
+def test_xml_flat_sets_default_only():
+    read_web_service_configuration(_xml("<web-service>legacy</web-service>"))
+    assert config.web_service == "legacy"
+    assert config.web_service_groups == {}
+
+
+def test_xml_object_sets_default_and_overrides():
+    read_web_service_configuration(
+        _xml(
+            "<web-service><default>new</default>"
+            "<groups><admin>legacy</admin></groups></web-service>"
+        )
+    )
+    assert config.web_service == "new"
+    assert config.web_service_groups == {"admin": "legacy"}
+
+
+def test_api_service_is_a_backcompat_alias():
+    read_web_service_configuration(_json({"api-service": "legacy"}))
+    assert config.web_service == "legacy"
+
+
+def test_absent_config_leaves_defaults():
+    read_web_service_configuration(_json({"something-else": "1"}))
+    assert config.web_service == "new"
+    assert config.web_service_groups == {}

--- a/uv.lock
+++ b/uv.lock
@@ -1,9 +1,53 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
     "python_full_version < '3.11'",
+]
+
+[[package]]
+name = "a2wsgi"
+version = "1.10.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/cb/822c56fbea97e9eee201a2e434a80437f6750ebcb1ed307ee3a0a7505b14/a2wsgi-1.10.10.tar.gz", hash = "sha256:a5bcffb52081ba39df0d5e9a884fc6f819d92e3a42389343ba77cbf809fe1f45", size = 18799, upload-time = "2025-06-18T09:00:10.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/d5/349aba3dc421e73cbd4958c0ce0a4f1aa3a738bc0d7de75d2f40ed43a535/a2wsgi-1.10.10-py3-none-any.whl", hash = "sha256:d2b21379479718539dc15fce53b876251a0efe7615352dfe49f6ad1bc507848d", size = 17389, upload-time = "2025-06-18T09:00:09.676Z" },
+]
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/8e/38aa427ed5402449e226975b649c5dc73ccadfefeb95e6aecb8f8ea4b6b6/annotated_doc-0.0.5.tar.gz", hash = "sha256:c7e58ce09192557605d8bbd92836d7e1d520ac9580096042c0bfd197efacf1bb", size = 10758, upload-time = "2026-07-28T13:50:58.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/30/e900b21425a860e195f32e37657aa1f7c7f2b1bfb26f03ca209b90933c06/annotated_doc-0.0.5-py3-none-any.whl", hash = "sha256:117bac03a25ede5df5440e855b32d556049ca169ead221505badf432fed4b101", size = 5302, upload-time = "2026-07-28T13:50:57.239Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
 ]
 
 [[package]]
@@ -399,12 +443,16 @@ name = "djehuty"
 version = "26.4"
 source = { editable = "." }
 dependencies = [
+    { name = "a2wsgi" },
     { name = "boto3" },
     { name = "defusedxml" },
+    { name = "fastapi" },
     { name = "jinja2" },
     { name = "pillow" },
+    { name = "pydantic" },
     { name = "pygit2", version = "1.18.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pygit2", version = "1.19.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "python-multipart" },
     { name = "rdflib" },
     { name = "requests" },
     { name = "werkzeug" },
@@ -414,6 +462,7 @@ dependencies = [
 dev = [
     { name = "coverage", extra = ["toml"] },
     { name = "faker" },
+    { name = "httpx" },
     { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-playwright" },
@@ -430,11 +479,15 @@ lint = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2wsgi", specifier = ">=1.10.0" },
     { name = "boto3" },
     { name = "defusedxml", specifier = ">=0.7.1" },
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "jinja2", specifier = ">=3.0.3" },
     { name = "pillow", specifier = ">=9.4.0" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pygit2", specifier = ">=1.6.1" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "rdflib", specifier = ">=6.0.0" },
     { name = "requests", specifier = ">=2.26.0" },
     { name = "werkzeug", specifier = ">=2.0.2" },
@@ -444,6 +497,7 @@ requires-dist = [
 dev = [
     { name = "coverage", extras = ["toml"], specifier = ">=7.0" },
     { name = "faker", specifier = ">=37.12.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "playwright", specifier = ">=1.40.0" },
     { name = "pytest", specifier = ">=7.4.0" },
     { name = "pytest-playwright", specifier = ">=0.4.4" },
@@ -478,6 +532,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/d2/026af1e002bbc6df534d1f8262b18ec79a974f928e9290bfbfdfe7c7b2af/faker-40.36.0.tar.gz", hash = "sha256:754048c76c03afa7de83eee8f4bcee3cf668cbb7d995f54a4e9678db7f110308", size = 2025903, upload-time = "2026-07-24T21:11:33.088Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/9a/b947ed175ce9a0dcb070ccf3607f0ce8720cfb5ed1a36166a150b2acd5af/faker-40.36.0-py3-none-any.whl", hash = "sha256:82b9497d9cfe017048075bcf969298a74b1b6e39f5e4dad1211085d1133f7b62", size = 2062829, upload-time = "2026-07-24T21:11:31.37Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.141.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/02/91e3416a8fdd715abb903a952a6bec7cdd8d14eed55d415fc8595524c319/fastapi-0.141.1.tar.gz", hash = "sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1", size = 425799, upload-time = "2026-07-29T17:18:05.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/03/10388a42375ee7e4ac9b94eb2c5c569c8b5795e377e701c9ac3ad63de890/fastapi-0.141.1-py3-none-any.whl", hash = "sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3", size = 131954, upload-time = "2026-07-29T17:18:04.364Z" },
 ]
 
 [[package]]
@@ -576,6 +646,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/54/70/50de47a488f14df260b50ae34fb5d56016e308b098eab02c878b5223c26a/greenlet-3.5.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:e44da2f5bbdaabaf7d80b73dbb430c7035771e9f244e3c8b769715c9d8fa0a16", size = 1681159, upload-time = "2026-06-26T18:31:52.986Z" },
     { url = "https://files.pythonhosted.org/packages/a7/13/1055e1dda7882073eda533e2b96c62e55bbd2db7fda6d5ece992febc7071/greenlet-3.5.3-cp315-cp315t-win_amd64.whl", hash = "sha256:8ff8bed3e3baa20a3ea261ce00526f1898ad4801d4886fd2220580ee0ad8fadf", size = 244007, upload-time = "2026-06-26T18:22:04.353Z" },
     { url = "https://files.pythonhosted.org/packages/b4/0d/ca7d15afbdc397e3401134c9e1800d51d12b829661786187a4ad08fe484f/greenlet-3.5.3-cp315-cp315t-win_arm64.whl", hash = "sha256:b7068bd09f761f3f5b4d214c2bed063186b2a86148c740b3873e3f56d79bac31", size = 242586, upload-time = "2026-06-26T18:23:37.93Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -979,6 +1086,137 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1212,6 +1450,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
 name = "python-slugify"
 version = "8.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1374,6 +1621,19 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/16/dc49e4b9d348b0f0567a67613a946f4e26b3299408ccf78df318c51a2aec/starlette-1.4.0.tar.gz", hash = "sha256:ecf3a067176d63c6412f98c660dab3355b525584d3725c0c40a4519d33ec2130", size = 2708995, upload-time = "2026-08-05T09:36:43.693Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/f6/7916cd7717e196bba370c0f17abb30466014ce29094665c3581e51a8c24b/starlette-1.4.0-py3-none-any.whl", hash = "sha256:cacd43738e07b834844e2c8e97b898b40089d74f2678234b0a3e93cd3d515813", size = 74021, upload-time = "2026-08-05T09:36:41.944Z" },
+]
+
+[[package]]
 name = "text-unidecode"
 version = "1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1443,6 +1703,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Summary**

Foundation for the phased Werkzeug to FastAPI HTTP migration (see
`docs/http-migration.md`). It adds the three pieces every later group PR builds on: a
route-group registry (which group owns a path), an umbrella FastAPI app that mounts
the new routers, and a WSGI dispatcher that sends each request to the new stack or to
the legacy `wsgi.py` based on a per-group `web-service` config switch. The point of
the switch: any migrated group can be flipped back to legacy in production with a
one-word config change and a restart — no rebuild, no hotfix.

This PR migrates no routes. No groups are registered yet, so every request is served
by legacy exactly as before. The only new surface is the API reference under `/api/`
(`/api/docs`, `/api/redoc`, `/api/openapi.json`), served by the new stack; legacy has
no `/api/` routes. `wsgi.py` is untouched.

**Changes**
- `docs/http-migration.md`, `mkdocs.yml`: the migration plan — principles (AS-IS,
  reversible per group), route groups, rollout/rollback, and how legacy is removed.
- `pyproject.toml`, `uv.lock`: runtime deps `fastapi`, `pydantic`, `a2wsgi`,
  `python-multipart`; `httpx` added to the dev group for testing.
- `src/djehuty/route_groups.py`: route-group registry; resolves a path to new or
  legacy. Registers only `api-docs` (`always_new`).
- `src/djehuty/application.py`: umbrella FastAPI app (`create_app`); future group
  routers mount here.
- `src/djehuty/dispatch.py`: `WebServiceDispatcher` + `build_wsgi_app`; falls back to
  legacy-only if the new stack cannot be imported; never imports `djehuty.web.wsgi`.
- `src/djehuty/web/config/runtime.py`: `web_service` default and
  `web_service_groups` overrides.
- `src/djehuty/web/ui.py`: parses the `web-service` block (JSON and XML, flat and
  object form, `api-service` alias); both entry points — the internal server and the
  uWSGI `application` — now serve the dispatcher.
- `etc/djehuty/*.json|.xml`: document the `web-service` block in the example configs.
- `tests/unit/`: six new files covering the registry, umbrella app, dispatcher,
  config parsing, the uWSGI entry point, and an isolation test asserting no new-stack
  module imports `wsgi.py`.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

N/A

**Screenshots (optional)**

N/A — a screenshot of `/api/docs` could be added to show the always-on API reference.

**Notes (optional)**

- The `web-service` config is optional: with no block, `default` is `new`, and since
  unregistered paths always resolve to legacy, behaviour is unchanged.
- Follow-up PRs add one route group at a time (router + registry entry + AS-IS
  contract tests), each independently toggleable between new and legacy.