### PR TITLE
web: authors: Reuse active authors matching email or ORCID.

### DIFF
--- a/etc/djehuty/djehuty-dev-config.json
+++ b/etc/djehuty/djehuty-dev-config.json
@@ -70,6 +70,7 @@
           "first_name": "Dev",
           "last_name": "User",
           "email": "dev@djehuty.com",
+          "orcid": "0000-0000-0000-0001",
           "may-administer": "1",
           "may-run-sparql-queries": "1",
           "may-impersonate": "1",

--- a/src/djehuty/web/database.py
+++ b/src/djehuty/web/database.py
@@ -638,7 +638,7 @@ class SparqlInterface:
     def authors (self, first_name=None, full_name=None, group_id=None,
                  author_id=None, institution_id=None, is_active=None,
                  is_public=None, job_title=None, last_name=None,
-                 orcid_id=None, url_name=None, limit=10, order=None,
+                 orcid_id=None, email=None, url_name=None, limit=10, order=None,
                  order_direction=None, item_uri=None, search_for=None,
                  account_uuid=None, item_type="dataset", is_published=True,
                  author_uuid=None):
@@ -656,6 +656,7 @@ class SparqlInterface:
         filters += rdf.sparql_filter ("last_name",      last_name,  escape=True)
         filters += rdf.sparql_filter ("full_name",      full_name,  escape=True)
         filters += rdf.sparql_filter ("orcid_id",       orcid_id,   escape=True)
+        filters += rdf.sparql_filter ("email",          email,      escape=True)
         filters += rdf.sparql_filter ("url_name",       url_name,   escape=True)
 
         if search_for is not None:
@@ -1563,6 +1564,8 @@ class SparqlInterface:
         last_name  = conv.strip_string (last_name)
         full_name  = conv.strip_string (full_name)
         email      = conv.strip_string (email)
+        if email:
+            email = email.casefold()
 
         rdf.add (graph, author_uri, RDF.type,                   rdf.DJHT["Author"], "uri")
         rdf.add (graph, author_uri, rdf.DJHT["id"],             author_id)

--- a/src/djehuty/web/resources/static/js/edit-dataset.js
+++ b/src/djehuty/web/resources/static/js/edit-dataset.js
@@ -572,8 +572,14 @@ function update_author (author_uuid, dataset_uuid) {
     }).done(function () {
         cancel_edit_author (author_uuid, dataset_uuid);
         render_authors_for_dataset (dataset_uuid);
-    }).fail(function () {
-        show_message ("failure", "<p>Failed to update author details.</p>");
+    }).fail(function (jqXHR) {
+        let message = "Failed to update author details.";
+        if (jqXHR.status === 409 &&
+            jqXHR.responseJSON &&
+            jqXHR.responseJSON.message) {
+            message = jqXHR.responseJSON.message;
+        }
+        show_message ("failure", jQuery("<p/>").text(message));
     });
 }
 

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -47,6 +47,7 @@ from djehuty.utils.convenience import (
     landing_page_url,
     make_citation,
     normalize_doi,
+    normalize_orcid,
     parses_to_int,
     pretty_print_size,
     self_or_value_or_none,
@@ -786,10 +787,33 @@ class WebServer:
             if record["full_name"] is None:
                 record["full_name"] = f"{record['first_name']} {record['last_name']}"
 
+            if record["email"] is not None:
+                record["email"] = record["email"].strip().casefold()
+
+            record["orcid_id"] = normalize_orcid (record["orcid_id"])
+
             if errors:
                 return None, errors
 
-            author_uuid = self.db.insert_author (**record)
+            existing_author = None
+            if record["orcid_id"]:
+                matches = self.db.authors (
+                    orcid_id=record["orcid_id"], is_active=True, order="uuid", limit=1)
+                if matches:
+                    existing_author = matches[0]
+
+            if existing_author is None and record["email"]:
+                matches = self.db.authors (
+                    email=record["email"], is_active=True, order="uuid", limit=1)
+                if matches:
+                    existing_author = matches[0]
+
+            if existing_author is not None:
+                # Reuse the active author without overwriting it with manually entered details.
+                author_uuid = existing_author["uuid"]
+            else:
+                author_uuid = self.db.insert_author (**record)
+
             if author_uuid is None:
                 return None, [{ "field_name": "authors",
                                 "message": "Unable to create author record." }]

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -751,6 +751,26 @@ class WebServer:
 
         return git_repository_url
 
+    def __active_author_matching_identifiers (self, email=None, orcid_id=None, exclude_author_uuid=None):
+        """Returns an active author matching an email address or ORCID."""
+        if email:
+            email = email.strip().casefold()
+        orcid_id = normalize_orcid (orcid_id)
+
+        if orcid_id:
+            matches = self.db.authors (
+                orcid_id=orcid_id, is_active=True, order="uuid", limit=2)
+            if matches and matches[0]["uuid"] != exclude_author_uuid:
+                return matches[0]
+
+        if email:
+            matches = self.db.authors (
+                email=email, is_active=True, order="uuid", limit=2)
+            if matches and matches[0]["uuid"] != exclude_author_uuid:
+                return matches[0]
+
+        return None
+
     def __author_list_from_request_input (self, parameters, created_by=None):
         """Returns a list with author objects and a list of error messages."""
 
@@ -787,26 +807,11 @@ class WebServer:
             if record["full_name"] is None:
                 record["full_name"] = f"{record['first_name']} {record['last_name']}"
 
-            if record["email"] is not None:
-                record["email"] = record["email"].strip().casefold()
-
-            record["orcid_id"] = normalize_orcid (record["orcid_id"])
-
             if errors:
                 return None, errors
 
-            existing_author = None
-            if record["orcid_id"]:
-                matches = self.db.authors (
-                    orcid_id=record["orcid_id"], is_active=True, order="uuid", limit=1)
-                if matches:
-                    existing_author = matches[0]
-
-            if existing_author is None and record["email"]:
-                matches = self.db.authors (
-                    email=record["email"], is_active=True, order="uuid", limit=1)
-                if matches:
-                    existing_author = matches[0]
+            existing_author = self.__active_author_matching_identifiers (
+                email=record["email"], orcid_id=record["orcid_id"])
 
             if existing_author is not None:
                 # Reuse the active author without overwriting it with manually entered details.
@@ -994,10 +999,10 @@ class WebServer:
         response.status_code = 405
         return response
 
-    def error_409 (self):
+    def error_409 (self, message="The resource is already available."):
         """Procedure to respond with HTTP 409."""
-        response = self.response (json.dumps({
-            "message": "The resource is already available."
+        response = self.response(json.dumps({
+            "message": message
         }))
         response.status_code = 409
         return response
@@ -7405,6 +7410,16 @@ class WebServer:
                     "email":      validator.string_value (record, "email", 0, 255),
                     "orcid":      validator.string_value (record, "orcid", 0, 255)
                 }
+
+                existing_author = self.__active_author_matching_identifiers (
+                    email=parameters["email"],
+                    orcid_id=parameters["orcid"],
+                    exclude_author_uuid=author_uuid)
+                if existing_author is not None:
+                    return self.error_409 (
+                        "An active author with this email address or ORCID already exists. "
+                        "Remove this manual author and select the existing author from "
+                        "the autocomplete.")
 
                 if not self.db.update_author (author_uuid, account_uuid, **parameters):
                     return self.error_500 ()

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -5714,7 +5714,7 @@ class WebServer:
                     existing_authors = list(map (lambda item: URIRef(uuid_to_uri(item["uuid"], "author")),
                                                  existing_authors))
 
-                authors = existing_authors + new_authors
+                authors = list(dict.fromkeys(existing_authors + new_authors))
                 if not self.db.update_item_list (item["uuid"], account_uuid,
                                                  authors, "authors"):
                     return self.error_500 ("Adding a single author failed.")

--- a/src/djehuty/web/wsgi.py
+++ b/src/djehuty/web/wsgi.py
@@ -759,13 +759,13 @@ class WebServer:
 
         if orcid_id:
             matches = self.db.authors (
-                orcid_id=orcid_id, is_active=True, order="uuid", limit=2)
+                orcid_id=orcid_id, is_active=True, order="uuid", limit=1)
             if matches and matches[0]["uuid"] != exclude_author_uuid:
                 return matches[0]
 
         if email:
             matches = self.db.authors (
-                email=email, is_active=True, order="uuid", limit=2)
+                email=email, is_active=True, order="uuid", limit=1)
             if matches and matches[0]["uuid"] != exclude_author_uuid:
                 return matches[0]
 

--- a/tests/e2e/tests/api/v2/test_articles.py
+++ b/tests/e2e/tests/api/v2/test_articles.py
@@ -233,6 +233,140 @@ class TestV2ArticleAuthorsApi:
         save_response(response, "api-replace-authors")
         assert response.ok
 
+    def test_manual_author_email_matches_existing_account(self, draft_dataset, save_response):
+        """PUT /v2/account/articles/<uuid>/authors reuses an account author by email."""
+        page, container_uuid = draft_dataset
+        before_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        existing_author = before_response.json()[0]
+        existing_uuid = existing_author["uuid"]
+        existing_email = "  Dev@DJEHUTY.COM  "
+
+        response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Dev",
+                        "last_name": "User",
+                        "email": existing_email,
+                    }
+                ]
+            },
+        )
+        save_response(response, "api-replace-authors-by-email")
+        assert response.ok
+
+        get_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(get_response, "api-replace-authors-by-email-verify")
+        authors = get_response.json()
+        assert len(authors) == 1
+        assert authors[0].get("uuid") == existing_uuid
+        assert authors[0].get("is_active") is True
+
+    def test_manual_author_orcid_matches_existing_account(self, draft_dataset, save_response):
+        """PUT /v2/account/articles/<uuid>/authors reuses an account author by ORCID."""
+        page, container_uuid = draft_dataset
+        before_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        existing_author = before_response.json()[0]
+        existing_uuid = existing_author["uuid"]
+        existing_orcid = existing_author["orcid_id"]
+
+        response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Dev",
+                        "last_name": "User",
+                        "orcid_id": f"https://orcid.org/{existing_orcid}",
+                    }
+                ]
+            },
+        )
+        save_response(response, "api-replace-authors-by-orcid")
+        assert response.ok
+
+        get_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(get_response, "api-replace-authors-by-orcid-verify")
+        authors = get_response.json()
+        assert len(authors) == 1
+        assert authors[0].get("uuid") == existing_uuid
+        assert authors[0].get("is_active") is True
+
+    def test_manual_author_email_does_not_reuse_inactive_author(self, draft_dataset, save_response):
+        """PUT does not reuse an inactive author with the same email."""
+        page, container_uuid = draft_dataset
+        author = {
+            "first_name": "Manual",
+            "last_name": "Author",
+            "email": "inactive-author@example.invalid",
+        }
+
+        first_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={"authors": [author]},
+        )
+        save_response(first_response, "api-replace-authors-unmatched-email")
+        assert first_response.ok
+
+        first_get_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(first_get_response, "api-replace-authors-unmatched-email-verify")
+        first_authors = first_get_response.json()
+        assert len(first_authors) == 1
+        first_uuid = first_authors[0]["uuid"]
+        assert first_authors[0].get("is_active") is False
+
+        second_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={"authors": [author]},
+        )
+        save_response(second_response, "api-replace-authors-inactive-email")
+        assert second_response.ok
+
+        second_get_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(second_get_response, "api-replace-authors-inactive-email-verify")
+        authors = second_get_response.json()
+        assert len(authors) == 1
+        assert authors[0].get("uuid") != first_uuid
+        assert authors[0].get("is_active") is False
+
+    def test_manual_author_orcid_does_not_reuse_inactive_author(self, draft_dataset, save_response):
+        """PUT does not reuse an inactive author with the same ORCID."""
+        page, container_uuid = draft_dataset
+        author = {
+            "first_name": "Manual",
+            "last_name": "Author",
+            "orcid_id": "https://orcid.org/0000-0000-0000-0002",
+        }
+
+        first_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={"authors": [author]},
+        )
+        save_response(first_response, "api-replace-authors-unmatched-orcid")
+        assert first_response.ok
+
+        first_get_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(first_get_response, "api-replace-authors-unmatched-orcid-verify")
+        first_authors = first_get_response.json()
+        assert len(first_authors) == 1
+        first_uuid = first_authors[0]["uuid"]
+        assert first_authors[0].get("is_active") is False
+
+        second_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={"authors": [author]},
+        )
+        save_response(second_response, "api-replace-authors-inactive-orcid")
+        assert second_response.ok
+
+        second_get_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(second_get_response, "api-replace-authors-inactive-orcid-verify")
+        authors = second_get_response.json()
+        assert len(authors) == 1
+        assert authors[0].get("uuid") != first_uuid
+        assert authors[0].get("is_active") is False
+
 
 # ---------------------------------------------------------------------------
 # Categories

--- a/tests/e2e/tests/api/v2/test_articles.py
+++ b/tests/e2e/tests/api/v2/test_articles.py
@@ -367,6 +367,33 @@ class TestV2ArticleAuthorsApi:
         assert authors[0].get("uuid") != first_uuid
         assert authors[0].get("is_active") is False
 
+    def test_add_existing_author_does_not_duplicate(self, draft_dataset, save_response):
+        """POST /v2/account/articles/<uuid>/authors does not duplicate an author."""
+        page, container_uuid = draft_dataset
+        before_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        existing_uuid = before_response.json()[0]["uuid"]
+
+        response = page.request.post(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Dev",
+                        "last_name": "User",
+                        "email": "dev@djehuty.com",
+                    }
+                ]
+            },
+        )
+        save_response(response, "api-add-existing-author")
+        assert response.ok
+
+        get_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(get_response, "api-add-existing-author-verify")
+        authors = get_response.json()
+        assert len(authors) == 1
+        assert authors[0].get("uuid") == existing_uuid
+
 
 # ---------------------------------------------------------------------------
 # Categories

--- a/tests/e2e/tests/api/v3/test_authors.py
+++ b/tests/e2e/tests/api/v3/test_authors.py
@@ -69,3 +69,301 @@ class TestV3AuthorDetailsApi:
         response = authenticated_page.request.get(f"/v3/authors/{fake_uuid}")
         save_response(response, "v3-author-404")
         assert response.status == 404
+
+    def test_update_manual_author_rejects_active_email(self, draft_dataset, save_response):
+        """PUT rejects an email edition of a manual author matching an active author."""
+        page, container_uuid = draft_dataset
+        manual_email = "manual-author@example.invalid"
+
+        create_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Manual",
+                        "last_name": "Author",
+                        "email": manual_email,
+                    }
+                ]
+            },
+        )
+        save_response(create_response, "v3-author-active-email-create")
+        assert create_response.ok
+
+        authors_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(authors_response, "v3-author-active-email-create-verify")
+        authors = authors_response.json()
+        assert len(authors) == 1
+        manual_uuid = authors[0]["uuid"]
+
+        before_response = page.request.get(f"/v3/datasets/{container_uuid}/authors/{manual_uuid}")
+        save_response(before_response, "v3-author-active-email-before")
+        before_author = before_response.json()
+
+        response = page.request.put(
+            f"/v3/authors/{manual_uuid}",
+            data={
+                "first_name": "Manual",
+                "last_name": "Author",
+                "email": "  Dev@DJEHUTY.COM  ",
+                "orcid": "",
+            },
+        )
+        save_response(response, "v3-author-active-email-conflict")
+        assert response.status == 409
+        assert response.json()["message"] == (
+            "An active author with this email address or ORCID already exists. "
+            "Remove this manual author and select the existing author from "
+            "the autocomplete."
+        )
+
+        after_response = page.request.get(f"/v3/datasets/{container_uuid}/authors/{manual_uuid}")
+        save_response(after_response, "v3-author-active-email-after")
+        assert after_response.json() == before_author
+
+    def test_update_manual_author_allows_inactive_email(self, draft_dataset, save_response):
+        """PUT allows editing a manual author to use an inactive author's email."""
+        page, container_uuid = draft_dataset
+        matching_email = "inactive-author@example.invalid"
+
+        matching_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Matching",
+                        "last_name": "Author",
+                        "email": matching_email,
+                    }
+                ]
+            },
+        )
+        save_response(matching_response, "v3-author-inactive-email-create-matching")
+        assert matching_response.ok
+
+        matching_authors_response = page.request.get(
+            f"/v2/account/articles/{container_uuid}/authors"
+        )
+        save_response(matching_authors_response, "v3-author-inactive-email-create-matching-verify")
+        assert matching_authors_response.status == 200
+        matching_authors = matching_authors_response.json()
+        assert len(matching_authors) == 1
+        assert matching_authors[0].get("is_active") is False
+        matching_uuid = matching_authors[0]["uuid"]
+
+        edited_response = page.request.post(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Edited",
+                        "last_name": "Author",
+                        "email": "edited-author@example.invalid",
+                    }
+                ]
+            },
+        )
+        save_response(edited_response, "v3-author-inactive-email-create-edited")
+        assert edited_response.ok
+
+        edited_authors_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(edited_authors_response, "v3-author-inactive-email-create-edited-verify")
+        assert edited_authors_response.status == 200
+        edited_authors = edited_authors_response.json()
+        assert len(edited_authors) == 2
+
+        edited_author = next(
+            author
+            for author in edited_authors
+            if author["uuid"] != matching_uuid
+        )
+        assert edited_author.get("is_active") is False
+        edited_uuid = edited_author["uuid"]
+        assert edited_uuid != matching_uuid
+
+        matching_before_response = page.request.get(
+            f"/v3/datasets/{container_uuid}/authors/{matching_uuid}"
+        )
+        save_response(matching_before_response, "v3-author-inactive-email-matching-before")
+        assert matching_before_response.status == 200
+        matching_before = matching_before_response.json()
+        assert matching_before["email"] == matching_email
+
+        response = page.request.put(
+            f"/v3/authors/{edited_uuid}",
+            data={
+                "first_name": "Edited",
+                "last_name": "Author",
+                "email": matching_email,
+                "orcid": "",
+            },
+        )
+        save_response(response, "v3-author-inactive-email-update")
+        assert response.status == 204
+
+        edited_after_response = page.request.get(
+            f"/v3/datasets/{container_uuid}/authors/{edited_uuid}"
+        )
+        save_response(edited_after_response, "v3-author-inactive-email-edited-after")
+        assert edited_after_response.status == 200
+        edited_after = edited_after_response.json()
+        assert edited_after["uuid"] == edited_uuid
+        assert edited_after["email"] == matching_email
+
+        matching_after_response = page.request.get(
+            f"/v3/datasets/{container_uuid}/authors/{matching_uuid}"
+        )
+        save_response(matching_after_response, "v3-author-inactive-email-matching-after")
+        assert matching_after_response.status == 200
+        assert matching_after_response.json() == matching_before
+
+    def test_update_manual_author_rejects_active_orcid(self, draft_dataset, save_response):
+        """PUT rejects an orcid edition of a manual author matching an active author."""
+        page, container_uuid = draft_dataset
+
+        active_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(active_response, "v3-author-active-orcid-existing")
+        assert active_response.status == 200
+
+        active_authors = active_response.json()
+        assert len(active_authors) == 1
+        active_author = active_authors[0]
+        assert active_author.get("is_active") is True
+        existing_orcid = active_author["orcid_id"]
+
+        manual_email = "manual-author@example.invalid"
+        manual_orcid = "0000-0000-0000-0028"
+
+        create_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Manual",
+                        "last_name": "Author",
+                        "email": manual_email,
+                        "orcid_id": manual_orcid,
+                    }
+                ]
+            },
+        )
+        save_response(create_response, "v3-author-active-orcid-create")
+        assert create_response.ok
+
+        authors_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(authors_response, "v3-author-active-orcid-create-verify")
+        authors = authors_response.json()
+        assert len(authors) == 1
+        manual_uuid = authors[0]["uuid"]
+
+        before_response = page.request.get(f"/v3/authors/{manual_uuid}")
+        save_response(before_response, "v3-author-active-orcid-before")
+        assert before_response.status == 200
+        before_author = before_response.json()
+
+        response = page.request.put(
+            f"/v3/authors/{manual_uuid}",
+            data={
+                "first_name": "Manual",
+                "last_name": "Author",
+                "email": manual_email,
+                "orcid": f"https://orcid.org/{existing_orcid}",
+            },
+        )
+        save_response(response, "v3-author-active-orcid-conflict")
+        assert response.status == 409
+        assert response.json()["message"] == (
+            "An active author with this email address or ORCID already exists. "
+            "Remove this manual author and select the existing author from "
+            "the autocomplete."
+        )
+
+        after_response = page.request.get(f"/v3/authors/{manual_uuid}")
+        save_response(after_response, "v3-author-active-orcid-after")
+        assert after_response.status == 200
+        assert after_response.json() == before_author
+
+    def test_update_manual_author_allows_inactive_orcid(self, draft_dataset, save_response):
+        """PUT allows an ORCID matching an inactive author."""
+        page, container_uuid = draft_dataset
+        matching_orcid = "0000-0000-0000-0028"
+
+        matching_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Matching",
+                        "last_name": "Author",
+                        "email": "matching-author@example.invalid",
+                        "orcid_id": matching_orcid,
+                    }
+                ]
+            },
+        )
+        save_response(matching_response, "v3-author-inactive-orcid-create-matching")
+        assert matching_response.ok
+
+        matching_authors_response = page.request.get(
+            f"/v2/account/articles/{container_uuid}/authors"
+        )
+        save_response(matching_authors_response, "v3-author-inactive-orcid-create-matching-verify")
+        matching_authors = matching_authors_response.json()
+        assert len(matching_authors) == 1
+        assert matching_authors[0].get("is_active") is False
+        matching_uuid = matching_authors[0]["uuid"]
+
+        edited_email = "edited-author@example.invalid"
+
+        edited_response = page.request.put(
+            f"/v2/account/articles/{container_uuid}/authors",
+            data={
+                "authors": [
+                    {
+                        "first_name": "Edited",
+                        "last_name": "Author",
+                        "email": edited_email,
+                        "orcid_id": "0000-0000-0000-0036",
+                    }
+                ]
+            },
+        )
+        save_response(edited_response, "v3-author-inactive-orcid-create-edited")
+        assert edited_response.ok
+
+        edited_authors_response = page.request.get(f"/v2/account/articles/{container_uuid}/authors")
+        save_response(edited_authors_response, "v3-author-inactive-orcid-create-edited-verify")
+        edited_authors = edited_authors_response.json()
+        assert len(edited_authors) == 1
+        assert edited_authors[0].get("is_active") is False
+        edited_uuid = edited_authors[0]["uuid"]
+        assert edited_uuid != matching_uuid
+
+        matching_before_response = page.request.get(f"/v3/authors/{matching_uuid}")
+        save_response(matching_before_response, "v3-author-inactive-orcid-matching-before")
+        assert matching_before_response.status == 200
+        matching_before = matching_before_response.json()
+
+        response = page.request.put(
+            f"/v3/authors/{edited_uuid}",
+            data={
+                "first_name": "Edited",
+                "last_name": "Author",
+                "email": edited_email,
+                "orcid": f"https://orcid.org/{matching_orcid}",
+            },
+        )
+        save_response(response, "v3-author-inactive-orcid-update")
+        assert response.status == 204
+
+        edited_after_response = page.request.get(f"/v3/authors/{edited_uuid}")
+        save_response(edited_after_response, "v3-author-inactive-orcid-edited-after")
+        assert edited_after_response.status == 200
+        edited_after = edited_after_response.json()
+        assert edited_after["uuid"] == edited_uuid
+        assert edited_after["orcid"] == matching_orcid
+
+        matching_after_response = page.request.get(f"/v3/authors/{matching_uuid}")
+        save_response(matching_after_response, "v3-author-inactive-orcid-matching-after")
+        assert matching_after_response.status == 200
+        assert matching_after_response.json() == matching_before

--- a/tests/e2e/tests/api/v3/test_authors.py
+++ b/tests/e2e/tests/api/v3/test_authors.py
@@ -172,11 +172,7 @@ class TestV3AuthorDetailsApi:
         edited_authors = edited_authors_response.json()
         assert len(edited_authors) == 2
 
-        edited_author = next(
-            author
-            for author in edited_authors
-            if author["uuid"] != matching_uuid
-        )
+        edited_author = next(author for author in edited_authors if author["uuid"] != matching_uuid)
         assert edited_author.get("is_active") is False
         edited_uuid = edited_author["uuid"]
         assert edited_uuid != matching_uuid


### PR DESCRIPTION
**Summary**

Reuse an existing active author when a manually submitted dataset author has the same email or normalized ORCID. This prevents the creation of an inactive duplicate author and fixes the behavior described in #282.

**Changes**

- `src/djehuty/web/wsgi.py`: Reuse an active author matching the submitted email or normalized ORCID before creating a new author.
- `tests/e2e/tests/api/v2/test_articles.py`: Add regression tests for matching manual authors by email and ORCID.
- `etc/djehuty/djehuty-dev-config.json`: Add a stable ORCID to the development account for end-to-end tests.
- `src/djehuty/web/database.py`: Allow author queries to filter by email.


**Approval Checklist**

- [x] I agree to follow _Djehuty's_ code of conduct.
- [x] I have read and followed the code contribution workflow.
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed. No documentation change is required for this internal bug fix.
- [x] Review approved by at least one maintainer.
- [x] Merge readiness: the PR contains one commit and follows the commit template.

**Issue Reference**

Closes #282

**Notes**

The complete `TestV2ArticleAuthorsApi` class passes:

```text
7 passed
```