### PR TITLE
web: resources: html_templates: Remove ROR link from institution name.

### DIFF
--- a/src/djehuty/web/resources/html_templates/public_metadata.html
+++ b/src/djehuty/web/resources/html_templates/public_metadata.html
@@ -209,11 +209,10 @@
 {%- if item.publisher %}
         <div id="publisher">
             <h3 class="label">Publisher</h3>
+                {{item.publisher}}
     {%- set publisher_ror = publisher_rors.get(item.publisher) if publisher_rors else none %}
     {%- if publisher_ror %}
-                <a class="corporate-identity" href="{{publisher_ror}}" target="_blank" rel="noopener noreferrer" title="View {{item.publisher}} in the Research Organization Registry (opens in new window)">{{item.publisher}} <img src="/static/images/ror-icon.svg" alt="ROR" class="ror-icon" /></a>
-    {%- else %}
-                {{item.publisher}}
+                <a class="corporate-identity" href="{{publisher_ror}}" target="_blank" rel="noopener noreferrer" title="View {{item.publisher}} in the Research Organization Registry (opens in new window)"><img src="/static/images/ror-icon.svg" alt="ROR" class="ror-icon" /></a>
     {%- endif %}
         </div>
 {%- endif %}


### PR DESCRIPTION
**Summary**

Removes the ROR (Research Organisation Registry) link from the Publisher field on the public dataset/collection metadata page. The institution name now renders as plain text instead of a clickable link.

**Changes**
- `src/djehuty/web/resources/html_templates/public_metadata.html`: Remove the ROR link from the Publisher field, rendering it as plain text.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #231

**Screenshots (optional)**

On the datasets detail page, before:
<img width="206" height="98" alt="image" src="https://github.com/user-attachments/assets/495e6302-18fd-44f3-b3ef-15fa3a7bbdc7" />


After the change:
<img width="236" height="101" alt="image" src="https://github.com/user-attachments/assets/0d7a5dbe-041d-40a2-ba6c-5cb2fab97616" />


**Notes (optional)**

None.