### PR TITLE
tests: files: Test downloads from S3

### DIFF
--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -14,14 +14,27 @@ services:
         INSTALL_DEV: "1"
     environment:
       COVERAGE_FILE: /coverage/.coverage
-    # $$ escapes compose interpolation so the container shell expands
-    # DJEHUTY_CONFIG from the environment (set on the dev compose service).
+      DJEHUTY_CONFIG: /config/djehuty/djehuty-e2e-config.json
+    # $$ escapes Compose interpolation so the container shell
+    # expands DJEHUTY_CONFIG from this service's environment.
     command:
       - sh
       - -c
       - exec coverage run -m djehuty.ui web --initialize --config-file "$$DJEHUTY_CONFIG"
     volumes:
       - ./coverage:/coverage
+
+  minio:
+    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    command: ["server", "/data"]
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/live"]
+      interval: 5s
+      retries: 12
+      start_period: 10s
 
   seed:
     image: openlink/virtuoso-opensource-7:7.2.13
@@ -42,11 +55,17 @@ services:
     depends_on:
       seed:
         condition: service_completed_successfully
+      minio:
+        condition: service_healthy
     environment:
       E2E_BASE_URL: http://djehuty:8080
       E2E_SPARQL_URL: http://virtuoso:8890/sparql
       E2E_SPARQL_GRAPH: djehuty://local
       E2E_AUTO_LOGIN_EMAIL: dev@djehuty.com
+      E2E_MINIO_ENDPOINT:   http://minio:9000
+      E2E_MINIO_ACCESS_KEY: minioadmin
+      E2E_MINIO_SECRET_KEY: minioadmin
+      E2E_MINIO_BUCKET:     test-bucket
       # Source tree is mounted read-only; keep pytest from trying to
       # write a cache or .pyc files into it.
       PYTHONDONTWRITEBYTECODE: "1"
@@ -54,6 +73,7 @@ services:
     volumes:
       - ../tests:/app/tests:ro
       - ./test-results:/app/test-results
+      - djehuty-data:/djehuty-data
     working_dir: /app/tests/e2e
     entrypoint: []
     command:

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -24,17 +24,8 @@ services:
     volumes:
       - ./coverage:/coverage
 
-  minio:
-    image: minio/minio:RELEASE.2025-01-20T14-49-07Z
-    environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
-    command: ["server", "/data"]
-    healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:9000/minio/health/live"]
-      interval: 5s
-      retries: 12
-      start_period: 10s
+  floci:
+    image: floci/floci:2.0.1
 
   seed:
     image: openlink/virtuoso-opensource-7:7.2.13
@@ -55,17 +46,17 @@ services:
     depends_on:
       seed:
         condition: service_completed_successfully
-      minio:
+      floci:
         condition: service_healthy
     environment:
       E2E_BASE_URL: http://djehuty:8080
       E2E_SPARQL_URL: http://virtuoso:8890/sparql
       E2E_SPARQL_GRAPH: djehuty://local
       E2E_AUTO_LOGIN_EMAIL: dev@djehuty.com
-      E2E_MINIO_ENDPOINT:   http://minio:9000
-      E2E_MINIO_ACCESS_KEY: minioadmin
-      E2E_MINIO_SECRET_KEY: minioadmin
-      E2E_MINIO_BUCKET:     test-bucket
+      E2E_S3_ENDPOINT:   http://floci:4566
+      E2E_S3_ACCESS_KEY: test
+      E2E_S3_SECRET_KEY: test
+      E2E_S3_BUCKET:     test-bucket
       # Source tree is mounted read-only; keep pytest from trying to
       # write a cache or .pyc files into it.
       PYTHONDONTWRITEBYTECODE: "1"

--- a/etc/djehuty/djehuty-e2e-config.json
+++ b/etc/djehuty/djehuty-e2e-config.json
@@ -1,0 +1,22 @@
+{
+  "djehuty": {
+    "bind-address": "0.0.0.0",
+    "storage-root": "/data",
+    "include": [
+      "djehuty-dev-config.json"
+    ],
+    "storage": {
+      "location": [
+        "/data"
+      ],
+      "s3-bucket": [
+        {
+          "name": "test-bucket",
+          "key-id": "minioadmin",
+          "secret-key": "minioadmin",
+          "endpoint": "http://minio:9000"
+        }
+      ]
+    }
+  }
+}

--- a/etc/djehuty/djehuty-e2e-config.json
+++ b/etc/djehuty/djehuty-e2e-config.json
@@ -12,9 +12,9 @@
       "s3-bucket": [
         {
           "name": "test-bucket",
-          "key-id": "minioadmin",
-          "secret-key": "minioadmin",
-          "endpoint": "http://minio:9000"
+          "key-id": "test",
+          "secret-key": "test",
+          "endpoint": "http://floci:4566"
         }
       ]
     }

--- a/tests/e2e/tests/test_files.py
+++ b/tests/e2e/tests/test_files.py
@@ -14,9 +14,11 @@ Run with:
     cd tests/e2e && python -m pytest tests/test_files.py -v
 """
 
+import os
 import re
 from pathlib import Path
 
+import boto3
 import pytest
 from helpers.dataset import create_draft_dataset
 from pages.dataset_editor_page import DatasetEditorPage
@@ -38,6 +40,27 @@ def test_file(tmp_path: Path) -> str:
     return str(file_path)
 
 
+@pytest.fixture(scope="session")
+def minio_client():
+    """Connect to MinIO and create the test bucket when needed."""
+    bucket_name = os.environ["E2E_MINIO_BUCKET"]
+    client = boto3.client(
+        "s3",
+        endpoint_url=os.environ["E2E_MINIO_ENDPOINT"],
+        aws_access_key_id=os.environ["E2E_MINIO_ACCESS_KEY"],
+        aws_secret_access_key=os.environ["E2E_MINIO_SECRET_KEY"],
+    )
+
+    bucket_names = {
+        bucket["Name"]
+        for bucket in client.list_buckets()["Buckets"]
+    }
+    if bucket_name not in bucket_names:
+        client.create_bucket(Bucket=bucket_name)
+
+    return client, bucket_name
+
+
 @pytest.fixture()
 def dataset_with_file(authenticated_page: Page, test_file: str):
     """Create a draft dataset, upload a test file, and yield (url, editor).
@@ -53,6 +76,42 @@ def dataset_with_file(authenticated_page: Page, test_file: str):
     authenticated_page.goto(url)
     authenticated_page.wait_for_load_state("domcontentloaded")
     DatasetEditorPage(authenticated_page).delete()
+
+
+@pytest.fixture()
+def dataset_with_s3_file(dataset_with_file, minio_client):
+    """Move an uploaded file from local storage to MinIO."""
+    _, editor = dataset_with_file
+    client, bucket_name = minio_client
+
+    download_url = editor.get_file_download_url()
+    assert download_url is not None
+
+    file_uuid = download_url.rstrip("/").rsplit("/", 1)[-1]
+    object_key = f"{editor.container_uuid}_{file_uuid}"
+    local_file = Path("/djehuty-data") / object_key
+
+    assert local_file.is_file()
+    file_content = local_file.read_bytes()
+
+    client.put_object(
+        Bucket=bucket_name,
+        Key=object_key,
+        Body=file_content,
+    )
+
+    try:
+        local_file.unlink()
+        assert not local_file.exists()
+        yield editor.page, download_url
+    finally:
+        if not local_file.exists():
+            local_file.write_bytes(file_content)
+
+        client.delete_object(
+            Bucket=bucket_name,
+            Key=object_key,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +243,65 @@ class TestFileDownload:
         download = download_info.value
         screenshot(page, "after-download")
         assert download.suggested_filename == TEST_FILE_NAME
+
+    def test_download_file_from_s3(self, dataset_with_s3_file):
+        """A file stored only in S3 can be downloaded."""
+        page, download_url = dataset_with_s3_file
+
+        response = page.request.get(download_url)
+
+        assert response.status == 200
+        assert response.body() == TEST_FILE_CONTENT
+        assert response.headers.get("accept-ranges") == "bytes"
+
+    def test_resume_download_from_s3(self, dataset_with_s3_file):
+        """An interrupted S3 download can continue from the next byte."""
+        page, download_url = dataset_with_s3_file
+        resume_from = 10
+
+        first_response = page.request.get(
+            download_url,
+            headers={"Range": f"bytes=0-{resume_from - 1}"},
+        )
+
+        assert first_response.status == 206
+        assert first_response.body() == TEST_FILE_CONTENT[:resume_from]
+
+        etag = first_response.headers.get("etag")
+        assert etag is not None
+
+        resumed_response = page.request.get(
+            download_url,
+            headers={
+                "Range": f"bytes={resume_from}-",
+                "If-Range": etag,
+            },
+        )
+
+        assert resumed_response.status == 206
+        assert resumed_response.body() == TEST_FILE_CONTENT[resume_from:]
+
+        expected_range = (
+            f"bytes {resume_from}-{len(TEST_FILE_CONTENT) - 1}"
+            f"/{len(TEST_FILE_CONTENT)}"
+        )
+        assert resumed_response.headers.get("content-range") == expected_range
+
+        downloaded_content = first_response.body() + resumed_response.body()
+        assert downloaded_content == TEST_FILE_CONTENT
+
+    def test_download_file_from_s3_rejects_out_of_bounds_range(self, dataset_with_s3_file):
+        """An S3 download rejects a range beyond the end of the file."""
+        page, download_url = dataset_with_s3_file
+        file_size = len(TEST_FILE_CONTENT)
+
+        response = page.request.get(
+            download_url,
+            headers={"Range": f"bytes={file_size}-"},
+        )
+
+        assert response.status == 416
+        assert response.headers.get("content-range") == f"bytes */{file_size}"
 
     def test_download_all_files_as_zip(self, dataset_with_file, screenshot):
         """The 'download all files' zip link should work for draft datasets."""

--- a/tests/e2e/tests/test_files.py
+++ b/tests/e2e/tests/test_files.py
@@ -41,20 +41,17 @@ def test_file(tmp_path: Path) -> str:
 
 
 @pytest.fixture(scope="session")
-def minio_client():
-    """Connect to MinIO and create the test bucket when needed."""
-    bucket_name = os.environ["E2E_MINIO_BUCKET"]
+def s3_client():
+    """Connect to the S3 test service and create the test bucket when needed."""
+    bucket_name = os.environ["E2E_S3_BUCKET"]
     client = boto3.client(
         "s3",
-        endpoint_url=os.environ["E2E_MINIO_ENDPOINT"],
-        aws_access_key_id=os.environ["E2E_MINIO_ACCESS_KEY"],
-        aws_secret_access_key=os.environ["E2E_MINIO_SECRET_KEY"],
+        endpoint_url=os.environ["E2E_S3_ENDPOINT"],
+        aws_access_key_id=os.environ["E2E_S3_ACCESS_KEY"],
+        aws_secret_access_key=os.environ["E2E_S3_SECRET_KEY"],
     )
 
-    bucket_names = {
-        bucket["Name"]
-        for bucket in client.list_buckets()["Buckets"]
-    }
+    bucket_names = {bucket["Name"] for bucket in client.list_buckets()["Buckets"]}
     if bucket_name not in bucket_names:
         client.create_bucket(Bucket=bucket_name)
 
@@ -79,10 +76,10 @@ def dataset_with_file(authenticated_page: Page, test_file: str):
 
 
 @pytest.fixture()
-def dataset_with_s3_file(dataset_with_file, minio_client):
-    """Move an uploaded file from local storage to MinIO."""
+def dataset_with_s3_file(dataset_with_file, s3_client):
+    """Move an uploaded file from local storage to S3."""
     _, editor = dataset_with_file
-    client, bucket_name = minio_client
+    client, bucket_name = s3_client
 
     download_url = editor.get_file_download_url()
     assert download_url is not None
@@ -282,8 +279,7 @@ class TestFileDownload:
         assert resumed_response.body() == TEST_FILE_CONTENT[resume_from:]
 
         expected_range = (
-            f"bytes {resume_from}-{len(TEST_FILE_CONTENT) - 1}"
-            f"/{len(TEST_FILE_CONTENT)}"
+            f"bytes {resume_from}-{len(TEST_FILE_CONTENT) - 1}/{len(TEST_FILE_CONTENT)}"
         )
         assert resumed_response.headers.get("content-range") == expected_range
 


### PR DESCRIPTION
**Summary**

Add end-to-end tests for downloading files stored in S3. The tests use Floci as the S3 service. Before each S3 test, the file is copied to Floci and removed from local storage. This makes sure Djehuty can only get the file from S3. This adds the coverage requested in #267.

**Changes**

- `docker/docker-compose.e2e.yml`: Add a Floci service, give the tests the Floci connection settings, and let the test container access Djehuty's local file storage.
- `etc/djehuty/djehuty-e2e-config.json`: Add an end-to-end test configuration that tells Djehuty to look for files in the Floci test bucket.
- `tests/e2e/tests/test_files.py`:
  - **Test setup:** Add `s3_client`, which connects to Floci and creates the test bucket when needed. Add `dataset_with_s3_file`, which starts with a file uploaded through Djehuty, copies it to Floci, and removes the local copy. During the test, Floci is therefore the only place where Djehuty can find the file. After the test, `dataset_with_s3_file` restores the local file and removes the Floci object.
  - **Test cases:**
    - `test_download_file_from_s3` checks that the complete file can be downloaded from Floci.
    - `test_resume_download_from_s3` downloads the file in two byte ranges and checks that the two parts rebuild the original file.
    - `test_download_file_from_s3_rejects_out_of_bounds_range` requests a position beyond the end of the file and checks that Djehuty returns `416`.

**Approval Checklist**

- [x] I agree to follow *Djehuty's* code of conduct.
- [x] I have read and followed the code contribution workflow.
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed. No documentation change is required because this PR only adds end-to-end test coverage and test configuration.
- [ ] Review approved by at least one maintainer.
- [x] Merge readiness: the PR contains one commit and follows the commit template.

**Issue Reference**

Closes #267

**Notes**

The complete file test module passes:

```text
14 passed
```