### PR TITLE
chore: fix ci docs.yml to not remove cname when runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -63,3 +63,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
+          # Re-write the custom-domain file on every deploy. The publish dir is
+          # force-pushed to gh-pages, so without this each deploy deletes CNAME
+          # and GitHub drops the djehuty.4tu.nl mapping (the site 404s).
+          cname: djehuty.4tu.nl


### PR DESCRIPTION
**Summary**

Keep CNAME file when the job runs, maintaining djehuty.4tu.nl

**Changes**
- .github/workflows/docs.yml

**Approval Checklist**
- [x] I agree to follow _Djehuty's_ [code of conduct](https://github.com/4TUResearchData/djehuty?tab=coc-ov-file#readme).
- [x] I have read and I have follow the [code contribution workflow](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md).
- [x] Code style and conventions were respected.
- [x] Documentation has been updated where needed (README, docs, or examples).
- [x] Review approved by at least one maintainer.
- [x] Merge readiness (PR is squashed into a single commit and follows the [commit template](https://github.com/4TUResearchData/djehuty/blob/main/CONTRIBUTING.md#commit-message-template)).

**Issue Reference (optional - PRs may not be associated with an issue)**

Closes #ISSUE_NUMBER

**Screenshots (optional)**

Before/After visuals, UI changes, or relevant logs.

**Notes (optional)**

Additional context, caveats, or follow-up tasks.