### PR TITLE
fix: Fix duplicate "collect" UI on dataset pages

### DIFF
--- a/src/djehuty/web/formatter.py
+++ b/src/djehuty/web/formatter.py
@@ -570,6 +570,7 @@ def format_collection_record (record):
         "id":                conv.value_or_none(record, "collection_id"),
         "uuid":              conv.value_or_none(record, "container_uuid"),
         "title":             conv.value_or_none(record, "title"),
+        "version":           conv.value_or_none(record, "version"),
         "doi":               conv.value_or_none(record, "doi"),
         "handle":            conv.value_or(record, "handle", ""),
         "url":               conv.value_or_none(urls, "url"),

--- a/src/djehuty/web/resources/html_templates/public_metadata.html
+++ b/src/djehuty/web/resources/html_templates/public_metadata.html
@@ -36,6 +36,9 @@
   {%- if my_collections %}
     <div id="collect">
         <h3>Add to collection</h3>
+        <ul id="collect-published"></ul>
+        <div id="collect-separator">Drafts</div>
+        <ul id="collect-drafts"></ul>
     </div>
   {%- endif %}
 {%- endif %}

--- a/src/djehuty/web/resources/static/css/pub.css
+++ b/src/djehuty/web/resources/static/css/pub.css
@@ -59,6 +59,20 @@
 #download-all-files-message { display: none; border-radius: .5em; margin-top: 1em; }
 #download-all-files-message p { padding: 1em; color: #fff; }
 #collect h3, #cite h3 { margin-top: 0em; font-size: 1.25em !important; font-weight: bold; }
+#wrapper #content #collect ul { display: flex; flex-direction: column; align-items: flex-start; gap: .5em; }
+#wrapper #content #collect ul.many { flex-direction: row; flex-wrap: wrap; align-items: normal; }
+#wrapper #content #collect ul li { margin: 0em; }
+#wrapper #content #collect ul li a {
+    display: inline-block;
+    padding: .15em .5em;
+    border-radius: 1em;
+    border: 1px solid #ccc;
+    background: #f5f5f5;
+    font-size: 10pt;
+}
+#wrapper #content #collect ul li a:hover { background: #e5e5e5; }
+#collect-separator { margin: 1em 0em .5em 0em; font-weight: bold; color: #999; border-top: 1px solid #ccc; padding-top: .5em; }
+#collect-drafts li a { color: #999; }
 #cite-btn.close, #collect-btn.close { border-radius: .5em .5em 0em 0em !important; }
 #cite-btn.secondary, #collect-btn.secondary { background: none !important; color: #000; font-weight: normal; text-decoration: underline; border-radius: .5em .5em 0em 0em; }
 #versions-btn.old-version-style { background: #ff0 !important; }

--- a/src/djehuty/web/resources/static/css/pub.css
+++ b/src/djehuty/web/resources/static/css/pub.css
@@ -65,7 +65,7 @@
 #wrapper #content #collect ul li a {
     display: inline-block;
     padding: .15em .5em;
-    border-radius: 1em;
+    border-radius: 0.5em;
     border: 1px solid #ccc;
     background: #f5f5f5;
     font-size: 10pt;

--- a/src/djehuty/web/resources/static/js/landing_page.js
+++ b/src/djehuty/web/resources/static/js/landing_page.js
@@ -12,6 +12,16 @@ function add_dataset_to_collection (dataset_id, collection_id) {
     });
 }
 
+function append_collect_item (list_selector, collection, label) {
+    let item = jQuery("<a/>", { "href": "#", "class": "corporate-identity" })
+        .text(label)
+        .on("click", function (event) {
+            add_dataset_to_collection (dataset_uuid, collection.uuid);
+            stop_event_propagation (event);
+        });
+    jQuery("<li/>").append(item).appendTo(list_selector);
+}
+
 function toggle_access_request (event) {
     stop_event_propagation (event);
     let access_request_div = jQuery("#access-request-wrapper");
@@ -96,17 +106,36 @@ function render_draft_collections () {
         accept:      "application/json",
         dataType:    "json"
     }).done(function (records) {
-        jQuery("#collect ul").remove();
-        jQuery("#collect").append("<ul></ul>");
+        let published_by_uuid = {};
+        let drafts = [];
+
         for (let collection of records) {
-            let item = jQuery("<a/>", { "href": "#", "class": "corporate-identity" })
-                .text(collection.title)
-                .on("click", function (event) {
-                    add_dataset_to_collection (dataset_uuid, collection.uuid);
-                    stop_event_propagation (event);
-                });
-            jQuery("#collect ul").append(item);
+            if (collection.version == null) {
+                drafts.push(collection);
+                continue;
+            }
+            let existing = published_by_uuid[collection.uuid];
+            if (existing === undefined || collection.version > existing.version) {
+                published_by_uuid[collection.uuid] = collection;
+            }
         }
+        let published = Object.values(published_by_uuid);
+        published.sort((a, b) => a.title.localeCompare(b.title));
+        drafts.sort((a, b) => a.title.localeCompare(b.title));
+
+        jQuery("#collect-published").empty();
+        jQuery("#collect-drafts").empty();
+        jQuery("#collect-published").toggleClass("many", published.length > 10);
+        jQuery("#collect-drafts").toggleClass("many", drafts.length > 10);
+
+        for (let collection of published) {
+            append_collect_item ("#collect-published", collection, `${collection.title} (v${collection.version})`);
+        }
+        for (let collection of drafts) {
+            append_collect_item ("#collect-drafts", collection, `${collection.title}`);
+        }
+
+        jQuery("#collect-separator").toggle(drafts.length > 0);
     }).fail(function (jqXHR, textStatus, errorThrown) {
         if (jqXHR.status == 403) {
             show_message ("failure", "<p>No permission to list collections.</p>");

--- a/tests/e2e/tests/test_collections.py
+++ b/tests/e2e/tests/test_collections.py
@@ -752,23 +752,17 @@ class TestCollectButton:
         title = f"Collect Versioned {marker}"
         container_uuid = _create_titled_draft_collection(authenticated_page, title)
 
-        fill_required_fields_and_publish_collection(
-            authenticated_page, container_uuid, title=title
-        )
+        fill_required_fields_and_publish_collection(authenticated_page, container_uuid, title=title)
         authenticated_page.goto(f"/my/collections/{container_uuid}/new-version-draft")
         authenticated_page.wait_for_url("**/my/collections/*/edit")
-        fill_required_fields_and_publish_collection(
-            authenticated_page, container_uuid, title=title
-        )
+        fill_required_fields_and_publish_collection(authenticated_page, container_uuid, title=title)
 
         try:
             authenticated_page.goto(f"/datasets/{published_dataset}")
             authenticated_page.wait_for_load_state("domcontentloaded")
             authenticated_page.locator("#collect-btn").click()
 
-            entries = authenticated_page.locator("#collect-published li a").filter(
-                has_text=title
-            )
+            entries = authenticated_page.locator("#collect-published li a").filter(has_text=title)
             expect(entries.first).to_be_visible()
             screenshot(authenticated_page, "collect-menu-deduped-versions")
 

--- a/tests/e2e/tests/test_collections.py
+++ b/tests/e2e/tests/test_collections.py
@@ -1,16 +1,5 @@
 """
 Collection management tests.
-
-Covers:
-    - Create a new collection through UI
-    - View collection detail page
-    - Edit collection metadata
-    - Add/remove datasets from collection
-    - Delete collection
-    - Collection publish workflow
-
-Run with:
-    cd tests/e2e && python -m pytest tests/test_collections.py -v
 """
 
 import re
@@ -749,6 +738,110 @@ class TestCollectButton:
                     "collection. Under #218 every entry added the dataset to "
                     "whichever collection happened to be listed last."
                 )
+        finally:
+            for container_uuid in collections.values():
+                authenticated_page.request.delete(f"/v2/account/collections/{container_uuid}")
+
+    def test_collect_menu_dedupes_versions_to_latest(
+        self, authenticated_page: Page, published_dataset, screenshot
+    ):
+        """A collection with multiple published versions should appear once in
+        the collection menu, labelled with its latest version.
+        """
+        marker = uuid.uuid4().hex[:8]
+        title = f"Collect Versioned {marker}"
+        container_uuid = _create_titled_draft_collection(authenticated_page, title)
+
+        fill_required_fields_and_publish_collection(
+            authenticated_page, container_uuid, title=title
+        )
+        authenticated_page.goto(f"/my/collections/{container_uuid}/new-version-draft")
+        authenticated_page.wait_for_url("**/my/collections/*/edit")
+        fill_required_fields_and_publish_collection(
+            authenticated_page, container_uuid, title=title
+        )
+
+        try:
+            authenticated_page.goto(f"/datasets/{published_dataset}")
+            authenticated_page.wait_for_load_state("domcontentloaded")
+            authenticated_page.locator("#collect-btn").click()
+
+            entries = authenticated_page.locator("#collect-published li a").filter(
+                has_text=title
+            )
+            expect(entries.first).to_be_visible()
+            screenshot(authenticated_page, "collect-menu-deduped-versions")
+
+            assert entries.count() == 1, (
+                f"Expected exactly one entry for {title!r} across both published "
+                f"versions, got {entries.count()}: {entries.all_inner_texts()}"
+            )
+            assert "(v2)" in entries.first.inner_text(), (
+                f"Expected the deduped entry to show the latest version, got "
+                f"{entries.first.inner_text()!r}"
+            )
+        finally:
+            authenticated_page.request.delete(f"/v2/account/collections/{container_uuid}")
+
+    def test_collect_menu_separates_published_and_draft_collections(
+        self, authenticated_page: Page, published_dataset, screenshot
+    ):
+        """Draft and published collections should render in separate lists, with
+        only published entries carrying a version label.
+        """
+        marker = uuid.uuid4().hex[:8]
+        draft_title = f"Collect Draft {marker}"
+        published_title = f"Collect Published {marker}"
+
+        draft_uuid = _create_titled_draft_collection(authenticated_page, draft_title)
+        published_uuid = _create_titled_draft_collection(authenticated_page, published_title)
+        fill_required_fields_and_publish_collection(
+            authenticated_page, published_uuid, title=published_title
+        )
+
+        try:
+            authenticated_page.goto(f"/datasets/{published_dataset}")
+            authenticated_page.wait_for_load_state("domcontentloaded")
+            authenticated_page.locator("#collect-btn").click()
+            screenshot(authenticated_page, "collect-menu-draft-vs-published")
+
+            draft_entry = authenticated_page.locator("#collect-drafts li a").filter(
+                has_text=draft_title
+            )
+            published_entry = authenticated_page.locator("#collect-published li a").filter(
+                has_text=published_title
+            )
+
+            expect(draft_entry).to_be_visible()
+            expect(published_entry).to_be_visible()
+            assert "(v" not in draft_entry.inner_text()
+            assert "(v1)" in published_entry.inner_text()
+            expect(authenticated_page.locator("#collect-separator")).to_be_visible()
+        finally:
+            authenticated_page.request.delete(f"/v2/account/collections/{draft_uuid}")
+            authenticated_page.request.delete(f"/v2/account/collections/{published_uuid}")
+
+    def test_collect_menu_lists_alphabetically(
+        self, authenticated_page: Page, published_dataset, screenshot
+    ):
+        """Entries within each collection menu section should be sorted
+        alphabetically by title.
+        """
+        marker = uuid.uuid4().hex[:8]
+        titles = [f"Zebra {marker}", f"Alpha {marker}", f"Mike {marker}"]
+        collections = {t: _create_titled_draft_collection(authenticated_page, t) for t in titles}
+
+        try:
+            authenticated_page.goto(f"/datasets/{published_dataset}")
+            authenticated_page.wait_for_load_state("domcontentloaded")
+            authenticated_page.locator("#collect-btn").click()
+
+            entries = authenticated_page.locator("#collect-drafts li a")
+            expect(entries.first).to_be_visible()
+            screenshot(authenticated_page, "collect-menu-alphabetical")
+
+            texts = [t for t in entries.all_inner_texts() if marker in t]
+            assert texts == sorted(texts), f"Expected alphabetical order, got {texts}"
         finally:
             for container_uuid in collections.values():
                 authenticated_page.request.delete(f"/v2/account/collections/{container_uuid}")

--- a/tests/unit/test_formatter.py
+++ b/tests/unit/test_formatter.py
@@ -1,0 +1,91 @@
+"""Unit tests for djehuty.web.formatter."""
+
+from djehuty.web.formatter import format_collection_record
+
+
+class TestFormatCollectionRecord:
+    """format_collection_record must surface the `version` field so the
+    frontend can distinguish published versions from unversioned drafts.
+    """
+
+    def test_includes_version_when_present(self):
+        record = {
+            "collection_id": 1,
+            "container_uuid": "abc-123",
+            "title": "A collection",
+            "version": 3,
+        }
+        assert format_collection_record(record)["version"] == 3
+
+    def test_version_is_none_for_a_draft(self):
+        record = {
+            "collection_id": 1,
+            "container_uuid": "abc-123",
+            "title": "A draft collection",
+        }
+        assert format_collection_record(record)["version"] is None
+
+    def test_all_fields_are_mapped(self):
+        record = {
+            "collection_id": 1,
+            "container_uuid": "abc-123",
+            "title": "A collection",
+            "version": 2,
+            "doi": "10.1234/abc",
+            "handle": "hdl.handle.net/abc",
+            "url": "https://example.org/collections/abc-123",
+            "timeline_posted": "2024-01-01",
+            "timeline_submission": "2024-01-02",
+            "timeline_revision": "2024-01-03",
+            "timeline_first_online": "2024-01-04",
+            "timeline_publisher_publication": "2024-01-05",
+            "published_date": "2024-01-06",
+        }
+        assert format_collection_record(record) == {
+            "id": 1,
+            "uuid": "abc-123",
+            "title": "A collection",
+            "version": 2,
+            "doi": "10.1234/abc",
+            "handle": "hdl.handle.net/abc",
+            "url": "https://example.org/collections/abc-123",
+            "timeline": {
+                "posted": "2024-01-01",
+                "submission": "2024-01-02",
+                "revision": "2024-01-03",
+                "firstOnline": "2024-01-04",
+                "publisherPublication": "2024-01-05",
+            },
+            "published_date": "2024-01-06",
+        }
+
+    def test_missing_optional_fields_default_correctly(self):
+        record = {
+            "collection_id": 1,
+            "container_uuid": "abc-123",
+            "title": "A collection",
+        }
+        formatted = format_collection_record(record)
+
+        assert formatted["handle"] == ""
+        assert formatted["id"] == 1
+        for key in ("doi", "url", "published_date"):
+            assert formatted[key] is None
+        for key in formatted["timeline"]:
+            assert formatted["timeline"][key] is None
+
+    def test_timeline_fields_are_mapped_individually(self):
+        record = {
+            "collection_id": 1,
+            "container_uuid": "abc-123",
+            "title": "A collection",
+            "timeline_posted": "2024-01-01",
+            "timeline_first_online": "2024-01-04",
+        }
+        timeline = format_collection_record(record)["timeline"]
+
+        assert timeline["posted"] == "2024-01-01"
+        assert timeline["firstOnline"] == "2024-01-04"
+        assert timeline["submission"] is None
+        assert timeline["revision"] is None
+        assert timeline["publisherPublication"] is None


### PR DESCRIPTION
**Summary**

The "collect" menu on the dataset landing page lists every version of a collection as seperate, unlabelled, and visually joined entries. There is no way to tell versions or drafts apart from published collections. 

**Changes**
- `formatter.py`: include `version` in the collection JSON contract.
- `landing_page.js`: dedupe collections client-side to the latest published
  version per collection (grouped by `container_uuid`). Collections with
  `version == null` are assumed to be drafts. Published and draft collections
  now render in two separate lists, each sorted alphabetically, with
  published entries labelled `(vN)`.
- `public_metadata.html` / `pub.css`: render entries as pill-style list
  items, stacked vertically up to 10 per list, then wrapping horizontally
  beyond that (to handle very long collection titles without breaking
  layout at scale). Drafts render grayed out with a labelled separator
  between the two lists. Border radius is set to `0.5em` to match the existing
 roundness of the UI.
- `tests/unit/test_formatter.py`: unit tests for `format_collection_record`, `version` present/absent, full field mapping, and missing-field defaults.
- `tests/e2e/tests/test_collections.py`: regression tests for the collect
  menu.

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [ ] Review approved by at least one maintainer.
- [ ] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #216 

**Screenshots (optional)**
Before:
<img width="1323" height="368" alt="image" src="https://github.com/user-attachments/assets/ccdb6bd4-b1ce-424b-a0e6-922ddf695f3a" />

After: 
<img width="1318" height="612" alt="image" src="https://github.com/user-attachments/assets/67326484-1fda-4c1f-9dc4-ea0e56fb2362" />




**Notes (optional)**

Additional context, caveats, or follow-up tasks.