### PR TITLE
feat: Add custom-style support to Djehuty

### DIFF
--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -31,6 +31,7 @@
     },
     "custom-assets-root": "branding",
     "custom-logo-path": "branding/images/4TUResearchData_Logo_Grey_WarmOrange.png",
+    "custom-favicon-path": "branding/images/favicon.ico",
     "small-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "large-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "sandbox-message": {

--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -24,12 +24,13 @@
       "body-font-family": "'Aspekta', sans-serif",
       "ui-font-family": "'SpaceGrotesk', sans-serif",
       "font-face": [
-        { "family": "Aspekta", "src": "/s/fonts/Aspekta-300.woff2", "format": "woff2", "weight": "300 400", "style": "normal" },
-        { "family": "Aspekta", "src": "/s/fonts/Aspekta-500.woff2", "format": "woff2", "weight": "500 700", "style": "normal" },
-        { "family": "SpaceGrotesk", "src": "/s/fonts/SpaceGrotesk-Regular.woff2", "format": "woff2", "weight": "400 700", "style": "normal" }
+        { "family": "Aspekta", "src": "/assets/fonts/Aspekta-300.woff2", "format": "woff2", "weight": "300 400", "style": "normal" },
+        { "family": "Aspekta", "src": "/assets/fonts/Aspekta-500.woff2", "format": "woff2", "weight": "500 700", "style": "normal" },
+        { "family": "SpaceGrotesk", "src": "/assets/fonts/SpaceGrotesk-Regular.woff2", "format": "woff2", "weight": "400 700", "style": "normal" }
       ]
     },
-    "custom-logo-path": "/app/src/djehuty/web/resources/static/images/4TUResearchData_Logo_Grey_WarmOrange.png",
+    "custom-assets-root": "branding",
+    "custom-logo-path": "branding/images/4TUResearchData_Logo_Grey_WarmOrange.png",
     "small-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "large-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "sandbox-message": {

--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -20,6 +20,16 @@
       "privilege-button-color": "#fce3bf",
       "footer-background-color": "#707070"
     },
+    "fonts": {
+      "body-font-family": "'Aspekta', sans-serif",
+      "ui-font-family": "'SpaceGrotesk', sans-serif",
+      "font-face": [
+        { "family": "Aspekta", "src": "/s/fonts/Aspekta-300.woff2", "format": "woff2", "weight": "300 400", "style": "normal" },
+        { "family": "Aspekta", "src": "/s/fonts/Aspekta-500.woff2", "format": "woff2", "weight": "500 700", "style": "normal" },
+        { "family": "SpaceGrotesk", "src": "/s/fonts/SpaceGrotesk-Regular.woff2", "format": "woff2", "weight": "400 700", "style": "normal" }
+      ]
+    },
+    "custom-logo-path": "/app/src/djehuty/web/resources/static/images/4TUResearchData_Logo_Grey_WarmOrange.png",
     "small-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "large-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "sandbox-message": {

--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -18,7 +18,7 @@
       "primary-color-active": "#9d4800",
       "primary-foreground-color": "#000000",
       "privilege-button-color": "#fce3bf",
-      "footer-background-color": "#707070"
+      "footer-background-color": "#3C3C3C"
     },
     "fonts": {
       "body-font-family": "'Aspekta', sans-serif",
@@ -30,6 +30,13 @@
       ]
     },
     "custom-assets-root": "branding",
+    "custom-stylesheet": [
+      "/assets/css/footer.css",
+      "/assets/css/palette.css",
+      "/assets/css/typography.css",
+      "/assets/css/spacing.css",
+      "/assets/css/header.css"
+    ],
     "custom-logo-path": "branding/images/4TUResearchData_Logo_Grey_WarmOrange.png",
     "custom-favicon-path": "branding/images/favicon.ico",
     "small-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",

--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -64,6 +64,7 @@
       "/assets/css/spacing.css",
       "/assets/css/header.css",
       "/assets/css/buttons.css",
+      "/assets/css/action-bar.css",
       "/assets/css/shapes.css",
       "/assets/css/chips.css"
     ],

--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -6,9 +6,18 @@
     "site-description": "Djehuty development instance",
     "publisher-rors": {
       "publisher-ror": [
-        { "name": "4TU.ResearchData", "url": "https://ror.org/02d887280" },
-        { "name": "Delft University of Technology", "url": "https://ror.org/02e2c7k09" },
-        { "name": "Eindhoven University of Technology", "url": "https://ror.org/02c2kyt77" }
+        {
+          "name": "4TU.ResearchData",
+          "url": "https://ror.org/02d887280"
+        },
+        {
+          "name": "Delft University of Technology",
+          "url": "https://ror.org/02e2c7k09"
+        },
+        {
+          "name": "Eindhoven University of Technology",
+          "url": "https://ror.org/02c2kyt77"
+        }
       ]
     },
     "support-email-address": "dev@localhost",
@@ -24,9 +33,27 @@
       "body-font-family": "'Aspekta', sans-serif",
       "ui-font-family": "'SpaceGrotesk', sans-serif",
       "font-face": [
-        { "family": "Aspekta", "src": "/assets/fonts/Aspekta-300.woff2", "format": "woff2", "weight": "300 400", "style": "normal" },
-        { "family": "Aspekta", "src": "/assets/fonts/Aspekta-500.woff2", "format": "woff2", "weight": "500 700", "style": "normal" },
-        { "family": "SpaceGrotesk", "src": "/assets/fonts/SpaceGrotesk-Regular.woff2", "format": "woff2", "weight": "400 700", "style": "normal" }
+        {
+          "family": "Aspekta",
+          "src": "/assets/fonts/Aspekta-300.woff2",
+          "format": "woff2",
+          "weight": "300 400",
+          "style": "normal"
+        },
+        {
+          "family": "Aspekta",
+          "src": "/assets/fonts/Aspekta-500.woff2",
+          "format": "woff2",
+          "weight": "500 700",
+          "style": "normal"
+        },
+        {
+          "family": "SpaceGrotesk",
+          "src": "/assets/fonts/SpaceGrotesk-Regular.woff2",
+          "format": "woff2",
+          "weight": "400 700",
+          "style": "normal"
+        }
       ]
     },
     "custom-assets-root": "branding",
@@ -35,7 +62,10 @@
       "/assets/css/palette.css",
       "/assets/css/typography.css",
       "/assets/css/spacing.css",
-      "/assets/css/header.css"
+      "/assets/css/header.css",
+      "/assets/css/buttons.css",
+      "/assets/css/shapes.css",
+      "/assets/css/chips.css"
     ],
     "custom-logo-path": "branding/images/4TUResearchData_Logo_Grey_WarmOrange.png",
     "custom-favicon-path": "branding/images/favicon.ico",

--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -6,18 +6,9 @@
     "site-description": "Djehuty development instance",
     "publisher-rors": {
       "publisher-ror": [
-        {
-          "name": "4TU.ResearchData",
-          "url": "https://ror.org/02d887280"
-        },
-        {
-          "name": "Delft University of Technology",
-          "url": "https://ror.org/02e2c7k09"
-        },
-        {
-          "name": "Eindhoven University of Technology",
-          "url": "https://ror.org/02c2kyt77"
-        }
+        { "name": "4TU.ResearchData", "url": "https://ror.org/02d887280" },
+        { "name": "Delft University of Technology", "url": "https://ror.org/02e2c7k09" },
+        { "name": "Eindhoven University of Technology", "url": "https://ror.org/02c2kyt77" }
       ]
     },
     "support-email-address": "dev@localhost",
@@ -27,49 +18,18 @@
       "primary-color-active": "#9d4800",
       "primary-foreground-color": "#000000",
       "privilege-button-color": "#fce3bf",
-      "footer-background-color": "#3C3C3C"
+      "footer-background-color": "#707070"
     },
     "fonts": {
-      "body-font-family": "'Aspekta', sans-serif",
-      "ui-font-family": "'SpaceGrotesk', sans-serif",
-      "font-face": [
-        {
-          "family": "Aspekta",
-          "src": "/assets/fonts/Aspekta-300.woff2",
-          "format": "woff2",
-          "weight": "300 400",
-          "style": "normal"
-        },
-        {
-          "family": "Aspekta",
-          "src": "/assets/fonts/Aspekta-500.woff2",
-          "format": "woff2",
-          "weight": "500 700",
-          "style": "normal"
-        },
-        {
-          "family": "SpaceGrotesk",
-          "src": "/assets/fonts/SpaceGrotesk-Regular.woff2",
-          "format": "woff2",
-          "weight": "400 700",
-          "style": "normal"
-        }
-      ]
+      "body-font-family": "",
+      "ui-font-family": "",
+      "mono-font-family": "",
+      "font-face": []
     },
-    "custom-assets-root": "branding",
-    "custom-stylesheet": [
-      "/assets/css/footer.css",
-      "/assets/css/palette.css",
-      "/assets/css/typography.css",
-      "/assets/css/spacing.css",
-      "/assets/css/header.css",
-      "/assets/css/buttons.css",
-      "/assets/css/action-bar.css",
-      "/assets/css/shapes.css",
-      "/assets/css/chips.css"
-    ],
-    "custom-logo-path": "branding/images/4TUResearchData_Logo_Grey_WarmOrange.png",
-    "custom-favicon-path": "branding/images/favicon.ico",
+    "custom-assets-root": "",
+    "custom-stylesheet": [],
+    "custom-logo-path": "",
+    "custom-favicon-path": "",
     "small-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "large-footer": "<div id=\"footer-wrapper2\">\n<p>Development instance powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a>.</p>\n</div>",
     "sandbox-message": {

--- a/etc/djehuty/djehuty-example-config.json
+++ b/etc/djehuty/djehuty-example-config.json
@@ -20,6 +20,16 @@
       "privilege-button-color": "#fce3bf",
       "footer-background-color": "#707070"
     },
+    "fonts": {
+      "body-font-family": "",
+      "ui-font-family": "",
+      "mono-font-family": "",
+      "font-face": []
+    },
+    "custom-assets-root": "",
+    "custom-stylesheet": [],
+    "custom-logo-path": "",
+    "custom-favicon-path": "",
     "small-footer": "<div id=\"footer-wrapper2\">\n<p>This repository is powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a> built for <a href=\"https://data.4tu.nl\">4TU.ResearchData</a>.\n</p>\n</div>",
     "large-footer": "<div id=\"footer-wrapper2\">\n<p>This repository is powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a> built for <a href=\"https://data.4tu.nl\">4TU.ResearchData</a>.\n</p>\n</div>",
     "sandbox-message": {

--- a/etc/djehuty/djehuty-example-config.json
+++ b/etc/djehuty/djehuty-example-config.json
@@ -21,15 +21,36 @@
       "footer-background-color": "#707070"
     },
     "fonts": {
-      "body-font-family": "",
-      "ui-font-family": "",
-      "mono-font-family": "",
-      "font-face": []
+      "body-font-family": "'Example Sans', sans-serif",
+      "ui-font-family": "'Example UI', sans-serif",
+      "mono-font-family": "'Example Mono', monospace",
+      "font-face": [
+        {
+          "family": "Example Sans",
+          "src": "/assets/fonts/example-regular.woff2",
+          "weight": "400",
+          "style": "normal"
+        },
+        {
+          "family": "Example Sans",
+          "src": "/assets/fonts/example-bold.woff2",
+          "weight": "700"
+        },
+        {
+          "family": "Example UI",
+          "src": "/assets/fonts/example-ui-regular.woff2",
+          "weight": "400",
+          "style": "normal"
+        }
+      ]
     },
-    "custom-assets-root": "",
-    "custom-stylesheet": [],
-    "custom-logo-path": "",
-    "custom-favicon-path": "",
+    "custom-assets-root": "/etc/djehuty/assets",
+    "custom-stylesheet": [
+      "/assets/css/palette.css",
+      "/assets/css/buttons.css"
+    ],
+    "custom-logo-path": "/etc/djehuty/assets/images/logo.png",
+    "custom-favicon-path": "/etc/djehuty/assets/images/favicon.ico",
     "small-footer": "<div id=\"footer-wrapper2\">\n<p>This repository is powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a> built for <a href=\"https://data.4tu.nl\">4TU.ResearchData</a>.\n</p>\n</div>",
     "large-footer": "<div id=\"footer-wrapper2\">\n<p>This repository is powered by <a href=\"https://github.com/4TUResearchData/djehuty\">djehuty</a> built for <a href=\"https://data.4tu.nl\">4TU.ResearchData</a>.\n</p>\n</div>",
     "sandbox-message": {

--- a/etc/djehuty/djehuty-example-config.xml
+++ b/etc/djehuty/djehuty-example-config.xml
@@ -23,6 +23,25 @@
     <privilege-button-color>#fce3bf</privilege-button-color>
     <footer-background-color>#707070</footer-background-color>
   </colors>
+  <fonts>
+    <body-font-family></body-font-family>
+    <ui-font-family></ui-font-family>
+    <mono-font-family></mono-font-family>
+    <!--
+    <font-face>
+      <family></family>
+      <src></src>
+      <format>woff2</format>
+      <weight></weight>
+      <style></style>
+      <display>swap</display>
+    </font-face>
+    -->
+  </fonts>
+  <custom-assets-root></custom-assets-root>
+  <custom-stylesheet></custom-stylesheet>
+  <custom-logo-path></custom-logo-path>
+  <custom-favicon-path></custom-favicon-path>
   <small-footer>
     <div id="footer-wrapper2">
       <p>This repository is powered by <a href="https://github.com/4TUResearchData/djehuty">djehuty</a> built for <a href="https://data.4tu.nl">4TU.ResearchData</a>.

--- a/etc/djehuty/djehuty-example-config.xml
+++ b/etc/djehuty/djehuty-example-config.xml
@@ -24,24 +24,32 @@
     <footer-background-color>#707070</footer-background-color>
   </colors>
   <fonts>
-    <body-font-family></body-font-family>
-    <ui-font-family></ui-font-family>
-    <mono-font-family></mono-font-family>
-    <!--
+    <body-font-family>'Example Sans', sans-serif</body-font-family>
+    <ui-font-family>'Example UI', sans-serif</ui-font-family>
+    <mono-font-family>'Example Mono', monospace</mono-font-family>
     <font-face>
-      <family></family>
-      <src></src>
-      <format>woff2</format>
-      <weight></weight>
-      <style></style>
-      <display>swap</display>
+      <family>Example Sans</family>
+      <src>/assets/fonts/example-regular.woff2</src>
+      <weight>400</weight>
+      <style>normal</style>
     </font-face>
-    -->
+    <font-face>
+      <family>Example Sans</family>
+      <src>/assets/fonts/example-bold.woff2</src>
+      <weight>700</weight>
+    </font-face>
+    <font-face>
+      <family>Example UI</family>
+      <src>/assets/fonts/example-ui-regular.woff2</src>
+      <weight>400</weight>
+      <style>normal</style>
+    </font-face>
   </fonts>
-  <custom-assets-root></custom-assets-root>
-  <custom-stylesheet></custom-stylesheet>
-  <custom-logo-path></custom-logo-path>
-  <custom-favicon-path></custom-favicon-path>
+  <custom-assets-root>/etc/djehuty/assets</custom-assets-root>
+  <custom-stylesheet>/assets/css/palette.css</custom-stylesheet>
+  <custom-stylesheet>/assets/css/buttons.css</custom-stylesheet>
+  <custom-logo-path>/etc/djehuty/assets/images/logo.png</custom-logo-path>
+  <custom-favicon-path>/etc/djehuty/assets/images/favicon.ico</custom-favicon-path>
   <small-footer>
     <div id="footer-wrapper2">
       <p>This repository is powered by <a href="https://github.com/4TUResearchData/djehuty">djehuty</a> built for <a href="https://data.4tu.nl">4TU.ResearchData</a>.

--- a/src/djehuty/utils/convenience.py
+++ b/src/djehuty/utils/convenience.py
@@ -411,3 +411,8 @@ def normalize_orcid(orcid):
 def normalize_doi(doi):
     """Procedure to make storing DOIs consistent."""
     return normalize_identifier(normalize_identifier(doi, "https://doi.org/"), "doi.org/")
+
+
+def css_string(value):
+    """Escape VALUE for safe interpolation into a single-quoted CSS string."""
+    return str(value).replace("\\", "\\\\").replace("'", "\\'")

--- a/src/djehuty/utils/convenience.py
+++ b/src/djehuty/utils/convenience.py
@@ -415,4 +415,5 @@ def normalize_doi(doi):
 
 def css_string(value):
     """Escape VALUE for safe interpolation into a single-quoted CSS string."""
-    return str(value).replace("\\", "\\\\").replace("'", "\\'")
+    escaped = str(value).replace("\\", "\\\\").replace("'", "\\'")
+    return escaped.replace("\r\n", "\\A ").replace("\n", "\\A ").replace("\r", "\\A ")

--- a/src/djehuty/web/config.py
+++ b/src/djehuty/web/config.py
@@ -111,6 +111,5 @@ class RuntimeConfiguration:  # pylint: disable=too-few-public-methods
             "footer-background-color":  "#707070",
             "background-color":         "#ffffff"
         }
-        self.fonts                       = None
 
 config = RuntimeConfiguration()

--- a/src/djehuty/web/config.py
+++ b/src/djehuty/web/config.py
@@ -111,5 +111,6 @@ class RuntimeConfiguration:  # pylint: disable=too-few-public-methods
             "footer-background-color":  "#707070",
             "background-color":         "#ffffff"
         }
+        self.fonts                       = None
 
 config = RuntimeConfiguration()

--- a/src/djehuty/web/config/json_parser.py
+++ b/src/djehuty/web/config/json_parser.py
@@ -125,6 +125,13 @@ class JsonConfigElement:
                 return None
         return current
 
+    def findall(self, path):
+        tag = path.replace("./", "")
+        matches = [child for child in self._children if child.tag == tag]
+        if not matches and tag in self._scalar_index:
+            matches.append(self._scalar_index[tag])
+        return matches
+
     def iter(self, tag):
         if self._tag == tag:
             yield self

--- a/src/djehuty/web/config/runtime.py
+++ b/src/djehuty/web/config/runtime.py
@@ -117,6 +117,8 @@ class RuntimeConfiguration:  # pylint: disable=too-few-public-methods
             "footer-background-color": "#707070",
             "background-color": "#ffffff",
         }
+        self.fonts = None
+        self.custom_stylesheets = []
 
 
 config = RuntimeConfiguration()

--- a/src/djehuty/web/resources/html_templates/admin/exploratory.html
+++ b/src/djehuty/web/resources/html_templates/admin/exploratory.html
@@ -16,7 +16,7 @@
 .node-column-title {
     fill: #000000;
     font-size: 24px;
-    font-family: 'FiraMono', monospace;
+    font-family: var(--font-mono);
     transform: translate(0, 30);
 }
 .active-node {

--- a/src/djehuty/web/resources/html_templates/colors.css
+++ b/src/djehuty/web/resources/html_templates/colors.css
@@ -35,7 +35,7 @@ ul.latest-datasets li a:active { color: {{primary_color_active}}; }
 #files ul li a { color: {{primary_color}}; }
 #files ul li a:hover { color: {{primary_color_hover}}; }
 #files ul li a:active { color: {{primary_color_active}}; }
-#files ul li.zip { background: {{primary_color}}; margin-top: 1em; padding: .25em; width: 180px; text-align: center; border-radius: .5em; }
+#files ul li.zip { background: {{primary_color}}; margin-top: 2em; padding: .25em; width: 180px; text-align: center; border-radius: .5em; }
 #files ul li.zip a { font-weight: bold; color: #fff; }
 #total_size { font-size:12px; color: #fff; font-weight: normal; }
 .search-filter-row { padding: 0.8em 0.5em 0.5em 1em; border-left: 0.2em solid {{primary_color}}; background: #f9f9f9; margin-top: 0.5em; }

--- a/src/djehuty/web/resources/html_templates/dataset.html
+++ b/src/djehuty/web/resources/html_templates/dataset.html
@@ -25,7 +25,7 @@ const dataset_uuid = "{{item.container_uuid}}";
 {%- include 'public_metadata.html' %}
 <div id="data">
 {%- if item.is_embargoed %}
-    <h3 class="label">DATA - under embargo</h3>
+    <h3 class="label">Data - under embargo</h3>
         <div id="limited_access">
             <p>The files in this dataset are under embargo{%- if item.embargo_until_date %} until {{item.embargo_until_date}}{%- endif %}.</p>
     {%- if item.embargo_reason or item.confidential_reason %}
@@ -40,7 +40,7 @@ const dataset_uuid = "{{item.container_uuid}}";
     {%- endif %}
        </div>
 {%- elif item.is_restricted %}
-    <h3 class="label">DATA - restricted access</h3>
+    <h3 class="label">Data - restricted access</h3>
         <div id="limited_access">
             <h4>Reason</h4>
     {%- autoescape false %}
@@ -59,7 +59,7 @@ const dataset_uuid = "{{item.container_uuid}}";
         </div>
         {%- include 'dataset_access_request.html' %}
 {%- elif item.is_metadata_record %}
-    <h3 class="label">DATA - not available</h3>
+    <h3 class="label">Data - not available</h3>
         <div id="metadata_only">
     {%- if item.metadata_reason %}
             {{item.metadata_reason}}
@@ -74,7 +74,7 @@ const dataset_uuid = "{{item.container_uuid}}";
     <div id="private_view">As you are on a private link, you have access to the data files.</div>
 {%- endif %}
 {%- if not(item.is_restricted or item.is_embargoed) and files %}
-    <h3 class="label">DATA</h3>
+    <h3 class="label">Data</h3>
 {%- endif %}
 {%- if is_own_item or private_view or not(item.is_restricted or item.is_embargoed) %}
 {%- if services %}

--- a/src/djehuty/web/resources/html_templates/fonts.css
+++ b/src/djehuty/web/resources/html_templates/fonts.css
@@ -1,0 +1,28 @@
+{%- if fonts %}
+{%- for face in fonts.font_faces %}
+@font-face {
+    font-family: '{{face.family}}';
+    src: url('{{face.src}}') format('{{face.format}}');
+{%- if face.weight %}
+    font-weight: {{face.weight}};
+{%- endif %}
+{%- if face.style %}
+    font-style: {{face.style}};
+{%- endif %}
+{%- if face.display %}
+    font-display: {{face.display}};
+{%- endif %}
+}
+{%- endfor %}
+:root {
+{%- if fonts.body_font %}
+    --font-body: {{fonts.body_font | safe}};
+{%- endif %}
+{%- if fonts.ui_font %}
+    --font-ui: {{fonts.ui_font | safe}};
+{%- endif %}
+{%- if fonts.mono_font %}
+    --font-mono: {{fonts.mono_font | safe}};
+{%- endif %}
+}
+{%- endif %}

--- a/src/djehuty/web/resources/html_templates/fonts.css
+++ b/src/djehuty/web/resources/html_templates/fonts.css
@@ -1,16 +1,16 @@
 {%- if fonts %}
 {%- for face in fonts.font_faces %}
 @font-face {
-    font-family: '{{face.family}}';
-    src: url('{{face.src}}') format('{{face.format}}');
+    font-family: '{{face.family | css_string | safe}}';
+    src: url('{{face.src | css_string | safe}}') format('{{face.format | css_string | safe}}');
 {%- if face.weight %}
-    font-weight: {{face.weight}};
+    font-weight: {{face.weight | safe}};
 {%- endif %}
 {%- if face.style %}
-    font-style: {{face.style}};
+    font-style: {{face.style | safe}};
 {%- endif %}
 {%- if face.display %}
-    font-display: {{face.display}};
+    font-display: {{face.display | safe}};
 {%- endif %}
 }
 {%- endfor %}

--- a/src/djehuty/web/resources/html_templates/layout.html
+++ b/src/djehuty/web/resources/html_templates/layout.html
@@ -11,6 +11,9 @@
     <link rel="stylesheet" type="text/css" href="/theme/colors.css?cache={{startup_timestamp}}">
     <link rel="stylesheet" type="text/css" href="/static/css/main.css?cache=1780577091">
     <link rel="stylesheet" type="text/css" href="/theme/fonts.css?cache={{startup_timestamp}}">
+    {%- for stylesheet in custom_stylesheets | default([], true) %}
+    <link rel="stylesheet" type="text/css" href="{{stylesheet}}?cache={{startup_timestamp}}">
+    {%- endfor %}
     {% block headers %}{% endblock %}
   </head>
   <body>

--- a/src/djehuty/web/resources/html_templates/layout.html
+++ b/src/djehuty/web/resources/html_templates/layout.html
@@ -10,6 +10,7 @@
     <link rel='shortcut icon' type='image/x-icon' href='/static/images/favicon.ico'>
     <link rel="stylesheet" type="text/css" href="/theme/colors.css?cache={{startup_timestamp}}">
     <link rel="stylesheet" type="text/css" href="/static/css/main.css?cache=1780577091">
+    <link rel="stylesheet" type="text/css" href="/theme/fonts.css?cache={{startup_timestamp}}">
     {% block headers %}{% endblock %}
   </head>
   <body>

--- a/src/djehuty/web/resources/html_templates/portal.html
+++ b/src/djehuty/web/resources/html_templates/portal.html
@@ -8,7 +8,7 @@
     min-width: 275pt;
     text-align: right;
     font-size: 2em;
-    font-family: 'FiraMono', monospace;
+    font-family: var(--font-mono);
     padding: .1em .5em .1em 0em;
     border-right: solid 2pt #ccc;
 }
@@ -32,6 +32,7 @@
     width: 160pt;
     max-width: 160pt;
 }
+
 .tile-row-text a { text-decoration: none; font-size: 13pt }
 .tile-row-text {
     display: flex;
@@ -54,7 +55,7 @@
   font-size: 14pt;
   transform: translate(12%, -12%);
 }
-#new-notice { margin-top: 0em; margin-bottom: 40pt }
+#new-notice { margin-top: 0em; margin-bottom: 40pt; }
 </style>
 {% endblock %}
 {% block body %}

--- a/src/djehuty/web/resources/html_templates/portal.html
+++ b/src/djehuty/web/resources/html_templates/portal.html
@@ -186,7 +186,7 @@
       </a>
     </div>
     <div class="tile-row-text">
-      <a href="/categories/13551?categories=13557">Physical Geography And Environmental Geoscience</a>
+      <a href="/categories/13551?categories=13557">Physical Geography &amp; Environmental Geoscience</a>
 </div>
 </div>
 </li>
@@ -234,7 +234,7 @@
       </a>
     </div>
     <div class="tile-row-text">
-      <a href="/categories/13376">Agricultural And Veterinary Sciences</a>
+      <a href="/categories/13376">Agricultural &amp; Veterinary Sciences</a>
 </div>
 </div>
 </li>
@@ -246,7 +246,7 @@
       </a>
     </div>
     <div class="tile-row-text">
-      <a href="/categories/13611">Information And Computing Sciences</a>
+      <a href="/categories/13611">Information &amp; Computing Sciences</a>
 </div>
 </div>
 </li>
@@ -294,7 +294,7 @@
       </a>
     </div>
     <div class="tile-row-text">
-      <a href="/categories/13630?categories=13636">Electrical And Electronic Engineering</a>
+      <a href="/categories/13630?categories=13636">Electrical &amp; Electronic Engineering</a>
 </div>
 </div>
 </li>
@@ -306,7 +306,7 @@
       </a>
     </div>
     <div class="tile-row-text">
-      <a href="/categories/13362">Built Environment And Design</a>
+      <a href="/categories/13362">Built Environment &amp;<br>Design</a>
 </div>
 </div>
 </li>
@@ -342,7 +342,7 @@
       </a>
     </div>
     <div class="tile-row-text">
-      <a href="/categories/13474">Medical And Health Sciences</a>
+      <a href="/categories/13474">Medical &amp; Health<br>Sciences</a>
 </div>
 </div>
 </li>
@@ -354,7 +354,7 @@
       </a>
     </div>
     <div class="tile-row-text">
-      <a href="/categories/13500?categories=13503">Business And Management</a>
+      <a href="/categories/13500?categories=13503">Business &amp; Management</a>
 </div>
 </div>
 </li>

--- a/src/djehuty/web/resources/html_templates/portal.html
+++ b/src/djehuty/web/resources/html_templates/portal.html
@@ -54,7 +54,7 @@
   font-size: 14pt;
   transform: translate(12%, -12%);
 }
-#new-notice { margin-top: 0em; }
+#new-notice { margin-top: 0em; margin-bottom: 40pt }
 </style>
 {% endblock %}
 {% block body %}

--- a/src/djehuty/web/resources/html_templates/public_metadata.html
+++ b/src/djehuty/web/resources/html_templates/public_metadata.html
@@ -165,7 +165,7 @@
     {%- endif %}
     {%- if not private_view %}
         <div id="export">
-            <h3 class="label">Export as...</h3>
+            <h3 class="label">Export as</h3>
             <a class="corporate-identity public-button" href="/export/refworks/datasets/{{id_version}}">RefWorks</a>
             <a class="corporate-identity public-button" href="/export/bibtex/datasets/{{id_version}}">BibTeX</a>
             <a class="corporate-identity public-button" href="/export/refman/datasets/{{id_version}}">Reference Manager</a>

--- a/src/djehuty/web/resources/static/css/main.css
+++ b/src/djehuty/web/resources/static/css/main.css
@@ -22,6 +22,15 @@
     font-weight: normal;
     font-style: normal;
 }
+/* Typography variables. These variables resolved to the default fonts, so an
+   instance that does not override them renders exactly as before. Instances
+   can restyle typography without patching this file by overriding these
+   variables in /theme/fonts.css*/
+:root {
+    --font-body: 'SourceSans', sans-serif;
+    --font-ui:   'SourceSans', sans-serif;
+    --font-mono: 'FiraMono', monospace;
+}
 @font-face {
   font-family: 'Font Awesome 6';
   font-style: normal;
@@ -63,7 +72,7 @@ body,html {
     height: 100%;
     padding: 0em;
     margin: 0em;
-    font-family: 'SourceSans', sans-serif;
+    font-family: var(--font-body);
     font-size: 12pt;
     color: #000000;
 }
@@ -194,7 +203,7 @@ a.inline-button.close:active { background: #aa4444; color: #000; text-decoration
     display: block;
     min-width: 120pt;
 }
-#primary-menu li a { text-decoration: none; }
+#primary-menu li a { text-decoration: none; font-family: var(--font-ui); }
 .submenu {
     position: absolute;
     display: none;
@@ -284,14 +293,14 @@ h1 {
     color: #000000;
     padding: 0em;
     margin: 0em;
-    font-family: 'SourceSans', sans-serif;
+    font-family: var(--font-body);
     font-weight: normal;
     text-transform: uppercase;
 }
 a {
     color: #000000;
     text-decoration: underline;
-    font-family: 'SourceSans', sans-serif;
+    font-family: var(--font-body);
 }
 a:hover {
     color: #666666;
@@ -622,7 +631,7 @@ img { user-select: none; }
   display: block;
   background: #fffaea;
   border: solid 2pt #ffeecc;
-  font-family: 'SourceSans', sans-serif;
+  font-family: var(--font-body);
   font-size: 12pt;
   font-weight: normal;
   padding: .5em;

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -94,7 +94,7 @@ def config_value(xml_root, path, command_line=None, fallback=None, return_node=F
         if item is not None:
             if return_node:
                 return item
-            return item.text
+            return item.text.strip() if item.text else item.text
 
     ## Fall back to the fallback value.
     return fallback
@@ -724,6 +724,7 @@ def read_fonts_configuration(xml_root, logger):
 
         font_faces.append(
             {
+                "index": index,
                 "family": family,
                 "src": src,
                 "format": config_value(face, "format", fallback="woff2"),
@@ -775,9 +776,9 @@ def warn_about_unresolvable_asset(assets_root, source, description, logger):
 def warn_about_unresolvable_assets(assets_root, logger):
     """Procedure to warn about configured assets that cannot be served."""
     if config.fonts:
-        for index, face in enumerate(config.fonts["font_faces"]):
+        for face in config.fonts["font_faces"]:
             warn_about_unresolvable_asset(
-                assets_root, face["src"], f"Font '{face['family']}' (font-face #{index})", logger
+                assets_root, face["src"], f"Font '{face['family']}' (font-face #{face['index']})", logger
             )
 
     for stylesheet in config.custom_stylesheets:

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -744,6 +744,9 @@ def read_custom_stylesheets(xml_root):
 
 def warn_about_unresolvable_asset(assets_root, source, description, logger):
     """Procedure to warn when SOURCE cannot be served from ASSETS_ROOT."""
+    if not source:
+        logger.warning("%s has no source configured.", description)
+        return
 
     prefix = "/assets/"
     if not source.startswith(prefix):

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -679,6 +679,38 @@ def read_fonts_configuration (xml_root):
         "mono_font":  config_value (fonts, "mono-font-family"),
     }
 
+def read_custom_stylesheets (xml_root):
+    """Procedure to parse and set the instance-specific stylesheets."""
+    for stylesheet in xml_root.findall ("custom-stylesheet"):
+        if not stylesheet.text:
+            continue
+        href = stylesheet.text.strip()
+        if href not in config.custom_stylesheets:
+            config.custom_stylesheets.append (href)
+
+def warn_about_unresolvable_asset (assets_root, source, description, logger):
+    """Procedure to warn when SOURCE cannot be served from ASSETS_ROOT."""
+    prefix = "/assets/"
+    if not source.startswith (prefix):
+        return
+
+    if assets_root is None:
+        logger.warning ("%s refers to '%s' but 'custom-assets-root' is unset.",
+                        description, source)
+    elif not os.path.isfile (os.path.join (assets_root, source[len(prefix):])):
+        logger.warning ("%s refers to '%s' which does not exist under '%s'.",
+                        description, source, assets_root)
+
+def warn_about_unresolvable_assets (assets_root, logger):
+    """Procedure to warn about configured assets that cannot be served."""
+    if config.fonts:
+        for face in config.fonts["font_faces"]:
+            warn_about_unresolvable_asset (assets_root, face["src"],
+                                           f"Font '{face['family']}'", logger)
+
+    for stylesheet in config.custom_stylesheets:
+        warn_about_unresolvable_asset (assets_root, stylesheet, "Stylesheet", logger)
+
 def read_datacite_configuration (xml_root):
     """Procedure to parse and set the DataCite API configuration."""
     datacite = xml_root.find("datacite")
@@ -1013,6 +1045,17 @@ def read_configuration_file (server, config_file, logger, config_files):
             read_configuration_file (server, include, logger, config_files)
 
         read_menu_configuration (xml_root)
+        read_custom_stylesheets (xml_root)
+
+        custom_assets_root = config_value (xml_root, "custom-assets-root", None, None)
+        if custom_assets_root:
+            if not os.path.isabs (custom_assets_root):
+                custom_assets_root = os.path.abspath(os.path.join (config_dir, custom_assets_root))
+            if (server.add_static_root ("/assets", custom_assets_root) and not inside_reload):
+                logger.info ("Added assets root: %s", custom_assets_root)
+
+        if not inside_reload:
+            warn_about_unresolvable_assets (custom_assets_root, logger)
 
         custom_logo_path = config_value (xml_root, "custom-logo-path", None, None)
         if custom_logo_path:

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -655,6 +655,30 @@ def read_colors_configuration (xml_root):
                       "background-color"]:
             config.colors[color] = config_value (colors, color, fallback=config.colors[color])
 
+def read_fonts_configuration (xml_root):
+    """Procedure to parse and set the custom typography configuration."""
+    fonts = xml_root.find("fonts")
+    if fonts is None:
+        return
+
+    font_faces = []
+    for face in fonts.findall("font-face"):
+        font_faces.append({
+            "family":  config_value (face, "family"),
+            "src":     config_value (face, "src"),
+            "format":  config_value (face, "format", fallback="woff2"),
+            "weight":  config_value (face, "weight"),
+            "style":   config_value (face, "style"),
+            "display": config_value (face, "display", fallback="swap"),
+        })
+
+    config.fonts = {
+        "font_faces": font_faces,
+        "body_font":  config_value (fonts, "body-font-family"),
+        "ui_font":    config_value (fonts, "ui-font-family"),
+        "mono_font":  config_value (fonts, "mono-font-family"),
+    }
+
 def read_datacite_configuration (xml_root):
     """Procedure to parse and set the DataCite API configuration."""
     datacite = xml_root.find("datacite")
@@ -974,6 +998,7 @@ def read_configuration_file (server, config_file, logger, config_files):
         read_storage_configuration (xml_root, logger)
         read_quotas_configuration (xml_root)
         read_colors_configuration (xml_root)
+        read_fonts_configuration (xml_root)
         read_upload_dataset_configuration (xml_root, logger)
 
         for include_element in xml_root.iter('include'):

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -705,18 +705,27 @@ def read_colors_configuration(xml_root):
             config.colors[color] = config_value(colors, color, fallback=config.colors[color])
 
 
-def read_fonts_configuration(xml_root):
-    """Procedure to parse and set the custom typography configuration."""
+def read_fonts_configuration(xml_root, logger):
+    """Procedure to parse and set the custom typography configuration.
+    """
     fonts = xml_root.find("fonts")
     if fonts is None:
         return
 
     font_faces = []
-    for face in fonts.findall("font-face"):
+    for index, face in enumerate(fonts.findall("font-face")):
+        family = config_value(face, "family")
+        src = config_value(face, "src")
+        if not family or not src:
+            logger.warning(
+                "Dropping font-face #%d: 'family' and 'src' are both required.", index
+            )
+            continue
+
         font_faces.append(
             {
-                "family": config_value(face, "family"),
-                "src": config_value(face, "src"),
+                "family": family,
+                "src": src,
                 "format": config_value(face, "format", fallback="woff2"),
                 "weight": config_value(face, "weight"),
                 "style": config_value(face, "style"),
@@ -752,7 +761,7 @@ def warn_about_unresolvable_asset(assets_root, source, description, logger):
     if not source.startswith(prefix):
         return
 
-    if assets_root is None:
+    if not assets_root:
         logger.warning("%s refers to '%s' but 'custom-assets-root' is unset.", description, source)
     elif not os.path.isfile(os.path.join(assets_root, source[len(prefix) :])):
         logger.warning(
@@ -766,9 +775,9 @@ def warn_about_unresolvable_asset(assets_root, source, description, logger):
 def warn_about_unresolvable_assets(assets_root, logger):
     """Procedure to warn about configured assets that cannot be served."""
     if config.fonts:
-        for face in config.fonts["font_faces"]:
+        for index, face in enumerate(config.fonts["font_faces"]):
             warn_about_unresolvable_asset(
-                assets_root, face["src"], f"Font '{face['family']}'", logger
+                assets_root, face["src"], f"Font '{face['family']}' (font-face #{index})", logger
             )
 
     for stylesheet in config.custom_stylesheets:
@@ -1125,7 +1134,7 @@ def read_configuration_file(server, config_file, logger, config_files):
         read_storage_configuration(xml_root, logger)
         read_quotas_configuration(xml_root)
         read_colors_configuration(xml_root)
-        read_fonts_configuration(xml_root)
+        read_fonts_configuration(xml_root, logger)
         read_upload_dataset_configuration(xml_root, logger)
 
         for include_element in xml_root.iter("include"):

--- a/src/djehuty/web/ui.py
+++ b/src/djehuty/web/ui.py
@@ -25,6 +25,7 @@ from djehuty.web.config.json_parser import JsonConfigElement, parse_config_root
 try:
     from onelogin.saml2.auth import OneLogin_Saml2_Auth  # pylint: disable=unused-import
     from onelogin.saml2.errors import OneLogin_Saml2_Error  # pylint: disable=unused-import
+
     SAML2_DEPENDENCY_LOADED = True
 except (ImportError, ModuleNotFoundError):
     SAML2_DEPENDENCY_LOADED = False
@@ -32,6 +33,7 @@ except (ImportError, ModuleNotFoundError):
 PYVIPS_ERROR_MESSAGE = None
 try:
     import pyvips  # pylint: disable=unused-import
+
     PYVIPS_DEPENDENCY_LOADED = True
 except (ImportError, ModuleNotFoundError):
     PYVIPS_DEPENDENCY_LOADED = False
@@ -46,6 +48,7 @@ except OSError as pyvips_oserror_message:
 # a run-time configuration error.
 try:
     import uwsgi  # pylint: disable=unused-import
+
     UWSGI_DEPENDENCY_LOADED = True
 except ModuleNotFoundError:
     UWSGI_DEPENDENCY_LOADED = False
@@ -56,23 +59,29 @@ except ModuleNotFoundError:
 # it is required due to the run-time configuration.
 try:
     import boto3  # pylint: disable=unused-import
+
     BOTO3_DEPENDENCY_LOADED = True
 except (ImportError, ModuleNotFoundError):
     BOTO3_DEPENDENCY_LOADED = False
 
+
 class ConfigFileNotFound(Exception):
     """Raised when the database is not queryable."""
+
 
 class UnsupportedSAMLProtocol(Exception):
     """Raised when an unsupported SAML protocol is used."""
 
+
 class DependencyNotAvailable(Exception):
     """Raised when a required software dependency isn't available."""
+
 
 class MissingConfigurationError(Exception):
     """Raised when a crucial piece of configuration is missing."""
 
-def config_value (xml_root, path, command_line=None, fallback=None, return_node=False):
+
+def config_value(xml_root, path, command_line=None, fallback=None, return_node=False):
     """Procedure to get the value a config item should have at run-time."""
 
     ## Prefer command-line arguments.
@@ -90,24 +99,26 @@ def config_value (xml_root, path, command_line=None, fallback=None, return_node=
     ## Fall back to the fallback value.
     return fallback
 
-def read_boolean_value (xml_root, path, default_value, logger):
+
+def read_boolean_value(xml_root, path, default_value, logger):
     """Parses a boolean option and sets DESTINATION if the option is present."""
     try:
-        parsed = config_value (xml_root, path, None, None)
+        parsed = config_value(xml_root, path, None, None)
         if parsed is not None:
             return bool(int(parsed))
     except (ValueError, TypeError):
-        logger.error ("Erroneous value for '%s' - assuming '%s'.", path, default_value)
+        logger.error("Erroneous value for '%s' - assuming '%s'.", path, default_value)
 
     return default_value
 
-def read_raw_xml (xml_root, path, default_value=None):
+
+def read_raw_xml(xml_root, path, default_value=None):
     """
     Return the inner XML for PATH in XML_ROOT as a string or
     DEFAULT_VALUE upon failure.
     """
     try:
-        node = config_value (xml_root, path, None, None, return_node=True)
+        node = config_value(xml_root, path, None, None, return_node=True)
         if node is not None:
             if isinstance(node, JsonConfigElement):
                 return node.text, node.attrib
@@ -131,19 +142,20 @@ def read_raw_xml (xml_root, path, default_value=None):
                 attributes_rendered_length += 1
 
             # Get the raw XML so it can be used verbatim.
-            text = ElementTree.tostring (node, encoding="unicode")
+            text = ElementTree.tostring(node, encoding="unicode")
             # Strip the <path></path> bits and surrounding whitespace.
-            text = text.strip()[(length + attributes_rendered_length):(-1 * (length + 1))].strip()
+            text = text.strip()[(length + attributes_rendered_length) : (-1 * (length + 1))].strip()
             return text, attributes
     except TypeError:
         pass
 
     return default_value, None
 
-def read_storage_configuration (xml_root, logger):
+
+def read_storage_configuration(xml_root, logger):
     """Procedure to read storage locations."""
 
-    storage = xml_root.find ("storage")
+    storage = xml_root.find("storage")
     if not storage:
         return None
 
@@ -151,29 +163,30 @@ def read_storage_configuration (xml_root, logger):
         if location.tag != "location":
             continue
         quirks = location.attrib.get("quirks") == "1"
-        config.storage_locations.append({ "path": location.text, "quirks": quirks })
+        config.storage_locations.append({"path": location.text, "quirks": quirks})
 
     for item in storage:
         quirks = item.attrib.get("quirks") == "1"
         if item.tag == "location":
-            config.storage_locations.append({ "path": item.text, "quirks": quirks })
+            config.storage_locations.append({"path": item.text, "quirks": quirks})
 
         elif item.tag == "s3-bucket":
-            bucket = { "quirks-enabled": quirks }
-            bucket["name"] = config_value (item, "name")
-            bucket["key-id"] = config_value (item, "key-id")
-            bucket["secret-key"] = config_value (item, "secret-key")
-            bucket["endpoint"] = config_value (item, "endpoint")
+            bucket = {"quirks-enabled": quirks}
+            bucket["name"] = config_value(item, "name")
+            bucket["key-id"] = config_value(item, "key-id")
+            bucket["secret-key"] = config_value(item, "secret-key")
+            bucket["endpoint"] = config_value(item, "endpoint")
 
             for key in ("name", "key-id", "secret-key", "endpoint"):
-                if convenience.value_or_none (bucket, key) is None:
-                    logger.warning ("Missing '%s' for S3 bucket.", key)
+                if convenience.value_or_none(bucket, key) is None:
+                    logger.warning("Missing '%s' for S3 bucket.", key)
                     break
 
             config.s3_buckets[bucket["name"]] = bucket
     return None
 
-def read_quotas_configuration (xml_root):
+
+def read_quotas_configuration(xml_root):
     """Read quota information from XML_ROOT."""
 
     quotas = xml_root.find("quotas")
@@ -188,9 +201,9 @@ def read_quotas_configuration (xml_root):
 
     # Set specific quotas for member institutions and accounts.
     for quota_specification in quotas:
-        email  = quota_specification.attrib.get("email")
+        email = quota_specification.attrib.get("email")
         domain = quota_specification.attrib.get("domain")
-        value  = None
+        value = None
         try:
             value = int(quota_specification.text)
         except (ValueError, TypeError):
@@ -228,11 +241,16 @@ def read_sram_configuration (xml_root):
     if not sram:
         return None
 
-    config.sram_organization_api_token = config_value (sram, "organization-api-token", fallback = config.sram_organization_api_token)
-    config.sram_collaboration_id = config_value (sram, "collaboration-id", fallback = config.sram_collaboration_id)
+    config.sram_organization_api_token = config_value(
+        sram, "organization-api-token", fallback=config.sram_organization_api_token
+    )
+    config.sram_collaboration_id = config_value(
+        sram, "collaboration-id", fallback=config.sram_collaboration_id
+    )
     return None
 
-def read_saml_configuration (xml_root, logger):
+
+def read_saml_configuration(xml_root, logger):
     """Read the SAML configuration from XML_ROOT."""
 
     saml = xml_root.find("authentication/saml")
@@ -244,75 +262,75 @@ def read_saml_configuration (xml_root, logger):
         saml_version = saml.attrib["version"]
 
     if saml_version != "2.0":
-        logger.error ("Only SAML 2.0 is supported.")
+        logger.error("Only SAML 2.0 is supported.")
         raise UnsupportedSAMLProtocol
 
-    saml_strict = bool(int(config_value (saml, "strict", None, True)))
-    saml_debug  = bool(int(config_value (saml, "debug", None, False)))
+    saml_strict = bool(int(config_value(saml, "strict", None, True)))
+    saml_debug = bool(int(config_value(saml, "debug", None, False)))
 
     ## Attributes expected to receive from the IdP
-    attributes           = saml.find ("attributes")
+    attributes = saml.find("attributes")
     if attributes is None:
-        logger.error ("Missing attributes information for SAML.")
+        logger.error("Missing attributes information for SAML.")
     else:
-        config.saml_attribute_first_name = config_value (attributes, "first-name")
-        config.saml_attribute_last_name = config_value (attributes, "last-name")
-        config.saml_attribute_common_name = config_value (attributes, "common-name")
-        config.saml_attribute_email = config_value (attributes, "email")
-        config.saml_attribute_groups = config_value (attributes, "groups")
-        config.saml_attribute_group_prefix = config_value (attributes, "group-prefix")
+        config.saml_attribute_first_name = config_value(attributes, "first-name")
+        config.saml_attribute_last_name = config_value(attributes, "last-name")
+        config.saml_attribute_common_name = config_value(attributes, "common-name")
+        config.saml_attribute_email = config_value(attributes, "email")
+        config.saml_attribute_groups = config_value(attributes, "groups")
+        config.saml_attribute_group_prefix = config_value(attributes, "group-prefix")
 
     ## Service Provider settings
-    service_provider     = saml.find ("service-provider")
+    service_provider = saml.find("service-provider")
     if service_provider is None:
-        logger.error ("Missing service-provider information for SAML.")
+        logger.error("Missing service-provider information for SAML.")
 
-    saml_sp_x509         = config_value (service_provider, "x509-certificate")
-    saml_sp_private_key  = config_value (service_provider, "private-key")
+    saml_sp_x509 = config_value(service_provider, "x509-certificate")
+    saml_sp_private_key = config_value(service_provider, "private-key")
 
     ## Service provider metadata
-    sp_metadata          = service_provider.find ("metadata")
+    sp_metadata = service_provider.find("metadata")
     if sp_metadata is None:
-        logger.error ("Missing service provider's metadata for SAML.")
+        logger.error("Missing service provider's metadata for SAML.")
 
-    organization_name    = config_value (sp_metadata, "display-name")
-    organization_url     = config_value (sp_metadata, "url")
+    organization_name = config_value(sp_metadata, "display-name")
+    organization_url = config_value(sp_metadata, "url")
 
-    sp_tech_contact      = sp_metadata.find ("./contact[@type='technical']")
+    sp_tech_contact = sp_metadata.find("./contact[@type='technical']")
     if sp_tech_contact is None:
-        logger.error ("Missing technical contact information for SAML.")
-    sp_tech_email        = config_value (sp_tech_contact, "email")
+        logger.error("Missing technical contact information for SAML.")
+    sp_tech_email = config_value(sp_tech_contact, "email")
     if sp_tech_email is None:
         sp_tech_email = "-"
 
-    sp_admin_contact     = sp_metadata.find ("./contact[@type='administrative']")
+    sp_admin_contact = sp_metadata.find("./contact[@type='administrative']")
     if sp_admin_contact is None:
-        logger.error ("Missing administrative contact information for SAML.")
-    sp_admin_email        = config_value (sp_admin_contact, "email")
+        logger.error("Missing administrative contact information for SAML.")
+    sp_admin_email = config_value(sp_admin_contact, "email")
     if sp_admin_email is None:
         sp_admin_email = "-"
 
-    sp_support_contact   = sp_metadata.find ("./contact[@type='support']")
+    sp_support_contact = sp_metadata.find("./contact[@type='support']")
     if sp_support_contact is None:
-        logger.error ("Missing support contact information for SAML.")
-    sp_support_email        = config_value (sp_support_contact, "email")
+        logger.error("Missing support contact information for SAML.")
+    sp_support_email = config_value(sp_support_contact, "email")
     if sp_support_email is None:
         sp_support_email = "-"
 
     ## Identity Provider settings
-    identity_provider    = saml.find ("identity-provider")
+    identity_provider = saml.find("identity-provider")
     if identity_provider is None:
-        logger.error ("Missing identity-provider information for SAML.")
+        logger.error("Missing identity-provider information for SAML.")
 
-    saml_idp_entity_id   = config_value (identity_provider, "entity-id")
-    saml_idp_x509        = config_value (identity_provider, "x509-certificate")
+    saml_idp_entity_id = config_value(identity_provider, "entity-id")
+    saml_idp_x509 = config_value(identity_provider, "x509-certificate")
 
-    sso_service          = identity_provider.find ("single-signon-service")
+    sso_service = identity_provider.find("single-signon-service")
     if sso_service is None:
-        logger.error ("Missing SSO information of the identity-provider for SAML.")
+        logger.error("Missing SSO information of the identity-provider for SAML.")
 
-    saml_idp_sso_url     = config_value (sso_service, "url")
-    saml_idp_sso_binding = config_value (sso_service, "binding")
+    saml_idp_sso_url = config_value(sso_service, "url")
+    saml_idp_sso_binding = config_value(sso_service, "binding")
 
     config.identity_provider = "saml"
 
@@ -320,32 +338,29 @@ def read_saml_configuration (xml_root, logger):
     ## The SP entityId will and ACS URL be generated at a later time.
     config.saml_config = {
         "strict": saml_strict,
-        "debug":  saml_debug,
+        "debug": saml_debug,
         "sp": {
             "entityId": None,
             "assertionConsumerService": {
                 "url": None,
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
             },
             "singleLogoutService": {
                 "url": None,
-                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+                "binding": "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
             },
             "NameIDFormat": "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
             "x509cert": saml_sp_x509,
-            "privateKey": saml_sp_private_key
+            "privateKey": saml_sp_private_key,
         },
         "idp": {
             "entityId": saml_idp_entity_id,
             "singleSignOnService": {
                 "url": saml_idp_sso_url,
-                "binding": saml_idp_sso_binding
+                "binding": saml_idp_sso_binding,
             },
-            "singleLogoutService": {
-                "url": None,
-                "binding": None
-            },
-            "x509cert": saml_idp_x509
+            "singleLogoutService": {"url": None, "binding": None},
+            "x509cert": saml_idp_x509,
         },
         "security": {
             "nameIdEncrypted": False,
@@ -355,47 +370,48 @@ def read_saml_configuration (xml_root, logger):
             "signMetadata": True,
             "wantMessagesSigned": False,
             "wantAssertionsSigned": False,
-            "wantNameId" : True,
+            "wantNameId": True,
             "wantNameIdEncrypted": False,
             "wantAssertionsEncrypted": False,
             "allowSingleLabelDomains": False,
             "signatureAlgorithm": "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
             "digestAlgorithm": "http://www.w3.org/2001/04/xmlenc#sha256",
-            "rejectDeprecatedAlgorithm": True
+            "rejectDeprecatedAlgorithm": True,
         },
         "contactPerson": {
             "technical": {
                 "givenName": "Technical support",
-                "emailAddress": sp_tech_email
+                "emailAddress": sp_tech_email,
             },
             "support": {
                 "givenName": "General support",
-                "emailAddress": sp_support_email
+                "emailAddress": sp_support_email,
             },
             "administrative": {
                 "givenName": "Administrative support",
-                "emailAddress": sp_admin_email
-            }
+                "emailAddress": sp_admin_email,
+            },
         },
         "organization": {
             "nl": {
                 "name": organization_name,
                 "displayname": organization_name,
-                "url": organization_url
+                "url": organization_url,
             },
             "en": {
                 "name": organization_name,
                 "displayname": organization_name,
-                "url": organization_url
-            }
-        }
+                "url": organization_url,
+            },
+        },
     }
 
     del saml_sp_x509
     del saml_sp_private_key
     return None
 
-def setup_saml_service_provider (server, logger):
+
+def setup_saml_service_provider(server, logger):
     """Write the SAML configuration file to disk and set up its metadata."""
     ## python3-saml wants to read its configuration from a file,
     ## but unfortunately we can only indicate the directory for that
@@ -403,14 +419,14 @@ def setup_saml_service_provider (server, logger):
     ## for this purpose and place the file in that directory.
     if config.identity_provider == "saml":
         if not SAML2_DEPENDENCY_LOADED:
-            logger.error ("Missing python3-saml dependency.")
-            logger.error ("Cannot initiate authentication with SAML.")
+            logger.error("Missing python3-saml dependency.")
+            logger.error("Cannot initiate authentication with SAML.")
             raise DependencyNotAvailable
 
         saml_cache_dir = os.path.join(server.db.cache.storage, "saml-config")
-        os.makedirs (saml_cache_dir, mode=0o700, exist_ok=True)
-        if os.path.isdir (saml_cache_dir):
-            filename  = os.path.join (saml_cache_dir, "settings.json")
+        os.makedirs(saml_cache_dir, mode=0o700, exist_ok=True)
+        if os.path.isdir(saml_cache_dir):
+            filename = os.path.join(saml_cache_dir, "settings.json")
             saml_base_url = f"{config.base_url}/saml"
             saml_idp_binding = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
             # pylint: disable=unsubscriptable-object
@@ -421,15 +437,15 @@ def setup_saml_service_provider (server, logger):
             config.saml_config["sp"]["assertionConsumerService"]["url"] = f"{saml_base_url}/login"
             config.saml_config["idp"]["singleSignOnService"]["binding"] = saml_idp_binding
             # pylint: enable=unsubscriptable-object
-            config_fd = os.open (filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            with open (config_fd, "w", encoding="utf-8") as file_stream:
+            config_fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with open(config_fd, "w", encoding="utf-8") as file_stream:
                 json.dump(config.saml_config, file_stream)
             config.saml_config_path = saml_cache_dir
         else:
-            logger.error ("Failed to create '%s'.", saml_cache_dir)
+            logger.error("Failed to create '%s'.", saml_cache_dir)
 
 
-def refresh_group_configuration (server, logger, config_files):
+def refresh_group_configuration(server, logger, config_files):
     """Read and apply the group configuration from CONFIG_FILES."""
     for config_file in config_files:
         xml_root = parse_config_root(config_file)
@@ -439,7 +455,7 @@ def refresh_group_configuration (server, logger, config_files):
         if not groups:
             continue
 
-        logger.info ("Refreshing groups configuration.")
+        logger.info("Refreshing groups configuration.")
         # Reconcile by 'id' rather than the 'is_inferred' flag: groups
         group_ids = [group.attrib.get("id") for group in groups]
         server.db.delete_groups_by_id(group_ids)
@@ -447,81 +463,87 @@ def refresh_group_configuration (server, logger, config_files):
         for group in groups:
             group_name = group.attrib["name"]
             group_id = group.attrib["id"]
-            parent_id = convenience.value_or_none (group.attrib, "parent_id")
+            parent_id = convenience.value_or_none(group.attrib, "parent_id")
             domain = group.attrib["domain"]
             is_featured = group.attrib.get("is_featured") == "1"
-            group_uuid = server.db.insert_group (group_name, True, is_featured, group_id, parent_id, domain)
+            group_uuid = server.db.insert_group(
+                group_name, True, is_featured, group_id, parent_id, domain
+            )
             for member in group:
                 is_supervisor = member.attrib.get("is_supervisor") == "1"
                 email = member.attrib.get("email")
                 if email is None:
-                    logger.error ("Account must have 'email' attribute.")
+                    logger.error("Account must have 'email' attribute.")
                     continue
                 email = email.lower()
                 account = server.db.account_by_email(email)
                 if account is not None:
                     logger.info("Account %s already exists.", email)
-                    server.db.insert_group_member (group_uuid, account["uuid"], is_supervisor)
-                    server.db.update_account (account["uuid"], domain=domain)
+                    server.db.insert_group_member(group_uuid, account["uuid"], is_supervisor)
+                    server.db.update_account(account["uuid"], domain=domain)
                 else:
                     logger.info("Account %s does not exist.", email)
                     first_name = member.attrib.get("first_name")
-                    last_name  = member.attrib.get("last_name")
+                    last_name = member.attrib.get("last_name")
                     common_name = f"{first_name} {last_name}"
                     if first_name is None and last_name is None:
-                        logger.warning ("Adding account %s without name.", email)
+                        logger.warning("Adding account %s without name.", email)
                         common_name = None
-                    account_uuid = server.db.insert_account (
-                        email       = email,
-                        first_name  = first_name,
-                        last_name   = last_name,
-                        common_name = common_name,
-                        domain      = domain)
+                    account_uuid = server.db.insert_account(
+                        email=email,
+                        first_name=first_name,
+                        last_name=last_name,
+                        common_name=common_name,
+                        domain=domain,
+                    )
                     if account_uuid is None:
                         logger.error("Cannot find account for %s.", email)
                         continue
-                    server.db.insert_group_member (group_uuid, account_uuid, is_supervisor)
+                    server.db.insert_group_member(group_uuid, account_uuid, is_supervisor)
 
-def write_pem_file (file_stream, contents, format_name):
+
+def write_pem_file(file_stream, contents, format_name):
     """Writes CONTENTS to FILE_STREAM."""
     file_stream.write(f"-----BEGIN {format_name}-----\n")
     total_length = len(contents)
     start = 0
     while start < total_length:
-        file_stream.write (contents[start:start+64])
-        file_stream.write ("\n")
+        file_stream.write(contents[start : start + 64])
+        file_stream.write("\n")
         start += 64
     file_stream.write(f"-----END {format_name}-----\n")
 
-def setup_handle_registration (server, logger):
+
+def setup_handle_registration(server, logger):
     """Write the Handle configuration to a file."""
 
     handle_cache_dir = os.path.join(server.db.cache.storage, "handle-config")
-    os.makedirs (handle_cache_dir, mode=0o700, exist_ok=True)
-    if not os.path.isdir (handle_cache_dir):
-        logger.error ("Failed to create '%s'.", handle_cache_dir)
+    os.makedirs(handle_cache_dir, mode=0o700, exist_ok=True)
+    if not os.path.isdir(handle_cache_dir):
+        logger.error("Failed to create '%s'.", handle_cache_dir)
 
-    config.handle_certificate_path = os.path.join (handle_cache_dir, "certificate.pem")
-    config.handle_private_key_path = os.path.join (handle_cache_dir, "certificate.key")
+    config.handle_certificate_path = os.path.join(handle_cache_dir, "certificate.pem")
+    config.handle_private_key_path = os.path.join(handle_cache_dir, "certificate.key")
 
     if config.handle_certificate is None or config.handle_private_key is None:
         return None
 
-    config_fd = os.open (config.handle_certificate_path,
-                         os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                         0o600)
-    with open (config_fd, "w", encoding="utf-8") as file_stream:
-        write_pem_file (file_stream, config.handle_certificate, "CERTIFICATE")
+    config_fd = os.open(
+        config.handle_certificate_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+    )
+    with open(config_fd, "w", encoding="utf-8") as file_stream:
+        write_pem_file(file_stream, config.handle_certificate, "CERTIFICATE")
 
-    config_fd = os.open (config.handle_private_key_path,
-                         os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-                         0o600)
-    with open (config_fd, "w", encoding="utf-8") as file_stream:
-        write_pem_file (file_stream, config.handle_private_key, "PRIVATE KEY")
+    config_fd = os.open(
+        config.handle_private_key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+    )
+    with open(config_fd, "w", encoding="utf-8") as file_stream:
+        write_pem_file(file_stream, config.handle_private_key, "PRIVATE KEY")
 
     return None
 
-def read_privilege_configuration (xml_root, logger):
+
+def read_privilege_configuration(xml_root, logger):
     """Read the privileges configuration from XML_ROOT."""
     privileges = xml_root.find("privileges")
     if not privileges:
@@ -535,67 +557,83 @@ def read_privilege_configuration (xml_root, logger):
                 orcid = account.attrib["orcid"]
             lowercase_email = email.lower()
             config.privileges[lowercase_email] = {
-                "may_administer":  bool(int(config_value (account, "may-administer", None, False))),
-                "may_query":       bool(int(config_value (account, "may-run-sparql-queries", None, False))),
-                "may_impersonate": bool(int(config_value (account, "may-impersonate", None, False))),
-                "may_review":      bool(int(config_value (account, "may-review", None, False))),
-                "may_review_institution": bool(int(config_value (account, "may-review-institution", None, False))),
-                "may_review_quotas": bool(int(config_value (account, "may-review-quotas", None, False))),
-                "may_review_integrity": bool(int(config_value (account, "may-review-integrity", None, False))),
-                "may_process_feedback": bool(int(config_value (account, "may-process-feedback", None, False))),
-                "may_recalculate_statistics": bool(int(config_value (account, "may-recalculate-statistics", None, False))),
-                "may_receive_email_notifications": bool(int(config_value (account, "may-receive-email-notifications", None, True))),
-                "orcid":           orcid,
-                "first_name":      account.attrib.get("first_name"),
-                "last_name":       account.attrib.get("last_name"),
+                "may_administer": bool(int(config_value(account, "may-administer", None, False))),
+                "may_query": bool(
+                    int(config_value(account, "may-run-sparql-queries", None, False))
+                ),
+                "may_impersonate": bool(int(config_value(account, "may-impersonate", None, False))),
+                "may_review": bool(int(config_value(account, "may-review", None, False))),
+                "may_review_institution": bool(
+                    int(config_value(account, "may-review-institution", None, False))
+                ),
+                "may_review_quotas": bool(
+                    int(config_value(account, "may-review-quotas", None, False))
+                ),
+                "may_review_integrity": bool(
+                    int(config_value(account, "may-review-integrity", None, False))
+                ),
+                "may_process_feedback": bool(
+                    int(config_value(account, "may-process-feedback", None, False))
+                ),
+                "may_recalculate_statistics": bool(
+                    int(config_value(account, "may-recalculate-statistics", None, False))
+                ),
+                "may_receive_email_notifications": bool(
+                    int(config_value(account, "may-receive-email-notifications", None, True))
+                ),
+                "orcid": orcid,
+                "first_name": account.attrib.get("first_name"),
+                "last_name": account.attrib.get("last_name"),
             }
 
             ## The "needs_2fa" property is set to True when the user has any
             ## extra privilege.
             config.privileges[lowercase_email]["needs_2fa"] = (not config.disable_2fa) and (
-                config.privileges[lowercase_email]["may_administer"] or
-                config.privileges[lowercase_email]["may_query"] or
-                config.privileges[lowercase_email]["may_impersonate"] or
-                config.privileges[lowercase_email]["may_review"] or
-                config.privileges[lowercase_email]["may_process_feedback"] or
-                config.privileges[lowercase_email]["may_recalculate_statistics"] or
-                config.privileges[lowercase_email]["may_review_quotas"]
+                config.privileges[lowercase_email]["may_administer"]
+                or config.privileges[lowercase_email]["may_query"]
+                or config.privileges[lowercase_email]["may_impersonate"]
+                or config.privileges[lowercase_email]["may_review"]
+                or config.privileges[lowercase_email]["may_process_feedback"]
+                or config.privileges[lowercase_email]["may_recalculate_statistics"]
+                or config.privileges[lowercase_email]["may_review_quotas"]
             )
 
         except KeyError as error:
-            logger.error ("Missing %s attribute for a privilege configuration.", error)
+            logger.error("Missing %s attribute for a privilege configuration.", error)
         except ValueError as error:
-            logger.error ("Privilege configuration error: %s", error)
+            logger.error("Privilege configuration error: %s", error)
 
     return None
 
-def configure_file_logging (log_file, inside_reload, logger):
+
+def configure_file_logging(log_file, inside_reload, logger):
     """Procedure to set up logging to a file."""
     is_writeable = False
-    log_file     = os.path.abspath (log_file)
+    log_file = os.path.abspath(log_file)
     try:
-        with open (log_file, "a", encoding = "utf-8"):
+        with open(log_file, "a", encoding="utf-8"):
             is_writeable = True
     except (PermissionError, FileNotFoundError):
         pass
 
     if not is_writeable:
         if not inside_reload:
-            logger.warning ("Cannot write to '%s'.", log_file)
+            logger.warning("Cannot write to '%s'.", log_file)
     else:
-        file_handler = logging.FileHandler (log_file, 'a')
+        file_handler = logging.FileHandler(log_file, "a")
         if not inside_reload:
-            logger.info ("Writing further messages to '%s'.", log_file)
+            logger.info("Writing further messages to '%s'.", log_file)
 
-        formatter    = logging.Formatter('[%(levelname)s] %(asctime)s - %(name)s: %(message)s')
+        formatter = logging.Formatter("[%(levelname)s] %(asctime)s - %(name)s: %(message)s")
         file_handler.setFormatter(formatter)
         file_handler.setLevel(logging.INFO)
-        log          = logging.getLogger()
+        log = logging.getLogger()
         for handler in log.handlers[:]:
             log.removeHandler(handler)
         log.addHandler(file_handler)
 
-def read_menu_configuration (xml_root):
+
+def read_menu_configuration(xml_root):
     """Procedure to parse the menu configuration from XML_ROOT."""
     menu = xml_root.find("menu")
     if not menu:
@@ -608,29 +646,31 @@ def read_menu_configuration (xml_root):
                 sub_submenu = []
                 for sub_submenu_item in submenu_item:
                     if sub_submenu_item.tag == "sub-sub-menu":
-                        sub_submenu.append({
-                            "title": config_value (sub_submenu_item, "title"),
-                            "href":  config_value (sub_submenu_item, "href")
-                        })
-                submenu.append({
-                    "title":       config_value (submenu_item, "title"),
-                    "href":        config_value (submenu_item, "href"),
-                    "sub_submenu": sub_submenu
-                })
+                        sub_submenu.append(
+                            {
+                                "title": config_value(sub_submenu_item, "title"),
+                                "href": config_value(sub_submenu_item, "href"),
+                            }
+                        )
+                submenu.append(
+                    {
+                        "title": config_value(submenu_item, "title"),
+                        "href": config_value(submenu_item, "href"),
+                        "sub_submenu": sub_submenu,
+                    }
+                )
 
-        config.menu.append({
-            "title":   config_value (primary_menu_item, "title"),
-            "submenu": submenu
-        })
+        config.menu.append({"title": config_value(primary_menu_item, "title"), "submenu": submenu})
 
     return None
 
-def read_static_pages (static_pages, server, config_dir):
+
+def read_static_pages(static_pages, server, config_dir):
     """Procedure to parse and register static pages."""
     for page in static_pages:
-        uri_path        = config_value (page, "uri-path")
-        filesystem_path = config_value (page, "filesystem-path")
-        redirect_to     = page.find("redirect-to")
+        uri_path = config_value(page, "uri-path")
+        filesystem_path = config_value(page, "filesystem-path")
+        redirect_to = page.find("redirect-to")
 
         if uri_path is not None and filesystem_path is not None:
             if not os.path.isabs(filesystem_path):
@@ -643,19 +683,29 @@ def read_static_pages (static_pages, server, config_dir):
             code = 302
             if "code" in redirect_to.attrib:
                 code = int(redirect_to.attrib["code"])
-            server.static_pages[uri_path] = {"redirect-to": redirect_to.text, "code": code}
+            server.static_pages[uri_path] = {
+                "redirect-to": redirect_to.text,
+                "code": code,
+            }
 
-def read_colors_configuration (xml_root):
+
+def read_colors_configuration(xml_root):
     """Procedure to parse and set the color scheme configuration."""
     colors = xml_root.find("colors")
     if colors:
-        for color in ["primary-color", "primary-color-hover",
-                      "primary-color-active", "primary-foreground-color",
-                      "privilege-button-color", "footer-background-color",
-                      "background-color"]:
-            config.colors[color] = config_value (colors, color, fallback=config.colors[color])
+        for color in [
+            "primary-color",
+            "primary-color-hover",
+            "primary-color-active",
+            "primary-foreground-color",
+            "privilege-button-color",
+            "footer-background-color",
+            "background-color",
+        ]:
+            config.colors[color] = config_value(colors, color, fallback=config.colors[color])
 
-def read_fonts_configuration (xml_root):
+
+def read_fonts_configuration(xml_root):
     """Procedure to parse and set the custom typography configuration."""
     fonts = xml_root.find("fonts")
     if fonts is None:
@@ -663,124 +713,145 @@ def read_fonts_configuration (xml_root):
 
     font_faces = []
     for face in fonts.findall("font-face"):
-        font_faces.append({
-            "family":  config_value (face, "family"),
-            "src":     config_value (face, "src"),
-            "format":  config_value (face, "format", fallback="woff2"),
-            "weight":  config_value (face, "weight"),
-            "style":   config_value (face, "style"),
-            "display": config_value (face, "display", fallback="swap"),
-        })
+        font_faces.append(
+            {
+                "family": config_value(face, "family"),
+                "src": config_value(face, "src"),
+                "format": config_value(face, "format", fallback="woff2"),
+                "weight": config_value(face, "weight"),
+                "style": config_value(face, "style"),
+                "display": config_value(face, "display", fallback="swap"),
+            }
+        )
 
     config.fonts = {
         "font_faces": font_faces,
-        "body_font":  config_value (fonts, "body-font-family"),
-        "ui_font":    config_value (fonts, "ui-font-family"),
-        "mono_font":  config_value (fonts, "mono-font-family"),
+        "body_font": config_value(fonts, "body-font-family"),
+        "ui_font": config_value(fonts, "ui-font-family"),
+        "mono_font": config_value(fonts, "mono-font-family"),
     }
 
-def read_custom_stylesheets (xml_root):
-    """Procedure to parse and set the instance-specific stylesheets."""
-    for stylesheet in xml_root.findall ("custom-stylesheet"):
-        if not stylesheet.text:
-            continue
-        href = stylesheet.text.strip()
-        if href not in config.custom_stylesheets:
-            config.custom_stylesheets.append (href)
 
-def warn_about_unresolvable_asset (assets_root, source, description, logger):
+def read_custom_stylesheets(xml_root):
+    """Procedure to parse and set the instance-specific stylesheets."""
+    for stylesheet in xml_root.findall("custom-stylesheet"):
+        href = (stylesheet.text or "").strip()
+        if not href:
+            continue
+        if href not in config.custom_stylesheets:
+            config.custom_stylesheets.append(href)
+
+
+def warn_about_unresolvable_asset(assets_root, source, description, logger):
     """Procedure to warn when SOURCE cannot be served from ASSETS_ROOT."""
+
     prefix = "/assets/"
-    if not source.startswith (prefix):
+    if not source.startswith(prefix):
         return
 
     if assets_root is None:
-        logger.warning ("%s refers to '%s' but 'custom-assets-root' is unset.",
-                        description, source)
-    elif not os.path.isfile (os.path.join (assets_root, source[len(prefix):])):
-        logger.warning ("%s refers to '%s' which does not exist under '%s'.",
-                        description, source, assets_root)
+        logger.warning("%s refers to '%s' but 'custom-assets-root' is unset.", description, source)
+    elif not os.path.isfile(os.path.join(assets_root, source[len(prefix) :])):
+        logger.warning(
+            "%s refers to '%s' which does not exist under '%s'.",
+            description,
+            source,
+            assets_root,
+        )
 
-def warn_about_unresolvable_assets (assets_root, logger):
+
+def warn_about_unresolvable_assets(assets_root, logger):
     """Procedure to warn about configured assets that cannot be served."""
     if config.fonts:
         for face in config.fonts["font_faces"]:
-            warn_about_unresolvable_asset (assets_root, face["src"],
-                                           f"Font '{face['family']}'", logger)
+            warn_about_unresolvable_asset(
+                assets_root, face["src"], f"Font '{face['family']}'", logger
+            )
 
     for stylesheet in config.custom_stylesheets:
-        warn_about_unresolvable_asset (assets_root, stylesheet, "Stylesheet", logger)
+        warn_about_unresolvable_asset(assets_root, stylesheet, "Stylesheet", logger)
 
-def read_datacite_configuration (xml_root):
+
+def read_datacite_configuration(xml_root):
     """Procedure to parse and set the DataCite API configuration."""
     datacite = xml_root.find("datacite")
     if datacite:
-        config.datacite_url      = config_value (datacite, "api-url")
-        config.datacite_id       = config_value (datacite, "repository-id")
-        config.datacite_password = config_value (datacite, "password")
-        config.datacite_prefix   = config_value (datacite, "prefix")
+        config.datacite_url = config_value(datacite, "api-url")
+        config.datacite_id = config_value(datacite, "repository-id")
+        config.datacite_password = config_value(datacite, "password")
+        config.datacite_prefix = config_value(datacite, "prefix")
 
-def read_handle_configuration (xml_root):
+
+def read_handle_configuration(xml_root):
     """Procedure to parse and set the Handle API configuration."""
     handle = xml_root.find("handle")
     if handle:
-        config.handle_url         = config_value (handle, "url")
-        config.handle_certificate = config_value (handle, "certificate")
-        config.handle_private_key = config_value (handle, "private-key")
-        config.handle_prefix      = config_value (handle, "prefix")
-        config.handle_index       = config_value (handle, "index")
+        config.handle_url = config_value(handle, "url")
+        config.handle_certificate = config_value(handle, "certificate")
+        config.handle_private_key = config_value(handle, "private-key")
+        config.handle_prefix = config_value(handle, "prefix")
+        config.handle_index = config_value(handle, "index")
 
-def read_automatic_login_configuration (xml_root):
+
+def read_automatic_login_configuration(xml_root):
     """Procedure to parse and set automatic login for development setups."""
-    automatic_login_email = config_value (xml_root, "authentication/automatic-login-email")
-    if (automatic_login_email is not None
+    automatic_login_email = config_value(xml_root, "authentication/automatic-login-email")
+    if (
+        automatic_login_email is not None
         and config.orcid_client_id is None
-        and config.saml_config is None):
+        and config.saml_config is None
+    ):
         config.identity_provider = "automatic-login"
         config.automatic_login_email = automatic_login_email
 
-def read_orcid_configuration (xml_root):
+
+def read_orcid_configuration(xml_root):
     """Procedure to parse and set the ORCID API configuration."""
     orcid = xml_root.find("authentication/orcid")
     if orcid:
-        config.orcid_client_id     = config_value (orcid, "client-id")
-        config.orcid_client_secret = config_value (orcid, "client-secret")
-        config.orcid_endpoint      = config_value (orcid, "endpoint")
-        config.orcid_read_public_token = config_value (orcid, "read-public-token")
+        config.orcid_client_id = config_value(orcid, "client-id")
+        config.orcid_client_secret = config_value(orcid, "client-secret")
+        config.orcid_endpoint = config_value(orcid, "endpoint")
+        config.orcid_read_public_token = config_value(orcid, "read-public-token")
 
         # SAML takes precedence over ORCID authentication.
         if config.identity_provider != "saml":
-            config.identity_provider   = "orcid"
+            config.identity_provider = "orcid"
 
-def read_email_configuration (server, xml_root, logger):
+
+def read_email_configuration(server, xml_root, logger):
     """Procedure to parse and set the email server configuration."""
     email = xml_root.find("email")
     if email:
         try:
-            server.email.smtp_port = int(config_value (email, "port"))
-            server.email.smtp_server = config_value (email, "server")
-            server.email.from_address = config_value (email, "from")
-            server.email.smtp_username = config_value (email, "username")
-            server.email.smtp_password = config_value (email, "password")
-            server.email.subject_prefix = config_value (email, "subject-prefix", None, None)
-            server.email.do_starttls = bool(int(config_value (email, "starttls", None, 0)))
+            server.email.smtp_port = int(config_value(email, "port"))
+            server.email.smtp_server = config_value(email, "server")
+            server.email.from_address = config_value(email, "from")
+            server.email.smtp_username = config_value(email, "username")
+            server.email.smtp_password = config_value(email, "password")
+            server.email.subject_prefix = config_value(email, "subject-prefix", None, None)
+            server.email.do_starttls = bool(int(config_value(email, "starttls", None, 0)))
         except ValueError:
-            logger.error ("Could not configure the email subsystem:")
-            logger.error ("The email port should be a numeric value.")
+            logger.error("Could not configure the email subsystem:")
+            logger.error("The email port should be a numeric value.")
 
-def read_upload_dataset_configuration (xml_root, logger):
+
+def read_upload_dataset_configuration(xml_root, logger):
     """Procedure to parse and set the upload dataset configuration."""
     upload_dataset = xml_root.find("upload-dataset")
     if upload_dataset is not None:
-        config.allow_full_embargo = read_boolean_value(upload_dataset, "allow-full-embargo", True, logger)
+        config.allow_full_embargo = read_boolean_value(
+            upload_dataset, "allow-full-embargo", True, logger
+        )
         file_deposit_notice = upload_dataset.find("file-deposit/notice")
         if file_deposit_notice is not None:
             config.file_deposit_notice, _ = read_raw_xml(upload_dataset, "file-deposit/notice")
 
-def read_configuration_file (server, config_file, logger, config_files):
+
+def read_configuration_file(server, config_file, logger, config_files):
     """Procedure to parse a configuration file."""
 
-    inside_reload = os.environ.get('WERKZEUG_RUN_MAIN')
+    inside_reload = os.environ.get("WERKZEUG_RUN_MAIN")
     try:
         if config_file is None:
             raise FileNotFoundError
@@ -794,15 +865,16 @@ def read_configuration_file (server, config_file, logger, config_files):
             raise ConfigFileNotFound
 
         config_dir = os.path.dirname(config_file)
-        log_file = config_value (xml_root, "log-file", None, None)
+        log_file = config_value(xml_root, "log-file", None, None)
         if log_file is not None:
             config.log_file = log_file
-            configure_file_logging (log_file, inside_reload, logger)
+            configure_file_logging(log_file, inside_reload, logger)
 
-        config.address      = config_value (xml_root, "bind-address", config.address, "127.0.0.1")
-        config.port         = int(config_value (xml_root, "port", config.port, 8080))
-        config.alternative_port = config_value (xml_root, "alternative-port",
-                                                config.alternative_port, None)
+        config.address = config_value(xml_root, "bind-address", config.address, "127.0.0.1")
+        config.port = int(config_value(xml_root, "port", config.port, 8080))
+        config.alternative_port = config_value(
+            xml_root, "alternative-port", config.alternative_port, None
+        )
         if config.alternative_port is not None:
             config.alternative_port = int(config.alternative_port)
 
@@ -822,57 +894,67 @@ def read_configuration_file (server, config_file, logger, config_files):
                                                           config.auto_migrate_on_boot,
                                                           logger)
 
-        live_reload             = convenience.value_or_none (config, "live-reload")
-        config.use_reloader  = config_value (xml_root, "live-reload", None, live_reload)
 
-        debug_mode             = convenience.value_or_none (config, "debug-mode")
-        config.use_debugger    = config_value (xml_root, "debug-mode", None, debug_mode)
-        config.maximum_workers = int(config_value (xml_root, "maximum-workers", None, 1))
+        live_reload = convenience.value_or_none(config, "live-reload")
+        config.use_reloader = config_value(xml_root, "live-reload", None, live_reload)
 
-        endpoint = config_value (xml_root, "rdf-store/sparql-uri")
+        debug_mode = convenience.value_or_none(config, "debug-mode")
+        config.use_debugger = config_value(xml_root, "debug-mode", None, debug_mode)
+        config.maximum_workers = int(config_value(xml_root, "maximum-workers", None, 1))
+
+        endpoint = config_value(xml_root, "rdf-store/sparql-uri")
         if endpoint:
             config.endpoint = endpoint
 
-        update_endpoint = config_value (xml_root, "rdf-store/sparql-update-uri")
+        update_endpoint = config_value(xml_root, "rdf-store/sparql-update-uri")
         if update_endpoint:
             config.update_endpoint = update_endpoint
 
-        config.show_portal_summary = read_boolean_value (xml_root, "show-portal-summary",
-                                                         config.show_portal_summary, logger)
+        config.show_portal_summary = read_boolean_value(
+            xml_root, "show-portal-summary", config.show_portal_summary, logger
+        )
 
-        config.show_institutions = read_boolean_value (xml_root, "show-institutions",
-                                                       config.show_institutions, logger)
+        config.show_institutions = read_boolean_value(
+            xml_root, "show-institutions", config.show_institutions, logger
+        )
 
-        config.show_science_categories = read_boolean_value (xml_root, "show-science-categories",
-                                                             config.show_science_categories, logger)
+        config.show_science_categories = read_boolean_value(
+            xml_root, "show-science-categories", config.show_science_categories, logger
+        )
 
-        config.show_latest_datasets = read_boolean_value (xml_root, "show-latest-datasets",
-                                                          config.show_latest_datasets, logger)
+        config.show_latest_datasets = read_boolean_value(
+            xml_root, "show-latest-datasets", config.show_latest_datasets, logger
+        )
 
-        config.maintenance_mode = read_boolean_value (xml_root, "maintenance-mode",
-                                                      config.maintenance_mode, logger)
+        config.maintenance_mode = read_boolean_value(
+            xml_root, "maintenance-mode", config.maintenance_mode, logger
+        )
 
-        config.disable_2fa = read_boolean_value (xml_root, "disable-2fa",
-                                                 config.disable_2fa, logger)
+        config.disable_2fa = read_boolean_value(xml_root, "disable-2fa", config.disable_2fa, logger)
 
-        config.allow_crawlers = read_boolean_value (xml_root, "allow-crawlers",
-                                                    config.allow_crawlers, logger)
+        config.allow_crawlers = read_boolean_value(
+            xml_root, "allow-crawlers", config.allow_crawlers, logger
+        )
 
-        config.enable_iiif = read_boolean_value (xml_root, "enable-iiif",
-                                                 config.enable_iiif, logger)
+        config.enable_iiif = read_boolean_value(xml_root, "enable-iiif", config.enable_iiif, logger)
 
-        config.enable_codecheck = read_boolean_value (xml_root, "enable-codecheck",
-                                                 config.enable_codecheck, logger)
+        config.enable_codecheck = read_boolean_value(
+            xml_root, "enable-codecheck", config.enable_codecheck, logger
+        )
 
-        config.delay_inserting_log_entries = read_boolean_value (xml_root, "delay-inserting-log-entries",
-                                                                 config.delay_inserting_log_entries, logger)
+        config.delay_inserting_log_entries = read_boolean_value(
+            xml_root,
+            "delay-inserting-log-entries",
+            config.delay_inserting_log_entries,
+            logger,
+        )
 
-        ssi_psk = config_value (xml_root, "ssi-psk")
+        ssi_psk = config_value(xml_root, "ssi-psk")
         if ssi_psk is not None:
             ssi_psk = ssi_psk.replace(" ", "").replace("\n", "").replace("\r", "").replace("\t", "")
             config.ssi_psk = ssi_psk
 
-        enable_query_audit_log = xml_root.find ("enable-query-audit-log")
+        enable_query_audit_log = xml_root.find("enable-query-audit-log")
         if enable_query_audit_log is not None:
             transactions_directory = enable_query_audit_log.attrib.get("transactions-directory")
             if transactions_directory is not None:
@@ -880,57 +962,61 @@ def read_configuration_file (server, config_file, logger, config_files):
             try:
                 config.enable_query_audit_log = bool(int(enable_query_audit_log.text))
             except (ValueError, TypeError):
-                logger.info("Invalid value for enable-query-audit-log. Ignoring.. assuming 1 (True)")
+                logger.info(
+                    "Invalid value for enable-query-audit-log. Ignoring.. assuming 1 (True)"
+                )
 
         if config.use_reloader:
             config.use_reloader = bool(int(config.use_reloader))
         if config.use_debugger:
             config.use_debugger = bool(int(config.use_debugger))
 
-        cache_root = xml_root.find ("cache-root")
+        cache_root = xml_root.find("cache-root")
         if cache_root is not None:
             server.db.cache.storage = cache_root.text
             try:
                 clear_on_start = cache_root.attrib.get("clear-on-start")
                 config.clear_cache_on_start = bool(int(clear_on_start))
             except ValueError:
-                logger.warning ("Invalid value for the 'clear-on-start' attribute in 'cache-root'.")
-                logger.warning ("Will not clear cache on start; Use '1' to enable, or '0' to disable.")
+                logger.warning("Invalid value for the 'clear-on-start' attribute in 'cache-root'.")
+                logger.warning(
+                    "Will not clear cache on start; Use '1' to enable, or '0' to disable."
+                )
                 config.clear_cache_on_start = False
             except TypeError:
                 config.clear_cache_on_start = False
         elif server.db.cache.storage is None:
-            server.db.cache.storage = os.path.join (config.storage, "cache")
+            server.db.cache.storage = os.path.join(config.storage, "cache")
 
-        profile_images_root = xml_root.find ("profile-images-root")
+        profile_images_root = xml_root.find("profile-images-root")
         if profile_images_root is not None:
             config.profile_images_storage = profile_images_root.text
         elif config.profile_images_storage is None:
-            config.profile_images_storage = os.path.join (config.storage, "profile-images")
+            config.profile_images_storage = os.path.join(config.storage, "profile-images")
 
-        thumbnails_root = xml_root.find ("thumbnails-root")
+        thumbnails_root = xml_root.find("thumbnails-root")
         if thumbnails_root is not None:
             config.thumbnail_storage = thumbnails_root.text
         elif config.thumbnail_storage is None:
-            config.thumbnail_storage = os.path.join (config.storage, "thumbnails")
+            config.thumbnail_storage = os.path.join(config.storage, "thumbnails")
 
-        iiif_cache = xml_root.find ("iiif-cache-root")
+        iiif_cache = xml_root.find("iiif-cache-root")
         if iiif_cache is not None:
             config.iiif_cache_storage = iiif_cache.text
         elif config.iiif_cache_storage is None:
-            config.iiif_cache_storage = os.path.join (config.storage, "iiif")
+            config.iiif_cache_storage = os.path.join(config.storage, "iiif")
 
-        s3_cache = xml_root.find ("s3-cache-root")
+        s3_cache = xml_root.find("s3-cache-root")
         if s3_cache is not None:
             config.s3_cache_storage = s3_cache.text
         elif config.s3_cache_storage is None:
-            config.s3_cache_storage = os.path.join (config.storage, "s3")
+            config.s3_cache_storage = os.path.join(config.storage, "s3")
 
-        static_resources_cache = xml_root.find ("static-resources-cache")
+        static_resources_cache = xml_root.find("static-resources-cache")
         if static_resources_cache is not None:
             config.static_cache_root = static_resources_cache.text
 
-        production_mode = xml_root.find ("production")
+        production_mode = xml_root.find("production")
         if production_mode is not None:
             config.in_production = bool(int(production_mode.text))
             try:
@@ -938,103 +1024,109 @@ def read_configuration_file (server, config_file, logger, config_files):
                 if pre_production is not None:
                     config.in_preproduction = bool(int(pre_production))
             except (ValueError, TypeError):
-                logger.warning ("Invalid value for the 'pre-production' attribute in 'production'.")
-                logger.warning ("Pre-production mode is enabled; Use either '1' to enable, or '0' to disable.")
+                logger.warning("Invalid value for the 'pre-production' attribute in 'production'.")
+                logger.warning(
+                    "Pre-production mode is enabled; Use either '1' to enable, or '0' to disable."
+                )
                 config.in_preproduction = True
 
-        secondary_storage = xml_root.find ("secondary-storage-root")
+        secondary_storage = xml_root.find("secondary-storage-root")
         if secondary_storage is not None:
             config.secondary_storage = secondary_storage.text
             try:
                 quirks = secondary_storage.attrib.get("quirks")
                 config.secondary_storage_quirks = bool(int(quirks))
             except ValueError:
-                logger.warning ("Invalid value for the 'quirks' attribute in 'secondary-storage-root'.")
-                logger.warning ("Quirks-mode is disabled; Use either '1' to enable, or '0' to disable.")
+                logger.warning(
+                    "Invalid value for the 'quirks' attribute in 'secondary-storage-root'."
+                )
+                logger.warning(
+                    "Quirks-mode is disabled; Use either '1' to enable, or '0' to disable."
+                )
                 config.secondary_storage_quirks = False
             except TypeError:
                 config.secondary_storage_quirks = False
 
-        use_x_forwarded_for = bool(int(config_value (xml_root, "use-x-forwarded-for", None, 0)))
+        use_x_forwarded_for = bool(int(config_value(xml_root, "use-x-forwarded-for", None, 0)))
         if use_x_forwarded_for:
             server.log_access = server.log_access_using_x_forwarded_for
 
-        config.disable_collaboration = read_boolean_value (xml_root, "disable-collaboration",
-                                                           config.disable_collaboration,
-                                                           logger)
+        config.disable_collaboration = read_boolean_value(
+            xml_root, "disable-collaboration", config.disable_collaboration, logger
+        )
 
-        sandbox_message, sandbox_message_attributes = read_raw_xml (xml_root, "sandbox-message")
+        sandbox_message, sandbox_message_attributes = read_raw_xml(xml_root, "sandbox-message")
         if sandbox_message:
             config.sandbox_message_css = sandbox_message_attributes.get("style")
             config.sandbox_message = sandbox_message
 
-        notice_message, _ = read_raw_xml (xml_root, "notice-message")
+        notice_message, _ = read_raw_xml(xml_root, "notice-message")
         if notice_message:
             config.notice_message = notice_message
 
-        large_footer, _ = read_raw_xml (xml_root, "large-footer")
+        large_footer, _ = read_raw_xml(xml_root, "large-footer")
         if large_footer:
             config.large_footer = large_footer
 
-        small_footer, _ = read_raw_xml (xml_root, "small-footer")
+        small_footer, _ = read_raw_xml(xml_root, "small-footer")
         if small_footer:
             config.small_footer = small_footer
 
-        site_name = xml_root.find ("site-name")
+        site_name = xml_root.find("site-name")
         if site_name is not None:
             config.site_name = site_name.text
 
-        site_description = xml_root.find ("site-description")
+        site_description = xml_root.find("site-description")
         if site_description is not None:
             config.site_description = site_description.text
 
-        site_shorttag = xml_root.find ("site-shorttag")
+        site_shorttag = xml_root.find("site-shorttag")
         if site_shorttag is not None:
             config.site_shorttag = site_shorttag.text
 
-        publisher_rors = xml_root.find ("publisher-rors")
+        publisher_rors = xml_root.find("publisher-rors")
         if publisher_rors is not None:
             for entry in publisher_rors:
                 if entry.tag != "publisher-ror":
-                    logger.error ("Unexpected '%s' in 'publisher-rors'.", entry.tag)
+                    logger.error("Unexpected '%s' in 'publisher-rors'.", entry.tag)
                     raise SystemExit
-                name = entry.get ("name")
-                url  = entry.get ("url")
+                name = entry.get("name")
+                url = entry.get("url")
                 if not name or not url:
-                    logger.error ("'publisher-ror' requires non-empty 'name' and 'url' attributes.")
+                    logger.error("'publisher-ror' requires non-empty 'name' and 'url' attributes.")
                     raise SystemExit
                 config.publisher_rors[name.strip()] = url.strip()
 
-        support_email_address = xml_root.find ("support-email-address")
+        support_email_address = xml_root.find("support-email-address")
         if support_email_address is not None:
             config.support_email_address = support_email_address.text
 
-        depositing_domains = xml_root.find ("allowed-depositing-domains")
+        depositing_domains = xml_root.find("allowed-depositing-domains")
         if depositing_domains is not None:
             for domain in depositing_domains:
                 if domain.tag != "domain":
-                    logger.error ("Unexpected '%s' in 'allowed-depositing-domains'.", domain.tag)
+                    logger.error("Unexpected '%s' in 'allowed-depositing-domains'.", domain.tag)
                     raise SystemExit
                 if domain.text is None or domain.text.strip() == "":
                     continue
-                config.depositing_domains.append (domain.text.strip())
+                config.depositing_domains.append(domain.text.strip())
 
-        read_orcid_configuration (xml_root)
-        read_datacite_configuration (xml_root)
-        read_handle_configuration (xml_root)
-        read_email_configuration (server, xml_root, logger)
-        read_saml_configuration (xml_root, logger)
-        read_sram_configuration (xml_root)
-        read_automatic_login_configuration (xml_root)
-        read_privilege_configuration (xml_root, logger)
-        read_storage_configuration (xml_root, logger)
-        read_quotas_configuration (xml_root)
-        read_colors_configuration (xml_root)
-        read_fonts_configuration (xml_root)
-        read_upload_dataset_configuration (xml_root, logger)
+        read_orcid_configuration(xml_root)
+        read_datacite_configuration(xml_root)
+        read_handle_configuration(xml_root)
+        read_email_configuration(server, xml_root, logger)
+        read_saml_configuration(xml_root, logger)
+        read_sram_configuration(xml_root)
+        read_automatic_login_configuration(xml_root)
+        read_privilege_configuration(xml_root, logger)
+        read_storage_configuration(xml_root, logger)
+        read_quotas_configuration(xml_root)
+        read_colors_configuration(xml_root)
+        read_fonts_configuration(xml_root)
+        read_upload_dataset_configuration(xml_root, logger)
 
-        for include_element in xml_root.iter('include'):
-            include    = include_element.text
+        for include_element in xml_root.iter("include"):
+            include = include_element.text
 
             if include is None:
                 continue
@@ -1042,56 +1134,55 @@ def read_configuration_file (server, config_file, logger, config_files):
             if not os.path.isabs(include):
                 include = os.path.join(config_dir, include)
 
-            read_configuration_file (server, include, logger, config_files)
+            read_configuration_file(server, include, logger, config_files)
 
-        read_menu_configuration (xml_root)
-        read_custom_stylesheets (xml_root)
+        read_menu_configuration(xml_root)
+        read_custom_stylesheets(xml_root)
 
-        custom_assets_root = config_value (xml_root, "custom-assets-root", None, None)
+        custom_assets_root = config_value(xml_root, "custom-assets-root", None, None)
         if custom_assets_root:
-            if not os.path.isabs (custom_assets_root):
-                custom_assets_root = os.path.abspath(os.path.join (config_dir, custom_assets_root))
-            if (server.add_static_root ("/assets", custom_assets_root) and not inside_reload):
-                logger.info ("Added assets root: %s", custom_assets_root)
+            if not os.path.isabs(custom_assets_root):
+                custom_assets_root = os.path.abspath(os.path.join(config_dir, custom_assets_root))
+            if server.add_static_root("/assets", custom_assets_root) and not inside_reload:
+                logger.info("Added assets root: %s", custom_assets_root)
 
         if not inside_reload:
-            warn_about_unresolvable_assets (custom_assets_root, logger)
+            warn_about_unresolvable_assets(custom_assets_root, logger)
 
-        custom_logo_path = config_value (xml_root, "custom-logo-path", None, None)
+        custom_logo_path = config_value(xml_root, "custom-logo-path", None, None)
         if custom_logo_path:
-            if not os.path.isabs (custom_logo_path):
-                custom_logo_path = os.path.abspath(os.path.join (config_dir, custom_logo_path))
-            server.add_static_root ("/static/images/logo.png", custom_logo_path, prepend=True)
+            if not os.path.isabs(custom_logo_path):
+                custom_logo_path = os.path.abspath(os.path.join(config_dir, custom_logo_path))
+            server.add_static_root("/static/images/logo.png", custom_logo_path, prepend=True)
 
-        custom_favicon_path = config_value (xml_root, "custom-favicon-path", None, None)
+        custom_favicon_path = config_value(xml_root, "custom-favicon-path", None, None)
         if custom_favicon_path:
-            if not os.path.isabs (custom_favicon_path):
-                custom_favicon_path = os.path.abspath(os.path.join (config_dir, custom_favicon_path))
-            server.add_static_root ("/static/images/favicon.ico", custom_favicon_path, prepend=True)
+            if not os.path.isabs(custom_favicon_path):
+                custom_favicon_path = os.path.abspath(os.path.join(config_dir, custom_favicon_path))
+            server.add_static_root("/static/images/favicon.ico", custom_favicon_path, prepend=True)
 
         static_pages = xml_root.find("static-pages")
         if not static_pages:
             return config
 
-        resources_root = config_value (static_pages, "resources-root", None, None)
+        resources_root = config_value(static_pages, "resources-root", None, None)
         if not os.path.isabs(resources_root):
             # take resources_root relative to config_dir and turn into absolute path
             resources_root = os.path.abspath(os.path.join(config_dir, resources_root))
-        if (server.add_static_root ("/s", resources_root) and not inside_reload):
-            logger.info ("Added static root: %s", resources_root)
+        if server.add_static_root("/s", resources_root) and not inside_reload:
+            logger.info("Added static root: %s", resources_root)
 
-        read_static_pages (static_pages, server, config_dir)
+        read_static_pages(static_pages, server, config_dir)
 
         return config
 
     except ConfigFileNotFound as error:
         if not inside_reload:
-            logger.error ("%s does not look like a Djehuty configuration file.",
-                           config_file)
+            logger.error("%s does not look like a Djehuty configuration file.", config_file)
         raise SystemExit from error
     except ElementTree.ParseError as error:
         if not inside_reload:
-            logger.error ("%s does not contain valid XML.", config_file)
+            logger.error("%s does not contain valid XML.", config_file)
         raise SystemExit from error
     except json.JSONDecodeError as error:
         if not inside_reload:
@@ -1100,14 +1191,15 @@ def read_configuration_file (server, config_file, logger, config_files):
     except FileNotFoundError as error:
         if not inside_reload:
             if config_file is None:
-                logger.error ("No configuration file specified.")
+                logger.error("No configuration file specified.")
             else:
-                logger.error ("Could not open '%s'.", config_file)
+                logger.error("Could not open '%s'.", config_file)
         raise SystemExit from error
     except UnsupportedSAMLProtocol as error:
         raise SystemExit from error
 
-def extract_transactions (since_datetime, delayed=False):
+
+def extract_transactions(since_datetime, delayed=False):
     """Extract the queries from the audit log and write them as files."""
 
     if config.log_file is None:
@@ -1120,7 +1212,7 @@ def extract_transactions (since_datetime, delayed=False):
             directory_prefix = config.transactions_directory
             os.makedirs(directory_prefix, mode=0o700, exist_ok=True)
             if not os.path.isdir(directory_prefix):
-                print (f"Failed to create '{directory_prefix}'.", file=sys.stderr)
+                print(f"Failed to create '{directory_prefix}'.", file=sys.stderr)
         else:
             directory_prefix = "."
 
@@ -1128,35 +1220,39 @@ def extract_transactions (since_datetime, delayed=False):
         if delayed:
             entry_marker = "Query Audit Log (delayed):\n"
 
-        with open (filename, "r", encoding = "utf-8") as log_file:
-            print (f"Reading '{filename}'.", file=sys.stderr)
-            count        = 0
+        with open(filename, "r", encoding="utf-8") as log_file:
+            print(f"Reading '{filename}'.", file=sys.stderr)
+            count = 0
             state_output = 0
-            query        = ""
+            query = ""
             timestamp_line = ""
             for line in log_file:
                 if state_output == 2:
                     if line == "---\n":
                         state_output = 0
-                        with open (os.path.join (directory_prefix, f"transaction_{count:08d}.sparql"),
-                                   "w", encoding="utf-8") as output_file:
-                            output_file.write (query)
+                        with open(
+                            os.path.join(directory_prefix, f"transaction_{count:08d}.sparql"),
+                            "w",
+                            encoding="utf-8",
+                        ) as output_file:
+                            output_file.write(query)
                         query = ""
                         if count % 10000 == 0:
-                            print (f"\rExtracted {count} items...", end="")
+                            print(f"\rExtracted {count} items...", end="")
                     else:
                         now_statement = "    BIND(NOW() AS ?now)\n"
                         if now_statement == line:
                             try:
                                 components = timestamp_line.split(" ")
-                                date       = components[1]
-                                time       = components[2].partition(",")[0]
-                                replacement = (f'    BIND("{date}T{time}Z"'
-                                               '^^xsd:dateTime AS ?now)\n')
-                                line = line.replace (now_statement, replacement)
+                                date = components[1]
+                                time = components[2].partition(",")[0]
+                                replacement = f'    BIND("{date}T{time}Z"^^xsd:dateTime AS ?now)\n'
+                                line = line.replace(now_statement, replacement)
                             except IndexError:
-                                print (f"\rFailed to read '{timestamp_line}'.",
-                                       file=sys.stderr)
+                                print(
+                                    f"\rFailed to read '{timestamp_line}'.",
+                                    file=sys.stderr,
+                                )
 
                         # Due to a bug (c7204bc), some queries contained the
                         # following line.  It's safe to re-run the query
@@ -1165,7 +1261,7 @@ def extract_transactions (since_datetime, delayed=False):
                             query += line
                 elif state_output == 1 and line == "---\n":
                     state_output = 2
-                elif line.endswith (entry_marker):
+                elif line.endswith(entry_marker):
                     timestamp_line = line
 
                     if since_datetime:
@@ -1177,13 +1273,14 @@ def extract_transactions (since_datetime, delayed=False):
                     query += f"# {line}"
                     count += 1
                     state_output = 1
-            print (f"\rExtracted {count} items", file=sys.stderr)
+            print(f"\rExtracted {count} items", file=sys.stderr)
             return True
     except FileNotFoundError:
-        print (f"Could not open '{filename}'.", file=sys.stderr)
+        print(f"Could not open '{filename}'.", file=sys.stderr)
         return False
 
-def apply_transactions_from_directory (logger, server, transactions_directory):
+
+def apply_transactions_from_directory(logger, server, transactions_directory):
     """Apply extracted transactions from the query audit log."""
 
     # Override with the value from the configuration file.
@@ -1191,10 +1288,13 @@ def apply_transactions_from_directory (logger, server, transactions_directory):
     if config.transactions_directory is not None:
         directory = config.transactions_directory
 
-    print (f"Finding transactions in '{directory}'.")
-    transactions = list(filter(lambda x: (x.startswith("transaction_") and
-                                          x.endswith(".sparql")),
-                               os.listdir(directory)))
+    print(f"Finding transactions in '{directory}'.")
+    transactions = list(
+        filter(
+            lambda x: x.startswith("transaction_") and x.endswith(".sparql"),
+            os.listdir(directory),
+        )
+    )
     transactions = sorted(transactions)
 
     number_of_transactions = len(transactions)
@@ -1205,64 +1305,73 @@ def apply_transactions_from_directory (logger, server, transactions_directory):
     print(f"Applying {number_of_transactions} transactions.")
     try:
         for transaction_file in transactions:
-            filename = os.path.join (directory, transaction_file)
-            applied_filename = os.path.join (directory, f"applied_{transaction_file}")
+            filename = os.path.join(directory, transaction_file)
+            applied_filename = os.path.join(directory, f"applied_{transaction_file}")
             with open(filename, "r", encoding="utf-8") as transaction:
                 query = transaction.read()
-                server.db.sparql.update (query)
+                server.db.sparql.update(query)
                 server.db.sparql.commit()
                 print(f"Applied {transaction.name}.")
-            os.rename (filename, applied_filename)
+            os.rename(filename, applied_filename)
 
-        with open (applied_filename, "r", encoding="utf-8") as transaction:
-            line           = transaction.readline()
+        with open(applied_filename, "r", encoding="utf-8") as transaction:
+            line = transaction.readline()
             last_timestamp = " ".join(line.split(" ")[2:4])
             logger.setLevel(logging.INFO)
-            logger.info ("Applied transactions up until %s.", last_timestamp)
+            logger.info("Applied transactions up until %s.", last_timestamp)
         return True
     except Exception as error:  # pylint: disable=broad-exception-caught
-        print ("Applying transaction failed.", file=sys.stderr)
-        print (f"Exception: {type(error)}: {error}", file=sys.stderr)
+        print("Applying transaction failed.", file=sys.stderr)
+        print(f"Exception: {type(error)}: {error}", file=sys.stderr)
 
     return False
 
-def perform_rdf_export (logger, server, full_export):
+
+def perform_rdf_export(logger, server, full_export):
     """Make an RDF export of of the currently configured SPARQL endpoint."""
 
-    if not server.db.export_rdf (full_export):
-        logger.error ("Unable to create RDF export.")
+    if not server.db.export_rdf(full_export):
+        logger.error("Unable to create RDF export.")
         return False
 
-    logger.info ("Created RDF export in '%s'", config.export_directory)
+    logger.info("Created RDF export in '%s'", config.export_directory)
     return True
+
 
 ## ----------------------------------------------------------------------------
 ## Starting point for the command-line program
 ## ----------------------------------------------------------------------------
 
-def main (config_file=None, run_internal_server=True, initialize=True,
-          extract_transactions_from_log=None,
-          extract_delayed_transactions_from_log=None, apply_transactions=None,
-          full_rdf_export=False, public_rdf_export=False):
+
+def main(
+    config_file=None,
+    run_internal_server=True,
+    initialize=True,
+    extract_transactions_from_log=None,
+    extract_delayed_transactions_from_log=None,
+    apply_transactions=None,
+    full_rdf_export=False,
+    public_rdf_export=False,
+):
     """The main entry point for the 'web' subcommand."""
     try:
-        convenience.add_logging_level ("AUDIT", logging.INFO + 6)
-        convenience.add_logging_level ("ACCESS", logging.INFO + 5)
-        convenience.add_logging_level ("STORE", logging.INFO + 4)
+        convenience.add_logging_level("AUDIT", logging.INFO + 6)
+        convenience.add_logging_level("ACCESS", logging.INFO + 5)
+        convenience.add_logging_level("STORE", logging.INFO + 4)
 
         ## Differentiate the logger name for uWSGI vs built-in.
         logger = None
         if run_internal_server:
-            logger = logging.getLogger (__name__)
+            logger = logging.getLogger(__name__)
         else:
-            logger = logging.getLogger ("uwsgi:djehuty.web.ui")
+            logger = logging.getLogger("uwsgi:djehuty.web.ui")
 
         perform_export = full_rdf_export or public_rdf_export
         since_datetime = None
         ## Be less verbose when only extracting Query Audit Logs or making
         ## RDF exports.
         if extract_transactions_from_log or extract_delayed_transactions_from_log:
-            logger = logging.getLogger (__name__)
+            logger = logging.getLogger(__name__)
             logger.setLevel(logging.ERROR)
 
         if extract_transactions_from_log is not None:
@@ -1272,80 +1381,86 @@ def main (config_file=None, run_internal_server=True, initialize=True,
             since_datetime = extract_delayed_transactions_from_log
 
         if apply_transactions is not None or perform_export:
-            logger = logging.getLogger (__name__)
+            logger = logging.getLogger(__name__)
             logger.setLevel(logging.ERROR)
 
-        server = wsgi.WebServer ()
+        server = wsgi.WebServer()
         config_files = set()
-        read_configuration_file (server, config_file, logger, config_files)
+        read_configuration_file(server, config_file, logger, config_files)
 
         ## Handle extracting Query Audit Logs early on.
         if extract_transactions_from_log is not None:
-            return extract_transactions (since_datetime, delayed=False)
+            return extract_transactions(since_datetime, delayed=False)
         if extract_delayed_transactions_from_log is not None:
-            return extract_transactions (since_datetime, delayed=True)
+            return extract_transactions(since_datetime, delayed=True)
 
-        inside_reload = os.environ.get('WERKZEUG_RUN_MAIN')
+        inside_reload = os.environ.get("WERKZEUG_RUN_MAIN")
 
-        if (isinstance (config.endpoint, str) and
-            config.endpoint.startswith("bdb://") and
-            not berkeleydb.has_bsddb):
-            logger.error(("Configured a BerkeleyDB database back-end, "
-                          "but BerkeleyDB is not installed on the system "
-                          "or the 'berkeleydb' Python package is missing."))
+        if (
+            isinstance(config.endpoint, str)
+            and config.endpoint.startswith("bdb://")
+            and not berkeleydb.has_bsddb
+        ):
+            logger.error(
+                (
+                    "Configured a BerkeleyDB database back-end, "
+                    "but BerkeleyDB is not installed on the system "
+                    "or the 'berkeleydb' Python package is missing."
+                )
+            )
             raise DependencyNotAvailable
 
         if not server.db.cache.cache_is_ready() and not inside_reload:
-            logger.error ("Failed to set up cache layer.")
+            logger.error("Failed to set up cache layer.")
 
         if config.clear_cache_on_start and not inside_reload:
-            logger.info ("Clearing cache.")
-            server.db.cache.invalidate_all ()
+            logger.info("Clearing cache.")
+            server.db.cache.invalidate_all()
 
-        setup_saml_service_provider (server, logger)
+        setup_saml_service_provider(server, logger)
         if config.handle_url is not None and not inside_reload:
-            setup_handle_registration (server, logger)
+            setup_handle_registration(server, logger)
 
         if not config.in_production and not inside_reload:
-            logger.warning ("Assuming to run in a non-production environment.")
-            logger.warning (("Set <production> to 1 in your configuration "
-                             "file for hardened security settings."))
+            logger.warning("Assuming to run in a non-production environment.")
+            logger.warning(
+                ("Set <production> to 1 in your configuration file for hardened security settings.")
+            )
 
-        if config.in_production and not os.path.isdir (config.storage):
-            logger.error ("The storage directory '%s' does not exist.", config.storage)
+        if config.in_production and not os.path.isdir(config.storage):
+            logger.error("The storage directory '%s' does not exist.", config.storage)
             raise FileNotFoundError
 
         if config.profile_images_storage is not None and not inside_reload:
             try:
-                os.makedirs (config.profile_images_storage, mode=0o700, exist_ok=True)
+                os.makedirs(config.profile_images_storage, mode=0o700, exist_ok=True)
             except PermissionError:
-                logger.error ("Cannot create %s directory.",
-                              config.profile_images_storage)
-                config.profile_images_storage = os.path.join (config.storage, "profile-images")
-                logger.error ("Falling back to %s.", config.profile_images_storage)
+                logger.error("Cannot create %s directory.", config.profile_images_storage)
+                config.profile_images_storage = os.path.join(config.storage, "profile-images")
+                logger.error("Falling back to %s.", config.profile_images_storage)
 
         if config.thumbnail_storage is not None and not inside_reload:
             try:
-                os.makedirs (config.thumbnail_storage, mode=0o700, exist_ok=True)
+                os.makedirs(config.thumbnail_storage, mode=0o700, exist_ok=True)
             except PermissionError:
-                logger.error ("Cannot create %s directory.", config.thumbnail_storage)
+                logger.error("Cannot create %s directory.", config.thumbnail_storage)
 
-        if not server.add_static_root ("/thumbnails", config.thumbnail_storage):
-            logger.error ("Failed to setup route for thumbnails.")
+        if not server.add_static_root("/thumbnails", config.thumbnail_storage):
+            logger.error("Failed to setup route for thumbnails.")
 
         if config.iiif_cache_storage is not None and not inside_reload:
             try:
-                os.makedirs (config.iiif_cache_storage, mode=0o700, exist_ok=True)
+                os.makedirs(config.iiif_cache_storage, mode=0o700, exist_ok=True)
             except PermissionError:
-                logger.error ("Cannot create %s directory.", config.iiif_cache_storage)
+                logger.error("Cannot create %s directory.", config.iiif_cache_storage)
 
-        server.db.setup_sparql_endpoint ()
+        server.db.setup_sparql_endpoint()
 
         if apply_transactions is not None:
-            return apply_transactions_from_directory (logger, server, apply_transactions)
+            return apply_transactions_from_directory(logger, server, apply_transactions)
 
         if perform_export:
-            return perform_rdf_export (logger, server, full_rdf_export)
+            return perform_rdf_export(logger, server, full_rdf_export)
 
         config.djehuty_version = importlib.metadata.version("djehuty")
 
@@ -1355,160 +1470,177 @@ def main (config_file=None, run_internal_server=True, initialize=True,
             return server
 
         if inside_reload:
-            logger.info ("Reloaded.")
+            logger.info("Reloaded.")
         else:
             config.startup_timestamp = int(datetime.now().timestamp())
             if not config.menu:
-                logger.warning ("No menu structure provided.")
+                logger.warning("No menu structure provided.")
 
-            if shutil.which ("git") is None:
-                logger.error ("Cannot find the 'git' executable.  Please install it.")
+            if shutil.which("git") is None:
+                logger.error("Cannot find the 'git' executable.  Please install it.")
                 if config.in_production:
                     raise DependencyNotAvailable
 
             if config.orcid_client_id is not None and config.orcid_read_public_token is None:
-                if server.obtain_orcid_read_public_token ():
-                    logger.info ("Obtained read-public token from ORCID.")
+                if server.obtain_orcid_read_public_token():
+                    logger.info("Obtained read-public token from ORCID.")
 
             if config.depositing_domains:
-                logger.info ("Depositing is limited to the domains: %s.", config.depositing_domains)
+                logger.info(
+                    "Depositing is limited to the domains: %s.",
+                    config.depositing_domains,
+                )
 
-            logger.info ("SPARQL endpoint:         %s", config.endpoint)
+            logger.info("SPARQL endpoint:         %s", config.endpoint)
             if config.endpoint != config.update_endpoint:
-                logger.info ("SPARQL update_endpoint:  %s", config.update_endpoint)
-            logger.info ("State graph:             %s", config.state_graph)
-            logger.info ("Migrations graph:        %s", config.migrations_graph)
-            logger.info ("Auto-migrate on boot:    %s", config.auto_migrate_on_boot)
-            logger.info ("Storage path:            %s", config.storage)
+                logger.info("SPARQL update_endpoint:  %s", config.update_endpoint)
+            logger.info("State graph:             %s", config.state_graph)
+            logger.info("Migrations graph:        %s", config.migrations_graph)
+            logger.info("Auto-migrate on boot:    %s", config.auto_migrate_on_boot)
+            logger.info("Storage path:            %s", config.storage)
             if config.storage_locations:
                 for location in config.storage_locations:
-                    logger.info ("Storage path:            %s", location["path"])
-            logger.info ("Secondary storage path:  %s", config.secondary_storage)
-            logger.info ("Cache storage path:      %s", server.db.cache.storage)
-            logger.info ("Static pages loaded:     %s", len(server.static_pages))
+                    logger.info("Storage path:            %s", location["path"])
+            logger.info("Secondary storage path:  %s", config.secondary_storage)
+            logger.info("Cache storage path:      %s", server.db.cache.storage)
+            logger.info("Static pages loaded:     %s", len(server.static_pages))
             if config.handle_url is None:
-                logger.info ("Handle registration is disabled.")
+                logger.info("Handle registration is disabled.")
             else:
-                logger.info ("Handle prefix:           %s", config.handle_prefix)
+                logger.info("Handle prefix:           %s", config.handle_prefix)
 
             if config.enable_iiif:
-                os.makedirs (config.iiif_cache_storage, mode=0o700, exist_ok=True)
+                os.makedirs(config.iiif_cache_storage, mode=0o700, exist_ok=True)
                 if not PYVIPS_DEPENDENCY_LOADED:
-                    logger.error ("Dependency 'pyvips' is required for IIIF.")
+                    logger.error("Dependency 'pyvips' is required for IIIF.")
                     if PYVIPS_ERROR_MESSAGE is not None:
-                        logging.error ("Loading 'pyvips' failed with:\n---\n%s\n---",
-                                       PYVIPS_ERROR_MESSAGE)
+                        logging.error(
+                            "Loading 'pyvips' failed with:\n---\n%s\n---",
+                            PYVIPS_ERROR_MESSAGE,
+                        )
                     raise DependencyNotAvailable
-                logging.getLogger('pyvips').setLevel(logging.ERROR)
+                logging.getLogger("pyvips").setLevel(logging.ERROR)
 
             if config.s3_buckets:
-                os.makedirs (config.s3_cache_storage, mode=0o700, exist_ok=True)
+                os.makedirs(config.s3_cache_storage, mode=0o700, exist_ok=True)
                 if not BOTO3_DEPENDENCY_LOADED:
-                    logger.error ("Dependency 'boto3' is required for S3 buckets.")
+                    logger.error("Dependency 'boto3' is required for S3 buckets.")
                     raise DependencyNotAvailable
 
             if config.identity_provider is not None:
-                logger.info ("Using %s as identity provider.",
-                             config.identity_provider.upper())
+                logger.info("Using %s as identity provider.", config.identity_provider.upper())
             else:
-                logger.error ("Missing identity provider configuration.")
+                logger.error("Missing identity provider configuration.")
                 if config.in_production:
                     raise MissingConfigurationError
 
-            if not server.email.is_properly_configured ():
-                logger.warning ("Sending notification e-mails has been disabled.")
-                logger.warning ("Please configure a mail server to enable it.")
+            if not server.email.is_properly_configured():
+                logger.warning("Sending notification e-mails has been disabled.")
+                logger.warning("Please configure a mail server to enable it.")
                 if config.in_production:
-                    logger.error ("An e-mail server must be configured for production-mode.")
+                    logger.error("An e-mail server must be configured for production-mode.")
                     raise MissingConfigurationError
 
             if config.in_production and not server.db.feedback_reviewer_email_addresses():
-                logger.error ("An account with 'may-process-feedback' privileges must be configured.")
+                logger.error(
+                    "An account with 'may-process-feedback' privileges must be configured."
+                )
                 raise MissingConfigurationError
 
             for email_address in config.privileges:  # pylint: disable=consider-using-dict-items
                 if config.privileges[email_address.lower()]["needs_2fa"]:
-                    logger.info ("Enabled 2FA for %s.", email_address)
+                    logger.info("Enabled 2FA for %s.", email_address)
 
             if initialize:
                 if not server.db.sparql_is_up:
-                    logger.error ("Cannot initialize because the SPARQL endpoint is down.")
+                    logger.error("Cannot initialize because the SPARQL endpoint is down.")
                     return None
 
-                runner = MigrationRunner.from_config (server.db, config)
+                runner = MigrationRunner.from_config(server.db, config)
                 if config.auto_migrate_on_boot:
                     try:
-                        applied = runner.upgrade ()
+                        applied = runner.upgrade()
                     except DriftDetectedError as error:
-                        logger.error ("Migration drift detected: %s", error)
+                        logger.error("Migration drift detected: %s", error)
                         return None
                     if applied:
-                        logger.info ("Invalidating caches ...")
-                        server.db.cache.invalidate_all ()
-                        logger.info ("Applied %d migration(s).", applied)
+                        logger.info("Invalidating caches ...")
+                        server.db.cache.invalidate_all()
+                        logger.info("Applied %d migration(s).", applied)
                     else:
-                        logger.info ("Database already at head; no migration applied.")
-                elif runner.current () != runner.head ():
-                    logger.error (("Database is not at head and auto-migrate-on-boot "
-                                   "is disabled; run `djehuty migrate upgrade`."))
+                        logger.info("Database already at head; no migration applied.")
+                elif runner.current() != runner.head():
+                    logger.error(
+                        (
+                            "Database is not at head and auto-migrate-on-boot "
+                            "is disabled; run `djehuty migrate upgrade`."
+                        )
+                    )
                     return None
-                server.db.initialize_privileged_accounts ()
+                server.db.initialize_privileged_accounts()
                 initialize = False
 
         if not inside_reload:
-            refresh_group_configuration (server, logger, config_files)
+            refresh_group_configuration(server, logger, config_files)
 
             # The 'run_simple' procedure below doesn't allow to catch an
             # address-already-in-use error, so we have to test beforehand to
             # figure out if we need to use the fallback port instead.
             try:
-                bind_test = socket.socket (socket.AF_INET, socket.SOCK_STREAM)
-                bind_test.bind ((config.address, config.port))
+                bind_test = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                bind_test.bind((config.address, config.port))
                 bind_test.close()
             except OSError as error:
                 if config.alternative_port is not None:
-                    logger.info ("Falling back to port %s.", config.alternative_port)
+                    logger.info("Falling back to port %s.", config.alternative_port)
                     config.port = config.alternative_port
                 else:
-                    logger.info ("Unable to bind to port %s: %s.", config.port, error)
+                    logger.info("Unable to bind to port %s: %s.", config.port, error)
 
             if config.static_cache_root is not None:
                 server.create_static_error_pages()
 
-        run_simple (config.address, config.port, server,
-                    threaded=(config.maximum_workers <= 1),
-                    processes=config.maximum_workers,
-                    extra_files=list(config_files),
-                    use_debugger=config.use_debugger,
-                    use_reloader=config.use_reloader)
+        run_simple(
+            config.address,
+            config.port,
+            server,
+            threaded=(config.maximum_workers <= 1),
+            processes=config.maximum_workers,
+            extra_files=list(config_files),
+            use_debugger=config.use_debugger,
+            use_reloader=config.use_reloader,
+        )
 
     except (FileNotFoundError, DependencyNotAvailable, MissingConfigurationError):
         pass
 
     return None
 
+
 ## ----------------------------------------------------------------------------
 ## Starting point for uWSGI
 ## ----------------------------------------------------------------------------
 
-def application (env, start_response):
+
+def application(env, start_response):
     """The main entry point for the WSGI."""
 
-    logging.basicConfig(format='[%(levelname)s] %(asctime)s - %(name)s: %(message)s',
-                        level=logging.INFO)
+    logging.basicConfig(
+        format="[%(levelname)s] %(asctime)s - %(name)s: %(message)s", level=logging.INFO
+    )
 
     ## Suppress start-up info messages.
     logging.getLogger("uwsgi:djehuty.web.ui").setLevel(logging.WARNING)
 
     if not UWSGI_DEPENDENCY_LOADED:
-        start_response('500 Internal Server Error', [('Content-Type','text/html')])
+        start_response("500 Internal Server Error", [("Content-Type", "text/html")])
         return [b"<p>Cannot find the <code>uwsgi</code> Python module.</p>"]
 
-    config_file = os.getenv ("DJEHUTY_CONFIG_FILE")
+    config_file = os.getenv("DJEHUTY_CONFIG_FILE")
 
     if config_file is None:
-        start_response('200 OK', [('Content-Type','text/html')])
+        start_response("200 OK", [("Content-Type", "text/html")])
         return [b"<p>Please set the <code>DJEHUTY_CONFIG_FILE</code> environment variable.</p>"]
 
-    server = main (config_file=config_file, run_internal_server=False)
-    return server (env, start_response)
+    server = main(config_file=config_file, run_internal_server=False)
+    return server(env, start_response)

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -147,6 +147,7 @@ class WebServer:
             R("/browse",                                                         self.ui_redirect_to_home),
             R("/robots.txt",                                                     self.robots_txt),
             R("/theme/colors.css",                                               self.colors_css),
+            R("/theme/fonts.css",                                                self.fonts_css),
             R("/theme/loader.svg",                                               self.loader_svg),
             R("/login",                                                          self.ui_login),
             R("/account/home",                                                   self.ui_account_home),
@@ -890,6 +891,7 @@ class WebServer:
         base_dir = config.static_cache_root
         resources_path = os.path.dirname(__file__)
         stylesheet = self.colors_css (Request({}))
+        fonts_stylesheet = self.fonts_css (Request({}))
         try:
             os.makedirs (base_dir, mode=0o755, exist_ok=True)
             shutil.copytree (os.path.join (resources_path, "resources", "static"),
@@ -899,6 +901,9 @@ class WebServer:
             os.makedirs (os.path.join (base_dir, "theme"), mode=0o755, exist_ok=True)
             with open (os.path.join (base_dir, "theme", "colors.css"), "wb") as stream:
                 stream.write (stylesheet.get_data())
+
+            with open (os.path.join (base_dir, "theme", "fonts.css"), "wb") as stream:
+                stream.write (fonts_stylesheet.get_data())
 
             for page in ["500", "502"]:
                 with open (os.path.join (base_dir, f"{page}.html"), "wb") as stream:
@@ -1769,6 +1774,14 @@ class WebServer:
             privilege_button_color   = config.colors['privilege-button-color'],
             background_color         = config.colors["background-color"],
             sandbox_message_css      = config.sandbox_message_css)
+
+    def fonts_css (self, request):
+        """Implements /theme/fonts.css."""
+
+        if not self.accepts_content_type (request, "text/css", strict=False):
+            return self.error_406 ("text/css")
+
+        return self.__render_css_template ("fonts.css", fonts = config.fonts)
 
     def loader_svg (self, request):
         """Implements /theme/loader.svg."""

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -570,6 +570,7 @@ class WebServer:
         parameters    = {
             "base_url":            config.base_url,
             "nonce":               uuid.uuid4().hex,
+            "custom_stylesheets":  config.custom_stylesheets,
             "identity_provider":   config.identity_provider,
             "in_production":       config.in_production,
             "is_logged_in":        account is not None,

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -39,6 +39,7 @@ from djehuty.utils.constants import (
     member_url_names,
 )
 from djehuty.utils.convenience import (
+    css_string,
     decimal_coords,
     deduplicate_list,
     html_to_plaintext,
@@ -438,6 +439,7 @@ class WebServer:
                 # For static pages.
                 "/"
             ]), autoescape = True)
+        self.jinja.filters["css_string"] = css_string
 
         self.metadata_jinja = Environment(loader = FileSystemLoader([
             os.path.join(resources_path, "resources", "metadata_templates"),

--- a/tests/e2e/tests/test_citation.py
+++ b/tests/e2e/tests/test_citation.py
@@ -149,7 +149,7 @@ class TestExportLinks:
         screenshot(page, "export-section")
 
         expect(page.locator("#export")).to_be_visible()
-        expect(page.locator("#export h3")).to_have_text("Export as...")
+        expect(page.locator("#export h3")).to_have_text("Export as")
 
     @pytest.mark.parametrize("fmt,label", EXPORT_FORMATS)
     def test_export_link_present(self, published_dataset, fmt, label):

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -49,6 +49,16 @@ class TestSmoke:
         screenshot(page, "portal-footer-version")
         expect(page.locator("#footer")).to_contain_text(f"Djehuty v{true_version}")
 
+    def test_theme_fonts_stylesheet_is_available(self, page: Page):
+        """The portal should load the generated per-instance font stylesheet."""
+        response = page.request.get("/theme/fonts.css")
+
+        assert response.status == 200
+        assert response.headers["content-type"].startswith("text/css")
+        assert "@font-face" in response.text()
+
+        page.goto("/portal")
+        expect(page.locator('link[href^="/theme/fonts.css"]')).to_have_count(1)
 
 @pytest.mark.smoke
 class TestPageObjects:

--- a/tests/e2e/tests/test_smoke.py
+++ b/tests/e2e/tests/test_smoke.py
@@ -55,10 +55,10 @@ class TestSmoke:
 
         assert response.status == 200
         assert response.headers["content-type"].startswith("text/css")
-        assert "@font-face" in response.text()
 
         page.goto("/portal")
         expect(page.locator('link[href^="/theme/fonts.css"]')).to_have_count(1)
+
 
 @pytest.mark.smoke
 class TestPageObjects:

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -1,6 +1,7 @@
 """Tests for configuration file parsing."""
 
 import pytest
+from defusedxml import ElementTree
 
 from djehuty.web.config import config
 from djehuty.web.config.json_parser import JsonConfigElement
@@ -40,6 +41,10 @@ class TestConfigValue:
 
     def test_none_root_returns_fallback(self):
         assert config_value(None, "port", fallback="1234") == "1234"
+
+    def test_strips_leading_and_trailing_whitespace(self):
+        root = ElementTree.fromstring("<djehuty><family>\n  Example Sans\n</family></djehuty>")
+        assert config_value(root, "family") == "Example Sans"
 
 
 class TestReadBooleanValue:

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -137,6 +137,7 @@ class TestThemeConfiguration:
         assert config.fonts == {
             "font_faces": [
                 {
+                    "index": 0,
                     "family": "Example Sans",
                     "src": "/assets/fonts/example-regular.woff2",
                     "format": "woff2",
@@ -145,6 +146,7 @@ class TestThemeConfiguration:
                     "display": "swap",
                 },
                 {
+                    "index": 1,
                     "family": "Example Sans",
                     "src": "/assets/fonts/example-bold.woff2",
                     "format": "woff2",

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -4,10 +4,12 @@ import pytest
 
 from djehuty.web.config import config
 from djehuty.web.config.json_parser import JsonConfigElement
-from djehuty.web.ui import config_value, read_boolean_value, read_raw_xml
 from djehuty.web.ui import (
+    config_value,
+    read_boolean_value,
     read_custom_stylesheets,
     read_fonts_configuration,
+    read_raw_xml,
     warn_about_unresolvable_asset,
 )
 

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -2,7 +2,14 @@
 
 import pytest
 
+from djehuty.web.config import config
+from djehuty.web.config.json_parser import JsonConfigElement
 from djehuty.web.ui import config_value, read_boolean_value, read_raw_xml
+from djehuty.web.ui import (
+    read_custom_stylesheets,
+    read_fonts_configuration,
+    warn_about_unresolvable_asset,
+)
 
 
 class TestConfigValue:
@@ -78,6 +85,163 @@ class TestReadRawXml:
         content, attributes = read_raw_xml(config_root, "nonexistent", "fallback")
         assert content == "fallback"
         assert attributes is None
+
+
+class TestThemeConfiguration:
+    def test_missing_fonts_leave_fonts_unconfigured(self, monkeypatch):
+        """Leave fonts unconfigured when the section is absent."""
+        monkeypatch.setattr(config, "fonts", None)
+        root = JsonConfigElement("djehuty", {})
+
+        read_fonts_configuration(root)
+
+        assert config.fonts is None
+
+    def test_reads_font_faces_and_font_families(self, monkeypatch):
+        """Read font faces, families, and default properties."""
+        monkeypatch.setattr(config, "fonts", None)
+        root = JsonConfigElement(
+            "djehuty",
+            {
+                "fonts": {
+                    "body-font-family": "'Example Sans', sans-serif",
+                    "ui-font-family": "'Example UI', sans-serif",
+                    "mono-font-family": "'Example Mono', monospace",
+                    "font-face": [
+                        {
+                            "family": "Example Sans",
+                            "src": "/assets/fonts/example-regular.woff2",
+                            "format": "woff2",
+                            "weight": "400",
+                            "style": "normal",
+                        },
+                        {
+                            "family": "Example Sans",
+                            "src": "/assets/fonts/example-bold.woff2",
+                            "weight": "700",
+                        },
+                    ],
+                },
+            },
+        )
+
+        read_fonts_configuration(root)
+
+        assert config.fonts == {
+            "font_faces": [
+                {
+                    "family": "Example Sans",
+                    "src": "/assets/fonts/example-regular.woff2",
+                    "format": "woff2",
+                    "weight": "400",
+                    "style": "normal",
+                    "display": "swap",
+                },
+                {
+                    "family": "Example Sans",
+                    "src": "/assets/fonts/example-bold.woff2",
+                    "format": "woff2",
+                    "weight": "700",
+                    "style": None,
+                    "display": "swap",
+                },
+            ],
+            "body_font": "'Example Sans', sans-serif",
+            "ui_font": "'Example UI', sans-serif",
+            "mono_font": "'Example Mono', monospace",
+        }
+
+    def test_missing_custom_stylesheets_leave_list_empty(self, monkeypatch):
+        """Leave custom stylesheets empty when none are configured."""
+        monkeypatch.setattr(config, "custom_stylesheets", [])
+        root = JsonConfigElement("djehuty", {})
+
+        read_custom_stylesheets(root)
+
+        assert config.custom_stylesheets == []
+
+    def test_reads_unique_trimmed_custom_stylesheets(self, monkeypatch):
+        """Trim stylesheet paths, remove duplicates, and ignore blanks."""
+        monkeypatch.setattr(config, "custom_stylesheets", [])
+        root = JsonConfigElement(
+            "djehuty",
+            {
+                "custom-stylesheet": [
+                    "/assets/css/first.css",
+                    " /assets/css/second.css ",
+                    "/assets/css/first.css",
+                    "   ",
+                ],
+            },
+        )
+
+        read_custom_stylesheets(root)
+
+        assert config.custom_stylesheets == [
+            "/assets/css/first.css",
+            "/assets/css/second.css",
+        ]
+
+
+class TestAssetWarnings:
+    def test_ignores_non_asset_url(self, caplog, logger):
+        """Ignore asset references outside the served asset path."""
+        warn_about_unresolvable_asset(
+            None,
+            "https://example.com/custom.css",
+            "Stylesheet",
+            logger,
+        )
+
+        assert caplog.records == []
+
+    def test_warns_when_assets_root_is_unset(self, caplog, logger):
+        """Warn when an asset path is configured without an assets root."""
+        warn_about_unresolvable_asset(
+            None,
+            "/assets/css/custom.css",
+            "Stylesheet",
+            logger,
+        )
+
+        assert "'custom-assets-root' is unset" in caplog.text
+
+    def test_warns_when_asset_file_is_missing(self, tmp_path, caplog, logger):
+        """Warn when a configured asset file does not exist."""
+        warn_about_unresolvable_asset(
+            str(tmp_path),
+            "/assets/css/missing.css",
+            "Stylesheet",
+            logger,
+        )
+
+        assert "does not exist under" in caplog.text
+
+    def test_does_not_warn_when_asset_file_exists(self, tmp_path, caplog, logger):
+        """Do not warn when a configured asset file exists."""
+        asset = tmp_path / "css" / "custom.css"
+        asset.parent.mkdir()
+        asset.write_text("body {}", encoding="utf-8")
+
+        warn_about_unresolvable_asset(
+            str(tmp_path),
+            "/assets/css/custom.css",
+            "Stylesheet",
+            logger,
+        )
+
+        assert caplog.records == []
+
+    def test_warns_when_asset_source_is_missing(self, tmp_path, caplog, logger):
+        """Warn when a configured asset has no source."""
+        warn_about_unresolvable_asset(
+            str(tmp_path),
+            None,
+            "Font 'Example Sans'",
+            logger,
+        )
+
+        assert "has no source configured" in caplog.text
 
 
 class TestElementAttributes:

--- a/tests/unit/test_config_parser.py
+++ b/tests/unit/test_config_parser.py
@@ -90,16 +90,16 @@ class TestReadRawXml:
 
 
 class TestThemeConfiguration:
-    def test_missing_fonts_leave_fonts_unconfigured(self, monkeypatch):
+    def test_missing_fonts_leave_fonts_unconfigured(self, monkeypatch, logger):
         """Leave fonts unconfigured when the section is absent."""
         monkeypatch.setattr(config, "fonts", None)
         root = JsonConfigElement("djehuty", {})
 
-        read_fonts_configuration(root)
+        read_fonts_configuration(root, logger)
 
         assert config.fonts is None
 
-    def test_reads_font_faces_and_font_families(self, monkeypatch):
+    def test_reads_font_faces_and_font_families(self, monkeypatch, logger):
         """Read font faces, families, and default properties."""
         monkeypatch.setattr(config, "fonts", None)
         root = JsonConfigElement(
@@ -127,7 +127,7 @@ class TestThemeConfiguration:
             },
         )
 
-        read_fonts_configuration(root)
+        read_fonts_configuration(root, logger)
 
         assert config.fonts == {
             "font_faces": [
@@ -152,6 +152,37 @@ class TestThemeConfiguration:
             "ui_font": "'Example UI', sans-serif",
             "mono_font": "'Example Mono', monospace",
         }
+
+    def test_drops_font_faces_missing_family_or_src(self, monkeypatch, caplog, logger):
+        """Drop font-face entries missing a required 'family' or 'src', with a warning."""
+        monkeypatch.setattr(config, "fonts", None)
+        root = JsonConfigElement(
+            "djehuty",
+            {
+                "fonts": {
+                    "font-face": [
+                        {
+                            "family": "Example Sans",
+                            "src": "/assets/fonts/example-regular.woff2",
+                        },
+                        {
+                            "src": "/assets/fonts/missing-family.woff2",
+                        },
+                        {
+                            "family": "Missing Src",
+                        },
+                    ],
+                },
+            },
+        )
+
+        with caplog.at_level("WARNING"):
+            read_fonts_configuration(root, logger)
+
+        assert len(config.fonts["font_faces"]) == 1
+        assert config.fonts["font_faces"][0]["family"] == "Example Sans"
+        assert "font-face #1" in caplog.text
+        assert "font-face #2" in caplog.text
 
     def test_missing_custom_stylesheets_leave_list_empty(self, monkeypatch):
         """Leave custom stylesheets empty when none are configured."""
@@ -201,6 +232,17 @@ class TestAssetWarnings:
         """Warn when an asset path is configured without an assets root."""
         warn_about_unresolvable_asset(
             None,
+            "/assets/css/custom.css",
+            "Stylesheet",
+            logger,
+        )
+
+        assert "'custom-assets-root' is unset" in caplog.text
+
+    def test_warns_when_assets_root_is_empty_string(self, caplog, logger):
+        """Warn when an asset path is configured with an empty (not unset) assets root."""
+        warn_about_unresolvable_asset(
+            "",
             "/assets/css/custom.css",
             "Stylesheet",
             logger,

--- a/tests/unit/test_convenience.py
+++ b/tests/unit/test_convenience.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from djehuty.utils.convenience import strip_parenthesized_suffix
+from djehuty.utils.convenience import css_string, strip_parenthesized_suffix
 
 
 class TestStripParenthesizedSuffix:
@@ -28,3 +28,16 @@ class TestStripParenthesizedSuffix:
     @pytest.mark.parametrize("value", [None, 42])
     def test_non_string_values_pass_through(self, value):
         assert strip_parenthesized_suffix(value) is value
+
+
+class TestCssString:
+    """CSS-string escaping for values interpolated into single-quoted CSS strings."""
+
+    def test_escapes_backslashes_and_quotes(self):
+        assert css_string("O'Brien & Sons") == "O\\'Brien & Sons"
+        assert css_string("C:\\fonts") == "C:\\\\fonts"
+
+    def test_escapes_newlines(self):
+        assert css_string("Example\nSans") == "Example\\A Sans"
+        assert css_string("Example\r\nSans") == "Example\\A Sans"
+        assert css_string("Example\rSans") == "Example\\A Sans"

--- a/tests/unit/test_json_clean_schema.py
+++ b/tests/unit/test_json_clean_schema.py
@@ -50,6 +50,64 @@ class TestCleanSchema:
         assert group.attrib["is_featured"] == "1"
 
 
+class TestFindAll:
+    def test_returns_all_repeated_children(self):
+        """Return every child stored under a repeated key."""
+        elem = JsonConfigElement(
+            "fonts",
+            {
+                "font-face": [
+                    {"family": "First"},
+                    {"family": "Second"},
+                ],
+            },
+        )
+
+        faces = elem.findall("font-face")
+
+        assert [face.find("family").text for face in faces] == ["First", "Second"]
+
+    def test_returns_all_repeated_custom_stylesheets(self):
+        """Return repeated custom stylesheet values."""
+        elem = JsonConfigElement(
+            "djehuty",
+            {
+                "custom-stylesheet": [
+                    "/assets/css/base.css",
+                    "/assets/css/overrides.css",
+                ],
+            },
+        )
+
+        stylesheets = elem.findall("custom-stylesheet")
+
+        assert [stylesheet.text for stylesheet in stylesheets] == [
+            "/assets/css/base.css",
+            "/assets/css/overrides.css",
+        ]
+
+    def test_accepts_relative_path_prefix(self):
+        """Accept ElementTree-style relative path prefixes."""
+        elem = JsonConfigElement("fonts", {"font-face": [{"family": "First"}]})
+
+        assert len(elem.findall("./font-face")) == 1
+
+    def test_returns_scalar_as_single_result(self):
+        """Return a scalar value as a single matching element."""
+        elem = JsonConfigElement("fonts", {"body-font-family": "sans-serif"})
+
+        matches = elem.findall("body-font-family")
+
+        assert len(matches) == 1
+        assert matches[0].text == "sans-serif"
+
+    def test_returns_empty_list_for_missing_path(self):
+        """Return no matches for a missing path."""
+        elem = JsonConfigElement("fonts", {})
+
+        assert elem.findall("font-face") == []
+
+
 class TestBackCompat:
     def test_at_prefix_still_recognised(self):
         elem = JsonConfigElement("account", {"@orcid": "0000-0001"})

--- a/tests/unit/test_theme_css.py
+++ b/tests/unit/test_theme_css.py
@@ -1,0 +1,82 @@
+"""Tests for rendered theme CSS templates."""
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader
+
+TEMPLATES_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "djehuty"
+    / "web"
+    / "resources"
+    / "html_templates"
+)
+
+
+def render_fonts_css(fonts):
+    environment = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
+    template = environment.get_template("fonts.css")
+
+    return template.render(fonts=fonts)
+
+
+class TestFontsCss:
+    def test_renders_font_faces_and_variables(self):
+        """Render font faces and configured font-family variables."""
+        fonts = {
+            "font_faces": [
+                {
+                    "family": "Example Sans",
+                    "src": "/assets/fonts/example-sans.woff2",
+                    "format": "woff2",
+                    "weight": "400 700",
+                    "style": "normal",
+                    "display": "swap",
+                },
+            ],
+            "body_font": "'Example Sans', sans-serif",
+            "ui_font": "'Example Sans', sans-serif",
+            "mono_font": "'Example Mono', monospace",
+        }
+
+        css = render_fonts_css(fonts)
+
+        assert "font-family: 'Example Sans';" in css
+        assert "src: url('/assets/fonts/example-sans.woff2') format('woff2');" in css
+        assert "font-weight: 400 700;" in css
+        assert "font-style: normal;" in css
+        assert "font-display: swap;" in css
+        assert "--font-body: 'Example Sans', sans-serif;" in css
+        assert "--font-ui: 'Example Sans', sans-serif;" in css
+        assert "--font-mono: 'Example Mono', monospace;" in css
+
+    def test_omits_unspecified_optional_font_properties(self):
+        """Omit optional CSS declarations when their values are absent."""
+        fonts = {
+            "font_faces": [
+                {
+                    "family": "Example Sans",
+                    "src": "/assets/fonts/example-sans.woff2",
+                    "format": "woff2",
+                    "weight": None,
+                    "style": None,
+                    "display": None,
+                },
+            ],
+            "body_font": None,
+            "ui_font": None,
+            "mono_font": None,
+        }
+
+        css = render_fonts_css(fonts)
+
+        assert "font-family: 'Example Sans';" in css
+        assert "font-weight:" not in css
+        assert "font-style:" not in css
+        assert "font-display:" not in css
+        assert "--font-" not in css
+
+    def test_renders_empty_stylesheet_without_font_configuration(self):
+        """Render no CSS when fonts are not configured."""
+        assert render_fonts_css(None).strip() == ""

--- a/tests/unit/test_theme_css.py
+++ b/tests/unit/test_theme_css.py
@@ -5,12 +5,7 @@ from pathlib import Path
 from jinja2 import Environment, FileSystemLoader
 
 TEMPLATES_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "src"
-    / "djehuty"
-    / "web"
-    / "resources"
-    / "html_templates"
+    Path(__file__).resolve().parents[2] / "src" / "djehuty" / "web" / "resources" / "html_templates"
 )
 
 

--- a/tests/unit/test_theme_css.py
+++ b/tests/unit/test_theme_css.py
@@ -92,7 +92,7 @@ class TestFontsCss:
                     "display": None,
                 },
             ],
-            "body_font": "'O'Brien & Sons', sans-serif",
+            "body_font": '"O\'Brien & Sons", sans-serif',
             "ui_font": None,
             "mono_font": None,
         }
@@ -100,6 +100,6 @@ class TestFontsCss:
         css = render_fonts_css(fonts)
 
         assert "font-family: 'O\\'Brien & Sons';" in css
-        assert "--font-body: 'O'Brien & Sons', sans-serif;" in css
+        assert '--font-body: "O\'Brien & Sons", sans-serif;' in css
         assert "&amp;" not in css
         assert "&#39;" not in css and "&#x27;" not in css

--- a/tests/unit/test_theme_css.py
+++ b/tests/unit/test_theme_css.py
@@ -4,13 +4,16 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from djehuty.utils.convenience import css_string
+
 TEMPLATES_DIR = (
     Path(__file__).resolve().parents[2] / "src" / "djehuty" / "web" / "resources" / "html_templates"
 )
 
 
 def render_fonts_css(fonts):
-    environment = Environment(loader=FileSystemLoader(TEMPLATES_DIR))
+    environment = Environment(loader=FileSystemLoader(TEMPLATES_DIR), autoescape=True)
+    environment.filters["css_string"] = css_string
     template = environment.get_template("fonts.css")
 
     return template.render(fonts=fonts)

--- a/tests/unit/test_theme_css.py
+++ b/tests/unit/test_theme_css.py
@@ -78,3 +78,28 @@ class TestFontsCss:
     def test_renders_empty_stylesheet_without_font_configuration(self):
         """Render no CSS when fonts are not configured."""
         assert render_fonts_css(None).strip() == ""
+
+    def test_does_not_html_escape_font_values(self):
+        """Do not HTML-escape font values, since the output is CSS, not HTML."""
+        fonts = {
+            "font_faces": [
+                {
+                    "family": "O'Brien & Sons",
+                    "src": "/assets/fonts/obrien.woff2",
+                    "format": "woff2",
+                    "weight": None,
+                    "style": None,
+                    "display": None,
+                },
+            ],
+            "body_font": "'O'Brien & Sons', sans-serif",
+            "ui_font": None,
+            "mono_font": None,
+        }
+
+        css = render_fonts_css(fonts)
+
+        assert "font-family: 'O\\'Brien & Sons';" in css
+        assert "--font-body: 'O'Brien & Sons', sans-serif;" in css
+        assert "&amp;" not in css
+        assert "&#39;" not in css and "&#x27;" not in css


### PR DESCRIPTION
**Summary**

Add support for loading custom fonts, CSS stylesheets and static
assets from Djehuty's JSON configuration.

**Changes**

- `src/djehuty/web/config/json_parser.py`: Support repeated JSON definitions
   through `findall`.
- `src/djehuty/web/config/runtime.py`: Store custom font and stylesheet
  configuration at runtime.
- `src/djehuty/web/ui.py`: Read font and stylesheet configuration and validate
  configured asset paths.
- `src/djehuty/web/wsgi.py`: Serve generated font CSS and configured theme
  assets.
- `src/djehuty/web/resources/html_templates/fonts.css`: Generate font-face
  declarations and typography variables.
- `src/djehuty/web/resources/html_templates/layout.html`: Load generated font
  CSS and instance-specific stylesheets.
- `src/djehuty/web/resources/static/css/main.css`: Apply configurable
  typography variables.
- `etc/djehuty/djehuty-dev-config.json`: Add empty custom-style
    configuration fields.
- `etc/djehuty/djehuty-example-config.json`: Add empty custom-style
  configuration fields.
- `etc/djehuty/djehuty-example-config.xml`: Add empty custom-style
  configuration fields and a font-face definition.
- `tests/unit/`: Test JSON parsing, theme configuration, asset validation and
  generated CSS.
- `tests/e2e/tests/test_smoke.py`: Test that the generated font CSS is served and
  linked from portal pages.


**Approval Checklist**

- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #237 

**Screenshots (optional)**

**Notes (optional)**

I changed `read_custom_stylesheets` to ignore blank custom stylesheet entries in the config. See 404fd8e871f97797ba432554efc7e294513eef4d.  I changed `read_custom_stylesheets` to ignore blank custom stylesheet entries and added a warning for configured assets without a source (f799fd96a90ff2d494be929023388af3b2d13986). All other code from @gabrielakuhn remains unchanged. 

All example configs have fields defined to demonstrate usage. The `djehuty-dev-config.json` also has fields for consistency. 