### PR TITLE
fix: Consistent cite button label

### DIFF
--- a/src/djehuty/web/resources/static/js/utils.js
+++ b/src/djehuty/web/resources/static/js/utils.js
@@ -256,7 +256,7 @@ function autocomplete_funding (event, item_id) {
 function toggle_cite_collect (event, action) {
     stop_event_propagation (event);
     let other = (action === "collect") ? "cite" : "collect";
-    let label = (action === "collect") ? "Collect" : "Citation";
+    let label = (action === "collect") ? "Collect" : "Cite";
     let item = jQuery(`#${action}`);
     let other_item = jQuery(`#${other}`);
     if (item.is(":visible")) {

--- a/tests/e2e/tests/test_citation.py
+++ b/tests/e2e/tests/test_citation.py
@@ -130,6 +130,25 @@ class TestCiteDialog:
         expect(page.locator("#cite")).to_be_hidden()
         screenshot(page, "cite-closed")
 
+    def test_cite_button_label_stays_cite(self, published_dataset, screenshot):
+        """The Cite button label should stay "Cite" regardless if open or closed."""
+        page, container_uuid = published_dataset
+        page.goto(f"/datasets/{container_uuid}")
+        page.wait_for_load_state("domcontentloaded")
+
+        # Closed
+        cite_button = page.locator("#cite-btn")
+        expect(cite_button).to_have_text("Cite")
+        cite_button.click()
+
+        # Open
+        expect(cite_button).to_have_text("Cite")
+
+        # Closed again
+        cite_button.click()
+        expect(cite_button).to_have_text("Cite")
+        screenshot(page, "cite-label-stays")
+
 
 # ---------------------------------------------------------------------------
 # Export link tests


### PR DESCRIPTION
**Summary**

Keep the "Cite" button as is when opening/closing the citation tab. Previously, text would change to "Citation" but would never revert. After a short discussion, we decided that the text change is unnecessary. 

**Changes**
- src/djehuty/web/resources/static/js/utils.js: `toggle_cite_collect` no longer swaps the cite button's text to "Citation" when opening the panel.
- tests/e2e/tests/test_citation.py: add `test_cite_button_label_stays_cite` asserting the button text stays "Cite" across closed, opened, and re-closed.

**Approval Checklist**

- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #213 

**Screenshots (optional)**
<img width="1182" height="301" alt="image" src="https://github.com/user-attachments/assets/e1680378-9b5f-464a-ad96-0b709805782c" />
<img width="1316" height="294" alt="image" src="https://github.com/user-attachments/assets/dbef88e8-4dc1-438b-902c-ff2c9d1b26f3" />

**Notes (optional)**

Additional context, caveats, or follow-up tasks.