### PR TITLE
chore(lint): add format and move paths to pyproject.toml

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,8 +95,7 @@ Follow existing code conventions and existing patterns such as:
     - Line length: Keep lines within the project’s limit (100 characters, enforced by Ruff).
     - Comments & docs: Write comments/docstrings in the same style.
 - **No unused code**: Remove dead or commented-out code before committing.
-- **Linting**: Run `just lint` before committing. Ruff is enforced in CI on already-cleaned paths (see `lint_paths` in the `justfile`).
-
+- **Linting**: Run `just lint` before committing (or format using `just format`).
 
 
 ### Commits

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ just lint
 
 This runs `ruff check` (bugs, style errors, import sorting) and `ruff format --check` over the cleaned paths, using the Ruff version pinned in `uv.lock . CI runs the same recipe on every push and pull request, so a clean `just lint` locally means a green Lint job. 
 
+```bash
+just format
+```
+
+It applies the auto format from ruff in the files
+
 ---
 ### Contact information
 - **General**: info@djehuty.4tu.nl

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ artifacts; coverage from each shard is combined into a single report.
 
 Code style is enforced with [Ruff](https://docs.astral.sh/ruff/) and
 rolled out incrementally: only paths that have already been cleaned are
-checked (the `lint_paths` variable in the justfile), starting with
+checked (in the `include` list under `[tool.ruff]` in `pyproject.toml`), starting with
 `src/djehuty/utils/`.
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -204,5 +204,6 @@ lint:
 
 # Apply ruff format/fix (scope set by [tool.ruff] include in pyproject.toml)
 format:
-    uv run --group lint ruff check --fix
+    uv run --group lint ruff check --fix --exit-zero
     uv run --group lint ruff format
+    uv run --group lint ruff check

--- a/justfile
+++ b/justfile
@@ -197,16 +197,12 @@ test *args="":
         --screenshot=only-on-failure \
         --output=/app/test-results {{ args }}
 
-# Paths already cleaned and enforced by ruff (extended per sub-issue)
-lint_paths := "src/djehuty/utils" + \
-    " src/djehuty/web/config" + \
-    " src/djehuty/web/locks.py" + \
-    " src/djehuty/web/email_handler.py " + \
-    " src/djehuty/ui.py " + \
-    " src/djehuty/__init__.py " + \
-    " tests"
-
-# Lint and check formatting of cleaned paths
+# Lint and check formatting of cleaned paths (scope set by [tool.ruff] include in pyproject.toml)
 lint:
-    uv run --group lint ruff check {{ lint_paths }}
-    uv run --group lint ruff format --check {{ lint_paths }}
+    uv run --group lint ruff check
+    uv run --group lint ruff format --check
+
+# Apply ruff format/fix (scope set by [tool.ruff] include in pyproject.toml)
+format:
+    uv run --group lint ruff check --fix
+    uv run --group lint ruff format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,17 @@ directory = "coverage-html"
 
 [tool.ruff]
 line-length = 100
+# Paths already cleaned and enforced by ruff (extended per sub-issue).
+# `ruff check`/`ruff format` with no path args operate on these.
+include = [
+    "src/djehuty/utils/**/*.py",
+    "src/djehuty/web/config/**/*.py",
+    "src/djehuty/web/locks.py",
+    "src/djehuty/web/email_handler.py",
+    "src/djehuty/ui.py",
+    "src/djehuty/__init__.py",
+    "tests/**/*.py",
+]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
**Summary**

Added new command `just format` to help developers and contributors to format new code
Simplify the `justfile` without configuration, so used the include from tool.ruff in pyproject.toml 

**Changes**
- pyproject.toml: add in ruff section the include with enforced paths,
  before used in just
- justfile: include new command format and remove list_paths (moved to
  pyproject.toml)
- README.md: It applies the auto format from ruff in the files

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #ISSUE_NUMBER

**Screenshots (optional)**

Before/After visuals, UI changes, or relevant logs.

**Notes (optional)**

Additional context, caveats, or follow-up tasks.